### PR TITLE
feat(mapper): add Flask route mapping for Python projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added Flask route feature mapping for Python projects, including `web/` source roots and Python framework detection.
 - Added Next.js route mapping for `src/app` and `src/pages` layouts, thanks @obatried.
 - Added first-pass Python mapping for project metadata, console scripts, source groups, pytest suites, and conservative validation defaults, thanks @xiamx.
 - Added progress output for `clawpatch revalidate`, thanks @twidtwid.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added Flask route feature mapping for Python projects, including `web/` source roots and Python framework detection.
+- Added Flask route feature mapping for Python projects, including `web/` source roots, common root entry files, non-list method literals, and Python framework detection.
 - Added Next.js route mapping for `src/app` and `src/pages` layouts, thanks @obatried.
 - Added first-pass Python mapping for project metadata, console scripts, source groups, pytest suites, and conservative validation defaults, thanks @xiamx.
 - Added progress output for `clawpatch revalidate`, thanks @twidtwid.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ validation commands and records a patch attempt under `.clawpatch/`.
 - Go package tests and same-repo imports as review context
 - Rust `src/main.rs`, `src/bin/*.rs`, `src/lib.rs`, `crates/*`, and
   `tests/*.rs`
+- Python project metadata, console scripts, bounded source groups, pytest suites,
+  and Flask routes
 - SwiftPM `Sources/*` targets and `Tests/*` suites
 - common project config files
 

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -33,7 +33,7 @@ Supported deterministic mappers today:
 - Next.js `app/` and `pages/` routes
 - Go `cmd/*/main.go`
 - Go `internal/*` packages
-- Python project metadata, console scripts, bounded source groups, and pytest suites
+- Python project metadata, console scripts, bounded source groups, pytest suites, and Flask routes
 - Rust Cargo commands, libraries, workspace crates, and integration tests
 - SwiftPM executable targets, library targets, and test suites
 - nested SwiftPM packages
@@ -55,12 +55,13 @@ and Gradle modules are grouped from `src/main`, `src/test`, and `src/androidTest
 
 Python mapping covers `pyproject.toml` metadata, `[project.scripts]` and
 `[tool.poetry.scripts]` console scripts, source groups under common Python
-source roots, and pytest files. Framework-specific route mapping for FastAPI,
-Flask, and Django is not implemented yet.
+source roots including `web/`, pytest files, and Flask `@*.route(...)`
+handlers. Framework-specific route mapping for FastAPI and Django is not
+implemented yet.
 
 Known gaps:
 
 - no Express/Fastify/Hono route mapper yet
-- no FastAPI/Flask/Django route mapper yet
+- no FastAPI/Django route mapper yet
 - no import graph expansion beyond nearby tests yet
 - no agent enrichment yet

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -56,8 +56,9 @@ and Gradle modules are grouped from `src/main`, `src/test`, and `src/androidTest
 Python mapping covers `pyproject.toml` metadata, `[project.scripts]` and
 `[tool.poetry.scripts]` console scripts, source groups under common Python
 source roots including `web/`, pytest files, and Flask `@*.route(...)`
-handlers. Framework-specific route mapping for FastAPI and Django is not
-implemented yet.
+handlers in source roots and common root entry files such as `app.py` and
+`wsgi.py`. Flask route methods are read from list, tuple, or set literals.
+Framework-specific route mapping for FastAPI and Django is not implemented yet.
 
 Known gaps:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,12 +30,12 @@ stderr so pipes stay parseable.
 
 ## What clawpatch does
 
-- **Semantic feature mapping.** Detects npm bins, Next.js routes, Go packages, Rust crates, SwiftPM targets, and common config files as reviewable slices.
+- **Semantic feature mapping.** Detects npm bins, Next.js routes, Python packages and Flask routes, Go packages, Rust crates, SwiftPM targets, and common config files as reviewable slices.
 - **Automated code review.** Reviews features with AI providers (Codex CLI today), persists findings with severity, category, and line locations.
 - **Explicit fix workflow.** `clawpatch fix` runs validated patches for one finding at a time, never commits or pushes automatically.
 - **Stable state model.** All features, findings, patches live in `.clawpatch/` as JSON, resumable across runs.
 - **Safety first.** Review is read-only, fix refuses dirty worktrees, never auto-commits, validates before accepting patches.
