### PR TITLE
Add progress output for revalidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added Next.js route mapping for `src/app` and `src/pages` layouts, thanks @obatried.
 - Added first-pass Python mapping for project metadata, console scripts, source groups, pytest suites, and conservative validation defaults, thanks @xiamx.
+- Added progress output for `clawpatch revalidate`, thanks @twidtwid.
 - Improved Node/TypeScript mapping for large workspaces by splitting package source trees into bounded review groups with package-local tests.
 - Added generic nested SwiftPM, Apple/Xcode, and Gradle/Android app mapping.
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -476,8 +476,19 @@ export async function revalidateCommand(
   await writeRun(loaded.paths, run);
   const results: Array<{ finding: string; outcome: FindingRecord["status"]; reasoning: string }> =
     [];
+  emitRevalidateProgress(context, "start", {
+    run: currentRunId,
+    findings: findings.length,
+  });
   try {
-    for (const finding of findings) {
+    for (const [index, finding] of findings.entries()) {
+      const started = Date.now();
+      emitRevalidateProgress(context, "finding-start", {
+        index: index + 1,
+        total: findings.length,
+        finding: finding.findingId,
+        title: finding.title,
+      });
       const prompt = await buildRevalidatePrompt(loaded.root, JSON.stringify(finding, null, 2));
       const output = await provider.revalidate(loaded.root, prompt, config.provider.model);
       const updated = appendFindingHistory(
@@ -503,12 +514,27 @@ export async function revalidateCommand(
         outcome: output.outcome,
         reasoning: output.reasoning,
       });
+      emitRevalidateProgress(context, "finding-done", {
+        index: index + 1,
+        total: findings.length,
+        finding: finding.findingId,
+        outcome: output.outcome,
+        elapsed: `${Math.round((Date.now() - started) / 1000)}s`,
+      });
     }
     await writeRun(loaded.paths, {
       ...run,
       status: "completed",
       finishedAt: nowIso(),
       findingIds: results.map((result) => result.finding),
+    });
+    emitRevalidateProgress(context, "done", {
+      run: currentRunId,
+      revalidated: results.length,
+      fixed: results.filter((result) => result.outcome === "fixed").length,
+      open: results.filter((result) => result.outcome === "open").length,
+      uncertain: results.filter((result) => result.outcome === "uncertain").length,
+      falsePositive: results.filter((result) => result.outcome === "false-positive").length,
     });
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
@@ -518,6 +544,10 @@ export async function revalidateCommand(
       finishedAt: nowIso(),
       findingIds: run.findingIds,
       errors: [{ message, code: error instanceof ClawpatchError ? error.code : null }],
+    });
+    emitRevalidateProgress(context, "failed", {
+      run: currentRunId,
+      error: message,
     });
     throw error;
   }
@@ -903,6 +933,20 @@ function emitReviewProgress(
     .map(([key, value]) => `${key}=${String(value)}`)
     .join(" ");
   process.stderr.write(`clawpatch review ${event}${values.length > 0 ? ` ${values}` : ""}\n`);
+}
+
+function emitRevalidateProgress(
+  context: AppContext,
+  event: string,
+  fields: Record<string, string | number | boolean>,
+): void {
+  if (context.options.quiet) {
+    return;
+  }
+  const values = Object.entries(fields)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(" ");
+  process.stderr.write(`clawpatch revalidate ${event}${values.length > 0 ? ` ${values}` : ""}\n`);
 }
 
 function lockFeature(feature: FeatureRecord, currentRunId: string): FeatureRecord {

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { access, mkdir, readFile, rm, symlink, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import {
@@ -275,7 +275,13 @@ describe("workflow", () => {
       await writeFinding(paths, { ...finding, reasoning: markers[index] ?? "" });
     }
 
+    let progress = "";
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      progress += String(chunk);
+      return true;
+    });
     const result = await revalidateCommand(context, { all: true, status: "open", limit: "4" });
+    stderr.mockRestore();
     const updated = await readFindings(paths);
     const features = await readFeatures(paths);
 
@@ -293,6 +299,10 @@ describe("workflow", () => {
       "uncertain",
     ]);
     expect(updated.every((finding) => finding.history.at(-1)?.kind === "revalidate")).toBe(true);
+    expect(progress).toContain("clawpatch revalidate start");
+    expect(progress).toContain("clawpatch revalidate finding-start");
+    expect(progress).toContain("clawpatch revalidate finding-done");
+    expect(progress).toContain("clawpatch revalidate done");
     const uncertain = updated.find((finding) => finding.status === "uncertain");
     const uncertainFeature = features.find((feature) => feature.featureId === uncertain?.featureId);
     expect(uncertainFeature?.status).toBe("needs-fix");


### PR DESCRIPTION
## Summary
- emit stderr progress events for `clawpatch revalidate`, matching review progress visibility
- include run start, per-finding start/done, aggregate done, and failure events
- cover the progress stream in the workflow revalidation test

## Test plan
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm lint`
- `corepack pnpm format:check`
