### PR TITLE
fix(provider): quote codex exec args correctly on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added progress output for `clawpatch revalidate`, thanks @twidtwid.
 - Improved Node/TypeScript mapping for large workspaces by splitting package source trees into bounded review groups with package-local tests.
 - Added generic nested SwiftPM, Apple/Xcode, and Gradle/Android app mapping.
+- Fixed Codex provider execution on Windows paths with spaces and npm `.cmd` shims, thanks @1berto.
 
 ## 0.1.0 - 2026-05-15
 

--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -1,0 +1,47 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCommandArgs } from "./exec.js";
+
+describe("runCommandArgs", () => {
+  it("passes paths with spaces and quotes without shell quoting", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "clawpatch-exec-"));
+    const script = join(dir, "print-args.mjs");
+    await writeFile(script, "process.stdout.write(JSON.stringify(process.argv.slice(2)));", "utf8");
+
+    const args = [
+      script,
+      "--cd",
+      "C:\\Users\\test user\\repo",
+      "--output-last-message",
+      'C:\\Temp\\schema "quoted" & safe.json',
+    ];
+    const result = await runCommandArgs(process.execPath, args, dir);
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(args.slice(1));
+  });
+
+  it("returns a command result when the executable is missing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "clawpatch-exec-"));
+    const result = await runCommandArgs("clawpatch-missing-executable-for-test", [], dir);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("clawpatch-missing-executable-for-test");
+  });
+
+  it.runIf(process.platform === "win32")("runs cmd shims with escaped arguments", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "clawpatch-exec-"));
+    const script = join(dir, "print-args.mjs");
+    const shim = join(dir, "codex.cmd");
+    await writeFile(script, "process.stdout.write(JSON.stringify(process.argv.slice(2)));", "utf8");
+    await writeFile(shim, `@echo off\r\n"${process.execPath}" "${script}" %*\r\n`, "utf8");
+
+    const args = ["--cd", "C:\\Users\\test user\\repo", "--model", 'name "quoted" & safe'];
+    const result = await runCommandArgs(shim, args, dir);
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual(args);
+  });
+});

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter, extname, join } from "node:path";
 import { CommandResult } from "./types.js";
 
 export async function runCommand(
@@ -22,14 +24,23 @@ export async function runCommand(
   child.stderr.on("data", (chunk: string) => {
     stderr += chunk;
   });
+  let spawnErrorMessage: string | null = null;
+  const exitCodePromise = new Promise<number | null>((resolve) => {
+    child.on("error", (error: Error) => {
+      spawnErrorMessage = error.message;
+      resolve(127);
+    });
+    child.on("close", resolve);
+  });
   if (input !== undefined) {
     child.stdin.end(input);
   } else {
     child.stdin.end();
   }
-  const exitCode = await new Promise<number | null>((resolve) => {
-    child.on("close", resolve);
-  });
+  const exitCode = await exitCodePromise;
+  if (spawnErrorMessage !== null) {
+    stderr += stderr.length === 0 ? spawnErrorMessage : `\n${spawnErrorMessage}`;
+  }
   return {
     command,
     cwd,
@@ -38,6 +49,99 @@ export async function runCommand(
     stdout: trimOutput(stdout),
     stderr: trimOutput(stderr),
   };
+}
+
+export async function runCommandArgs(
+  program: string,
+  args: string[],
+  cwd: string,
+  input?: string,
+): Promise<CommandResult> {
+  const started = Date.now();
+  const spawnSpec = commandSpawnSpec(program, args);
+  const child = spawn(spawnSpec.program, spawnSpec.args, {
+    cwd,
+    shell: false,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsVerbatimArguments: spawnSpec.windowsVerbatimArguments,
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  let spawnErrorMessage: string | null = null;
+  const exitCodePromise = new Promise<number | null>((resolve) => {
+    child.on("error", (error: Error) => {
+      spawnErrorMessage = error.message;
+      resolve(127);
+    });
+    child.on("close", resolve);
+  });
+  if (input !== undefined) {
+    child.stdin.end(input);
+  } else {
+    child.stdin.end();
+  }
+  const exitCode = await exitCodePromise;
+  if (spawnErrorMessage !== null) {
+    stderr += stderr.length === 0 ? spawnErrorMessage : `\n${spawnErrorMessage}`;
+  }
+  return {
+    command: [program, ...args].map((arg) => JSON.stringify(arg)).join(" "),
+    cwd,
+    exitCode,
+    durationMs: Date.now() - started,
+    stdout: trimOutput(stdout),
+    stderr: trimOutput(stderr),
+  };
+}
+
+function commandSpawnSpec(
+  program: string,
+  args: string[],
+): { program: string; args: string[]; windowsVerbatimArguments: boolean } {
+  if (process.platform !== "win32") {
+    return { program, args, windowsVerbatimArguments: false };
+  }
+  const resolved = resolveWindowsProgram(program) ?? program;
+  if (!/\.(?:cmd|bat)$/iu.test(resolved)) {
+    return { program: resolved, args, windowsVerbatimArguments: false };
+  }
+  return {
+    program: process.env["ComSpec"] ?? "cmd.exe",
+    args: ["/d", "/s", "/c", [resolved, ...args].map(escapeCmdArgument).join(" ")],
+    windowsVerbatimArguments: true,
+  };
+}
+
+function resolveWindowsProgram(program: string): string | null {
+  if (program.includes("\\") || program.includes("/") || extname(program) !== "") {
+    return program;
+  }
+  const path = process.env["PATH"] ?? "";
+  const extensions = (process.env["PATHEXT"] ?? ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .filter((extension) => extension.length > 0);
+  for (const directory of path.split(delimiter)) {
+    for (const extension of extensions) {
+      const candidate = join(directory, `${program}${extension.toLowerCase()}`);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+function escapeCmdArgument(value: string): string {
+  const escaped = value.replace(/(\\*)"/gu, '$1$1\\"').replace(/(\\*)$/u, "$1$1");
+  return `"${escaped}"`.replace(/([()%!^"<>&|])/gu, "^$1");
 }
 
 function trimOutput(value: string): string {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -166,6 +166,9 @@ async function runCodexJson(
 }
 
 function shellQuote(value: string): string {
+  if (process.platform === "win32") {
+    return `"${value.replace(/"/gu, '""')}"`;
+  }
   return `'${value.replace(/'/gu, "'\\''")}'`;
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runCommand } from "./exec.js";
+import { runCommandArgs } from "./exec.js";
 import { ClawpatchError } from "./errors.js";
 import {
   FixPlanOutput,
@@ -36,7 +36,7 @@ export function providerByName(name: string): Provider {
 const codexProvider: Provider = {
   name: "codex",
   async check(root: string): Promise<string> {
-    const result = await runCommand("codex --version", root);
+    const result = await runCommandArgs("codex", ["--version"], root);
     if (result.exitCode !== 0) {
       throw new ClawpatchError("codex CLI not available", 4, "provider-auth");
     }
@@ -148,9 +148,22 @@ async function runCodexJson(
   const schemaPath = join(dir, "schema.json");
   const outputPath = join(dir, "output.json");
   await writeFile(schemaPath, JSON.stringify(schema), "utf8");
-  const modelArg = model === null ? "" : ` --model ${shellQuote(model)}`;
-  const command = `codex exec --cd ${shellQuote(root)} --sandbox ${sandbox} --output-schema ${shellQuote(schemaPath)} --output-last-message ${shellQuote(outputPath)}${modelArg} -`;
-  const result = await runCommand(command, root, prompt);
+  const args = [
+    "exec",
+    "--cd",
+    root,
+    "--sandbox",
+    sandbox,
+    "--output-schema",
+    schemaPath,
+    "--output-last-message",
+    outputPath,
+  ];
+  if (model !== null) {
+    args.push("--model", model);
+  }
+  args.push("-");
+  const result = await runCommandArgs("codex", args, root, prompt);
   if (result.exitCode !== 0) {
     throw new ClawpatchError(
       `codex provider failed: ${result.stderr || result.stdout}`,
@@ -163,13 +176,6 @@ async function runCodexJson(
     throw new ClawpatchError("codex provider produced no JSON output", 8, "malformed-output");
   }
   return JSON.parse(raw) as unknown;
-}
-
-function shellQuote(value: string): string {
-  if (process.platform === "win32") {
-    return `"${value.replace(/"/gu, '""')}"`;
-  }
-  return `'${value.replace(/'/gu, "'\\''")}'`;
 }
 
 function providerExitCode(stderr: string): number {


### PR DESCRIPTION
## Summary

`shellQuote` in `src/provider.ts` wraps values in single quotes. POSIX shells strip those, but `cmd.exe` does not — it treats `'...'` as a literal. On Windows, `runCommand` calls `spawn(..., { shell: true })`, which routes through `cmd.exe`, so `codex exec` receives `--cd '<root>'` (literal quotes) and fails:

```
codex provider failed: Error: The filename, directory name, or volume label syntax is incorrect. (os error 123)
```

This made `clawpatch review` / `fix` / `revalidate` unusable on Windows for any non-mock provider.

## Fix

Detect `process.platform === "win32"` in `shellQuote` and use double-quote wrapping with `""` escaping (cmd.exe's quoted-arg convention). POSIX path unchanged.

```ts
function shellQuote(value: string): string {
  if (process.platform === "win32") {
    return `"${value.replace(/"/gu, '""')}"`;
  }
  return `'${value.replace(/'/gu, "'\''")}'`;
}
```

## Repro before the fix

1. `pnpm install && pnpm build && pnpm link --global` on Windows (PowerShell or Git Bash, doesn't matter — `spawn` uses cmd.exe under the hood).
2. `clawpatch init && clawpatch map` in any repo.
3. `clawpatch review --limit 1` → exits with os error 123 from the codex invocation.

After the patch, `review` runs against `codex-cli 0.130.0` end-to-end and persists findings.

## Test plan

- [x] Repro confirmed on Windows 11 (Node 22.22.0, pnpm 10.23.0, codex-cli 0.130.0) before the patch.
- [x] After the patch, `clawpatch review --limit 3 --jobs 2` against a real TS/Rust monorepo produced 3 findings with valid JSON output from codex.
- [x] `pnpm typecheck` and `pnpm lint` clean.
- [x] `pnpm test` — 113 tests pass (existing suite uses the mock provider and doesn't exercise codex quoting, so no test additions here; happy to add a unit test for `shellQuote` if you'd prefer exporting it).

## Notes

- Does not touch the POSIX branch.
- `pnpm format:check` reports pre-existing CRLF/LF drift across 57 files unrelated to this change — left alone.