-- **Multi-language.** JavaScript/TypeScript, Go, Rust, Swift today; more mappers planned.
+- **Multi-language.** JavaScript/TypeScript, Python, Go, Rust, Swift today; more mappers planned.
 
 ## Pick your path
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -45,7 +45,7 @@ This discovers reviewable features:
 - npm package bins and scripts
 - Next.js routes
 - Go packages and commands
-- Python packages, console scripts, and pytest suites
+- Python packages, console scripts, Flask routes, and pytest suites
 - Rust crates and binaries
 - SwiftPM targets and tests
 - Config files

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -23,7 +23,7 @@ export async function detectProject(root: string): Promise<ProjectRecord> {
   const git = await discoverGit(root);
   const pkg = await readPackageJson(root);
   const packageManagers = await detectPackageManagers(root);
-  const frameworks = detectFrameworks(pkg);
+  const frameworks = await detectFrameworks(root, pkg);
   const languages = await detectLanguages(root);
   const commands = await detectCommands(root, pkg, languages, packageManagers);
   const name = typeof pkg?.name === "string" ? pkg.name : projectNameFromRoot(root, git.remoteUrl);
@@ -667,12 +667,20 @@ async function containsSwiftFile(dir: string): Promise<boolean> {
   return false;
 }
 
-function detectFrameworks(pkg: PackageJson | null): string[] {
+async function detectFrameworks(root: string, pkg: PackageJson | null): Promise<string[]> {
   const deps = dependencyNames(pkg);
   const frameworks: string[] = [];
   for (const name of ["next", "express", "fastify", "hono", "vitest"]) {
     if (deps.has(name)) {
       frameworks.push(name);
+    }
+  }
+  if (await isPythonProject(root)) {
+    const info = await pythonProjectInfo(root);
+    for (const name of ["flask", "fastapi", "django", "pytest"]) {
+      if (info.dependencies.has(name)) {
+        frameworks.push(name);
+      }
     }
   }
   return frameworks;

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1340,6 +1340,56 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     expect(admin?.trustBoundaries).toContain("auth");
   });
 
+  it("maps root-level Flask entry files and non-list methods", async () => {
+    const root = await fixtureRoot("clawpatch-python-flask-root-routes-");
+    await writeFixture(root, "requirements.txt", "Flask\npytest\n");
+    await writeFixture(
+      root,
+      "app.py",
+      [
+        "from flask import Flask",
+        "",
+        "app = Flask(__name__)",
+        "DYNAMIC_METHODS = ['POST']",
+        "",
+        "@app.route('/')",
+        "def index():",
+        "    return 'ok'",
+        "",
+        "@app.route('/submit', methods=('POST',))",
+        "def submit():",
+        "    return 'submitted'",
+        "",
+        "@app.route('/token', methods={'POST', 'DELETE'})",
+        "def token():",
+        "    return 'token'",
+        "",
+        "@app.route('/dynamic', methods=DYNAMIC_METHODS)",
+        "def dynamic():",
+        "    return 'dynamic'",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(root, "test_app.py", "def test_index():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const routes = result.features.filter((feature) => feature.source === "python-flask-route");
+    const byTitle = (title: string) => routes.find((feature) => feature.title === title);
+
+    expect(project.detected.frameworks).toContain("flask");
+    expect(byTitle("Flask route GET /")?.entrypoints[0]).toMatchObject({
+      path: "app.py",
+      symbol: "index",
+      route: "GET /",
+    });
+    expect(byTitle("Flask route POST /submit")?.tests).toEqual([
+      { path: "test_app.py", command: "pytest" },
+    ]);
+    expect(byTitle("Flask route POST,DELETE /token")?.trustBoundaries).toContain("auth");
+    expect(routes.map((feature) => feature.title)).not.toContain("Flask route GET /dynamic");
+  });
+
   it("does not map generic Python route decorators as Flask routes", async () => {
     const root = await fixtureRoot("clawpatch-python-generic-routes-");
     await writeFixture(root, "requirements.txt", "pytest\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1276,6 +1276,99 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     expect(suite?.tests).toEqual([{ path: "test_app.py", command: "pytest" }]);
   });
 
+  it("maps Flask routes under web source roots", async () => {
+    const root = await fixtureRoot("clawpatch-python-flask-routes-");
+    await writeFixture(root, "requirements.txt", "Flask\npytest\n");
+    await writeFixture(
+      root,
+      "web/app.py",
+      [
+        "from flask import Flask",
+        "",
+        "app = Flask(__name__)",
+        "",
+        "@app.route('/')",
+        "def index():",
+        "    return 'ok'",
+        "",
+        "@app.route('/api/items', methods=['GET', 'POST'])",
+        "def items():",
+        "    return 'items'",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "web/blueprints/admin.py",
+      [
+        "from flask import Blueprint",
+        "",
+        "admin_bp = Blueprint('admin', __name__)",
+        "",
+        "@admin_bp.route(",
+        "    '/admin/run-once',",
+        "    methods=['POST'],",
+        ")",
+        "def run_once():",
+        "    return 'queued'",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(root, "web/test_app.py", "def test_index():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const index = result.features.find((feature) => feature.title === "Flask route GET /");
+    const items = result.features.find(
+      (feature) => feature.title === "Flask route GET,POST /api/items",
+    );
+    const admin = result.features.find(
+      (feature) => feature.title === "Flask route POST /admin/run-once",
+    );
+
+    expect(project.detected.frameworks).toContain("flask");
+    expect(titles).toContain("Python source web");
+    expect(index?.source).toBe("python-flask-route");
+    expect(index?.entrypoints[0]).toMatchObject({
+      path: "web/app.py",
+      symbol: "index",
+      route: "GET /",
+    });
+    expect(index?.tests).toEqual([{ path: "web/test_app.py", command: "pytest" }]);
+    expect(items?.entrypoints[0]?.route).toBe("GET,POST /api/items");
+    expect(admin?.trustBoundaries).toContain("auth");
+  });
+
+  it("does not map generic Python route decorators as Flask routes", async () => {
+    const root = await fixtureRoot("clawpatch-python-generic-routes-");
+    await writeFixture(root, "requirements.txt", "pytest\n");
+    await writeFixture(
+      root,
+      "web/app.py",
+      [
+        "class Router:",
+        "    def route(self, path):",
+        "        def wrapper(fn):",
+        "            return fn",
+        "        return wrapper",
+        "",
+        "router = Router()",
+        "",
+        "@router.route('/not-flask')",
+        "def handler():",
+        "    return 'ok'",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(project.detected.frameworks).not.toContain("flask");
+    expect(result.features.some((feature) => feature.source === "python-flask-route")).toBe(false);
+  });
+
   it("uses Hatch pytest commands in mapped Python features", async () => {
     const root = await fixtureRoot("clawpatch-python-hatch-map-");
     await writeFixture(

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -17,6 +17,13 @@ type PythonScript = {
   target: string;
 };
 
+type FlaskRoute = {
+  filePath: string;
+  functionName: string;
+  routePath: string;
+  methods: string[];
+};
+
 type SourceGroup = {
   label: string;
   files: string[];
@@ -28,7 +35,7 @@ type PyprojectInfo = {
   hasPytest: boolean;
 };
 
-const sourceRoots = ["src", "app", "apps", "lib", "scripts"] as const;
+const sourceRoots = ["src", "app", "apps", "lib", "scripts", "web"] as const;
 const projectMetadataFiles = [
   "pyproject.toml",
   "setup.py",
@@ -97,6 +104,10 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
       testCommand,
       skipNearbyTests: true,
     });
+  }
+
+  for (const route of await flaskRouteSeeds(root, testFiles, testCommand)) {
+    seeds.push(route);
   }
 
   for (const group of await pythonSourceGroups(root)) {
@@ -310,6 +321,183 @@ async function resolvePythonScript(
     }
   }
   return { entryPath: "pyproject.toml", symbol };
+}
+
+async function flaskRouteSeeds(
+  root: string,
+  testFiles: string[],
+  testCommand: string | null,
+): Promise<FeatureSeed[]> {
+  const hasFlaskDependency = await pythonDependencyHas(root, "flask");
+  const routeFiles = (await walk(root, await pythonSourceRoots(root))).filter(
+    isReviewablePythonSourceFile,
+  );
+  const seeds: FeatureSeed[] = [];
+  for (const filePath of routeFiles) {
+    const source = await readFile(join(root, filePath), "utf8");
+    if (!hasFlaskDependency && !sourceLooksFlask(source)) {
+      continue;
+    }
+    const routes = parseFlaskRoutes(filePath, source);
+    for (const route of routes) {
+      const methodLabel = route.methods.join(",");
+      const tests = associatedTests([route.filePath], testFiles, testCommand);
+      seeds.push({
+        title: `Flask route ${methodLabel} ${route.routePath}`,
+        summary: `Flask route ${methodLabel} ${route.routePath} handled by ${route.functionName} in ${route.filePath}.`,
+        kind: "route",
+        source: "python-flask-route",
+        confidence: "high",
+        entryPath: route.filePath,
+        symbol: route.functionName,
+        route: `${methodLabel} ${route.routePath}`,
+        command: null,
+        ownedFiles: [{ path: route.filePath, reason: `Flask route handler ${route.functionName}` }],
+        contextFiles: tests.map((test) => ({ path: test.path, reason: "associated test" })),
+        tests,
+        tags: ["python", "flask", "route"],
+        trustBoundaries: flaskRouteTrustBoundaries(route),
+        testCommand,
+        skipNearbyTests: true,
+      });
+    }
+  }
+  return seeds;
+}
+
+async function pythonDependencyHas(root: string, dependency: string): Promise<boolean> {
+  if (await pathExists(join(root, "pyproject.toml"))) {
+    const source = await readFile(join(root, "pyproject.toml"), "utf8");
+    if (dependencyNames(source).has(dependency)) {
+      return true;
+    }
+  }
+  return dependencyFileHas(root, dependency);
+}
+
+function sourceLooksFlask(source: string): boolean {
+  return /^\s*(?:from\s+flask\s+import\s+|import\s+flask\b)/mu.test(source);
+}
+
+function parseFlaskRoutes(filePath: string, source: string): FlaskRoute[] {
+  const routes: FlaskRoute[] = [];
+  let pending: Array<{ routePath: string; methods: string[] }> = [];
+  let decoratorSource: string | null = null;
+  let decoratorDepth = 0;
+  for (const line of source.split("\n")) {
+    const trimmed = line.trim();
+    if (decoratorSource !== null) {
+      decoratorSource = `${decoratorSource} ${trimmed}`;
+      decoratorDepth += parenDelta(trimmed);
+      if (decoratorDepth <= 0) {
+        const route = parseFlaskRouteDecorator(decoratorSource);
+        if (route !== null) {
+          pending.push(route);
+        }
+        decoratorSource = null;
+        decoratorDepth = 0;
+      }
+      continue;
+    }
+
+    if (startsFlaskRouteDecorator(trimmed)) {
+      decoratorSource = trimmed;
+      decoratorDepth = parenDelta(trimmed);
+      if (decoratorDepth <= 0) {
+        const route = parseFlaskRouteDecorator(decoratorSource);
+        if (route !== null) {
+          pending.push(route);
+        }
+        decoratorSource = null;
+        decoratorDepth = 0;
+      }
+      continue;
+    }
+
+    const functionName = /^\s*(?:async\s+)?def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/u.exec(line)?.[1];
+    if (functionName !== undefined && pending.length > 0) {
+      for (const item of pending) {
+        routes.push({ filePath, functionName, ...item });
+      }
+      pending = [];
+      continue;
+    }
+
+    if (
+      pending.length > 0 &&
+      trimmed !== "" &&
+      !trimmed.startsWith("@") &&
+      !trimmed.startsWith("#")
+    ) {
+      pending = [];
+    }
+  }
+  return routes;
+}
+
+function startsFlaskRouteDecorator(line: string): boolean {
+  return /^@[A-Za-z_][A-Za-z0-9_.]*\.route\(/u.test(line);
+}
+
+function parseFlaskRouteDecorator(line: string): { routePath: string; methods: string[] } | null {
+  const match = /^\s*@[A-Za-z_][A-Za-z0-9_.]*\.route\(\s*(["'])(.*?)\1(.*)\)\s*(?:#.*)?$/u.exec(
+    line,
+  );
+  if (match?.[2] === undefined) {
+    return null;
+  }
+  return {
+    routePath: match[2],
+    methods: parseFlaskMethods(match[3] ?? ""),
+  };
+}
+
+function parseFlaskMethods(args: string): string[] {
+  const match = /methods\s*=\s*\[([^\]]*)\]/u.exec(args);
+  if (match?.[1] === undefined) {
+    return ["GET"];
+  }
+  const methods = [...match[1].matchAll(/["']([^"']+)["']/gu)]
+    .map((item) => item[1]?.toUpperCase())
+    .filter((item): item is string => item !== undefined && item.length > 0);
+  return methods.length > 0 ? [...new Set(methods)] : ["GET"];
+}
+
+function parenDelta(line: string): number {
+  let delta = 0;
+  let quote: string | null = null;
+  let escaped = false;
+  for (const char of line) {
+    if (quote !== null) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === "(") {
+      delta += 1;
+    } else if (char === ")") {
+      delta -= 1;
+    }
+  }
+  return delta;
+}
+
+function flaskRouteTrustBoundaries(route: FlaskRoute): FeatureSeed["trustBoundaries"] {
+  const boundaries: FeatureSeed["trustBoundaries"] = ["network", "user-input", "serialization"];
+  if (
+    route.methods.some((method) => method !== "GET") ||
+    /(^|\/)(admin|auth|login|token)(\/|$)/iu.test(route.routePath)
+  ) {
+    boundaries.push("auth");
+  }
+  return boundaries;
 }
 
 function standaloneTestSuites(testFiles: string[], command: string | null): FeatureSeed[] {

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -44,6 +44,13 @@ const projectMetadataFiles = [
 ] as const;
 const sourceGroupMaxOwnedFiles = 12;
 const sourceGroupMaxTests = 8;
+const flaskRootEntryFiles = [
+  "app.py",
+  "wsgi.py",
+  "application.py",
+  "server.py",
+  "main.py",
+] as const;
 
 export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
   if (!(await isPythonProject(root))) {
@@ -329,9 +336,7 @@ async function flaskRouteSeeds(
   testCommand: string | null,
 ): Promise<FeatureSeed[]> {
   const hasFlaskDependency = await pythonDependencyHas(root, "flask");
-  const routeFiles = (await walk(root, await pythonSourceRoots(root))).filter(
-    isReviewablePythonSourceFile,
-  );
+  const routeFiles = await flaskRouteFiles(root);
   const seeds: FeatureSeed[] = [];
   for (const filePath of routeFiles) {
     const source = await readFile(join(root, filePath), "utf8");
@@ -363,6 +368,19 @@ async function flaskRouteSeeds(
     }
   }
   return seeds;
+}
+
+async function flaskRouteFiles(root: string): Promise<string[]> {
+  const rootEntries: string[] = [];
+  for (const filePath of flaskRootEntryFiles) {
+    if (isReviewablePythonSourceFile(filePath) && (await isSafeFile(root, join(root, filePath)))) {
+      rootEntries.push(filePath);
+    }
+  }
+  const rootedFiles = (await walk(root, await pythonSourceRoots(root))).filter(
+    isReviewablePythonSourceFile,
+  );
+  return uniquePaths([...rootEntries, ...rootedFiles]);
 }
 
 async function pythonDependencyHas(root: string, dependency: string): Promise<boolean> {
@@ -446,21 +464,76 @@ function parseFlaskRouteDecorator(line: string): { routePath: string; methods: s
   if (match?.[2] === undefined) {
     return null;
   }
+  const methods = parseFlaskMethods(match[3] ?? "");
+  if (methods === null) {
+    return null;
+  }
   return {
     routePath: match[2],
-    methods: parseFlaskMethods(match[3] ?? ""),
+    methods,
   };
 }
 
-function parseFlaskMethods(args: string): string[] {
-  const match = /methods\s*=\s*\[([^\]]*)\]/u.exec(args);
-  if (match?.[1] === undefined) {
+function parseFlaskMethods(args: string): string[] | null {
+  const methodsIndex = args.search(/\bmethods\s*=/u);
+  if (methodsIndex === -1) {
     return ["GET"];
   }
-  const methods = [...match[1].matchAll(/["']([^"']+)["']/gu)]
+  const literal = flaskMethodsLiteral(args.slice(methodsIndex));
+  if (literal === null) {
+    return null;
+  }
+  const methods = [...literal.matchAll(/["']([^"']+)["']/gu)]
     .map((item) => item[1]?.toUpperCase())
     .filter((item): item is string => item !== undefined && item.length > 0);
-  return methods.length > 0 ? [...new Set(methods)] : ["GET"];
+  return methods.length > 0 ? [...new Set(methods)] : null;
+}
+
+function flaskMethodsLiteral(source: string): string | null {
+  const match = /^\s*methods\s*=\s*([[({])/u.exec(source);
+  if (match === null) {
+    return null;
+  }
+  const opener = match[1];
+  if (opener === undefined) {
+    return null;
+  }
+  const literalStart = match[0].length;
+  const closer = opener === "[" ? "]" : opener === "(" ? ")" : "}";
+  let quote: string | null = null;
+  let escaped = false;
+  let depth = 0;
+  for (let index = literalStart - 1; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === undefined) {
+      break;
+    }
+    if (quote !== null) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === opener) {
+      depth += 1;
+      continue;
+    }
+    if (char === closer) {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(literalStart, index);
+      }
+    }
+  }
+  return null;
 }
 
 function parenDelta(line: string): number {

--- a/website/index.html
+++ b/website/index.html
@@ -1160,8 +1160,8 @@
             </li>
           </ul>
           <p>
-            Clawpatch auto-detects Node.js, TypeScript, Next.js, Go, Rust/Cargo, SwiftPM, and common
-            build tools. You can customize settings after initialization.
+            Clawpatch auto-detects Node.js, TypeScript, Next.js, Python, Flask, Go, Rust/Cargo,
+            SwiftPM, and common build tools. You can customize settings after initialization.
           </p>
 
           <h2 id="feature-mapping">Feature Mapping</h2>
@@ -1169,9 +1169,10 @@
           <pre><code><span class="hl-cmd">clawpatch</span> map</code></pre>
           <p>Features are semantic units like:</p>
           <ul>
-            <li><strong>Routes</strong> — Next.js app and pages routes</li>
+            <li><strong>Routes</strong> — Next.js app/pages routes and Flask routes</li>
             <li>
-              <strong>Commands</strong> — npm package bins plus Go, Rust, and SwiftPM commands
+              <strong>Commands</strong> — npm package bins plus Python, Go, Rust, and SwiftPM
+              commands
             </li>
             <li>
               <strong>Packages</strong> — Go internal packages, Rust libraries, and Swift targets


### PR DESCRIPTION
## Summary
- Add Flask route feature mapping for Python projects, including `web/` source roots.
- Detect Python web/test frameworks from Python dependency metadata.
- Update README, docs, and static site copy for Python and Flask mapping coverage.

## Why
Python projects already map package metadata, console scripts, source groups, and pytest suites, but Flask endpoints were only reviewed as broad source groups. This gives web handlers route-sized review slices.

## Validation
- `pnpm typecheck`
- `pnpm test -- src/mapper.test.ts`
- `pnpm lint`
- `pnpm build`
- Local dry-run against a Flask/Python repository confirmed route-sized Flask features are produced

## Red-team notes
- Tightened route mapping to require a Flask dependency or Flask import before labeling `@*.route(...)` as Flask.
- Known limitation: blueprint `url_prefix` is not expanded into full mounted paths in this first pass.
- Known limitation: non-literal route paths or methods are intentionally skipped/defaulted rather than guessed.