### PR TITLE
feat(mapper): map Next routes under src/app and src/pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added Next.js route mapping for `src/app` and `src/pages` layouts, thanks @obatried.
 - Improved Node/TypeScript mapping for large workspaces by splitting package source trees into bounded review groups with package-local tests.
 - Added generic nested SwiftPM, Apple/Xcode, and Gradle/Android app mapping.
 

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -95,6 +95,16 @@ describe("mapFeatures", () => {
     );
     await writeFixture(
       root,
+      "src/pages/docs/page.tsx",
+      "export default function DocsPage() { return null; }\n",
+    );
+    await writeFixture(
+      root,
+      "src/pages/docs/route.tsx",
+      "export default function DocsRoute() { return null; }\n",
+    );
+    await writeFixture(
+      root,
       "src/pages/_app.tsx",
       "export default function App() { return null; }\n",
     );
@@ -118,6 +128,8 @@ describe("mapFeatures", () => {
     expect(titles).toContain("Route /dashboard");
     expect(titles).toContain("Route /api/health");
     expect(titles).toContain("Route /about");
+    expect(titles).toContain("Route /docs/page");
+    expect(titles).toContain("Route /docs/route");
     expect(bySource("/dashboard")).toBe("next-app-route");
     expect(bySource("/api/health")).toBe("next-app-route");
     expect(bySource("/about")).toBe("next-pages-route");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -62,6 +62,52 @@ describe("mapFeatures", () => {
     ]);
   });
 
+  it("maps Next routes under src/app and src/pages", async () => {
+    const root = await fixtureRoot("clawpatch-map-next-src-");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify(
+        {
+          name: "fixture-app",
+          scripts: { build: "next build" },
+          dependencies: { next: "1.0.0" },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(root, "tsconfig.json", "{}");
+    await writeFixture(
+      root,
+      "src/app/dashboard/page.tsx",
+      "export default function Page() { return null; }\n",
+    );
+    await writeFixture(
+      root,
+      "src/app/api/health/route.ts",
+      "export function GET() { return new Response('ok'); }\n",
+    );
+    await writeFixture(
+      root,
+      "src/pages/about.tsx",
+      "export default function About() { return null; }\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const bySource = (route: string) =>
+      result.features.find((feature) => feature.title === `Route ${route}`)?.source;
+
+    expect(titles).toContain("Route /dashboard");
+    expect(titles).toContain("Route /api/health");
+    expect(titles).toContain("Route /about");
+    expect(bySource("/dashboard")).toBe("next-app-route");
+    expect(bySource("/api/health")).toBe("next-app-route");
+    expect(bySource("/about")).toBe("next-pages-route");
+  });
+
   it("maps generated package bins back to source entries", async () => {
     const root = await fixtureRoot("clawpatch-map-bin-source-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -108,6 +108,28 @@ describe("mapFeatures", () => {
     expect(bySource("/about")).toBe("next-pages-route");
   });
 
+  it("does not map src app-shaped routes without a Next project signal", async () => {
+    const root = await fixtureRoot("clawpatch-map-src-non-next-");
+    await writeFixture(root, "package.json", JSON.stringify({ name: "plain-app" }, null, 2));
+    await writeFixture(
+      root,
+      "src/app/dashboard/page.tsx",
+      "export default function Page() { return null; }\n",
+    );
+    await writeFixture(
+      root,
+      "src/pages/about.tsx",
+      "export default function About() { return null; }\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(titles).not.toContain("Route /dashboard");
+    expect(titles).not.toContain("Route /about");
+  });
+
   it("maps generated package bins back to source entries", async () => {
     const root = await fixtureRoot("clawpatch-map-bin-source-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -93,6 +93,21 @@ describe("mapFeatures", () => {
       "src/pages/about.tsx",
       "export default function About() { return null; }\n",
     );
+    await writeFixture(
+      root,
+      "src/pages/_app.tsx",
+      "export default function App() { return null; }\n",
+    );
+    await writeFixture(
+      root,
+      "src/pages/_document.tsx",
+      "export default function Document() { return null; }\n",
+    );
+    await writeFixture(
+      root,
+      "src/pages/_error.tsx",
+      "export default function ErrorPage() { return null; }\n",
+    );
 
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
@@ -106,6 +121,9 @@ describe("mapFeatures", () => {
     expect(bySource("/dashboard")).toBe("next-app-route");
     expect(bySource("/api/health")).toBe("next-app-route");
     expect(bySource("/about")).toBe("next-pages-route");
+    expect(titles).not.toContain("Route /_app");
+    expect(titles).not.toContain("Route /_document");
+    expect(titles).not.toContain("Route /_error");
   });
 
   it("does not map src app-shaped routes without a Next project signal", async () => {

--- a/src/mappers/next.ts
+++ b/src/mappers/next.ts
@@ -2,17 +2,17 @@ import { walk } from "./shared.js";
 import { FeatureSeed } from "./types.js";
 
 export async function nextSeeds(root: string): Promise<FeatureSeed[]> {
-  const files = await walk(root, ["app", "pages"]);
+  const files = await walk(root, ["app", "pages", "src/app", "src/pages"]);
   const routeFiles = files.filter(
     (file) =>
       /(^|\/)(page|route)\.(tsx|ts|jsx|js)$/u.test(file) ||
-      /^pages\/.+\.(tsx|ts|jsx|js)$/u.test(file),
+      /^(src\/)?pages\/.+\.(tsx|ts|jsx|js)$/u.test(file),
   );
   return routeFiles.map((file) => ({
     title: `Route ${routeFromFile(file)}`,
     summary: `Web route implemented by ${file}.`,
     kind: "route",
-    source: file.startsWith("app/") ? "next-app-route" : "next-pages-route",
+    source: isAppRoute(file) ? "next-app-route" : "next-pages-route",
     confidence: "high",
     entryPath: file,
     symbol: null,
@@ -23,8 +23,13 @@ export async function nextSeeds(root: string): Promise<FeatureSeed[]> {
   }));
 }
 
+function isAppRoute(file: string): boolean {
+  return file.startsWith("app/") || file.startsWith("src/app/");
+}
+
 function routeFromFile(file: string): string {
   let route = file
+    .replace(/^src\//u, "")
     .replace(/^app\//u, "/")
     .replace(/^pages\//u, "/")
     .replace(/\/(page|route)\.[^.]+$/u, "")

--- a/src/mappers/next.ts
+++ b/src/mappers/next.ts
@@ -12,7 +12,7 @@ export async function nextSeeds(root: string): Promise<FeatureSeed[]> {
   const routeFiles = files.filter(
     (file) =>
       /(^|\/)(page|route)\.(tsx|ts|jsx|js)$/u.test(file) ||
-      /^(src\/)?pages\/.+\.(tsx|ts|jsx|js)$/u.test(file),
+      (/^(src\/)?pages\/.+\.(tsx|ts|jsx|js)$/u.test(file) && !isPagesFrameworkFile(file)),
   );
   return routeFiles.map((file) => ({
     title: `Route ${routeFromFile(file)}`,
@@ -31,6 +31,10 @@ export async function nextSeeds(root: string): Promise<FeatureSeed[]> {
 
 function isAppRoute(file: string): boolean {
   return file.startsWith("app/") || file.startsWith("src/app/");
+}
+
+function isPagesFrameworkFile(file: string): boolean {
+  return /^(src\/)?pages\/_(app|document|error)\.(tsx|ts|jsx|js)$/u.test(file);
 }
 
 async function isNextProject(root: string): Promise<boolean> {

--- a/src/mappers/next.ts
+++ b/src/mappers/next.ts
@@ -58,16 +58,26 @@ function dependencyFieldHas(field: unknown, name: string): boolean {
 }
 
 function routeFromFile(file: string): string {
-  let route = file
-    .replace(/^src\//u, "")
-    .replace(/^app\//u, "/")
-    .replace(/^pages\//u, "/")
-    .replace(/\/(page|route)\.[^.]+$/u, "")
-    .replace(/\.[^.]+$/u, "")
-    .replace(/\/index$/u, "")
-    .replace(/\[(.+?)\]/gu, ":$1");
+  let route = isAppRoute(file) ? appRouteFromFile(file) : pagesRouteFromFile(file);
   if (route === "") {
     route = "/";
   }
   return route;
+}
+
+function appRouteFromFile(file: string): string {
+  return file
+    .replace(/^src\//u, "")
+    .replace(/^app\//u, "/")
+    .replace(/\/(page|route)\.[^.]+$/u, "")
+    .replace(/\[(.+?)\]/gu, ":$1");
+}
+
+function pagesRouteFromFile(file: string): string {
+  return file
+    .replace(/^src\//u, "")
+    .replace(/^pages\//u, "/")
+    .replace(/\.[^.]+$/u, "")
+    .replace(/\/index$/u, "")
+    .replace(/\[(.+?)\]/gu, ":$1");
 }

--- a/src/mappers/next.ts
+++ b/src/mappers/next.ts
@@ -1,8 +1,14 @@
+import { join } from "node:path";
+import { readPackageJson } from "../detect.js";
+import { pathExists } from "../fs.js";
 import { walk } from "./shared.js";
 import { FeatureSeed } from "./types.js";
 
 export async function nextSeeds(root: string): Promise<FeatureSeed[]> {
-  const files = await walk(root, ["app", "pages", "src/app", "src/pages"]);
+  const prefixes = (await isNextProject(root))
+    ? ["app", "pages", "src/app", "src/pages"]
+    : ["app", "pages"];
+  const files = await walk(root, prefixes);
   const routeFiles = files.filter(
     (file) =>
       /(^|\/)(page|route)\.(tsx|ts|jsx|js)$/u.test(file) ||
@@ -25,6 +31,26 @@ export async function nextSeeds(root: string): Promise<FeatureSeed[]> {
 
 function isAppRoute(file: string): boolean {
   return file.startsWith("app/") || file.startsWith("src/app/");
+}
+
+async function isNextProject(root: string): Promise<boolean> {
+  const pkg = await readPackageJson(root);
+  if (
+    dependencyFieldHas(pkg?.dependencies, "next") ||
+    dependencyFieldHas(pkg?.devDependencies, "next")
+  ) {
+    return true;
+  }
+  for (const file of ["next.config.js", "next.config.mjs", "next.config.ts"]) {
+    if (await pathExists(join(root, file))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function dependencyFieldHas(field: unknown, name: string): boolean {
+  return typeof field === "object" && field !== null && Object.hasOwn(field, name);
 }
 
 function routeFromFile(file: string): string {


### PR DESCRIPTION
## Summary

The Next.js mapper walks only top-level `app/` and `pages/`, so any Next project that scaffolds routes under `src/` (the option Vercel's `create-next-app` offers and many real-world repos enable) yields zero route features. On a Next 16 + TypeScript app I tested, the mapper found only the package.json scripts and tsconfig as "features" and missed every actual route.

This PR teaches the Next mapper to recognize the `src/` layout in addition to the root layout.

## What changed

- `walk(root, ["app", "pages"])` extended to also include `src/app` and `src/pages`.
- Pages-router filter regex broadened from `^pages/...` to `^(src/)?pages/...`.
- `isAppRoute()` helper covers both `app/` and `src/app/` for the `source` field.
- `routeFromFile()` strips a leading `src/` so routes under both layouts resolve to the same canonical path (`/dashboard`, `/api/health`, `/about`).

## Tests

- Existing `maps package bins, scripts, configs, and Next routes` still passes (root-level layout unchanged).
- New `maps Next routes under src/app and src/pages` covers an App Router page, an App Router API route, and a Pages Router file, and asserts the `source` field for each.
- Full mapper suite: 56/57 passing; the one failure (`maps Go packages from symlinked explicit roots`) is pre-existing on `main` (macOS `/tmp` symlink quirk) and unrelated.
- `tsc --noEmit`, `oxlint`, and `oxfmt --check` all clean.

## Notes

Detection of which layout the host project uses isn't necessary at the mapper level; `walk()` already returns the empty set for missing prefixes, so both layouts coexist cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)