### PR TITLE
Map package scripts in Node workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added JVM semantic role mapping from Java annotations, imports, inheritance, interfaces, and method signatures.
+- Added selected package script mapping for Node workspace packages.
 - Detected Java/Kotlin language and default Gradle build/test commands for root Gradle projects.
 - Added FastAPI route feature mapping and kept root/web Python project detection in sync.
 - Added Flask route feature mapping for Python projects, including `web/` source roots, common root entry files, non-list method literals, and Python framework detection.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ validation commands and records a patch attempt under `.clawpatch/`.
 ## What It Maps Today
 
 - npm package bins
-- selected package scripts: `start`, `build`, `test`, `lint`, `typecheck`,
-  `format`
+- selected root and workspace package scripts: `start`, `build`, `test`,
+  `lint`, `typecheck`, `format`
 - Next.js `app/` and `pages/` routes
 - Go package slices from `go list ./...`, including command packages
 - Go package tests and same-repo imports as review context

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -27,7 +27,7 @@ A feature is a reviewable slice with:
 Supported deterministic mappers today:
 
 - npm package bins
-- selected package scripts
+- selected root and workspace package scripts
 - Node/TypeScript workspace packages from `package.json` workspaces, `pnpm-workspace.yaml`, and common package folders
 - bounded Node/TypeScript source groups under `src/`, `lib/`, `app/`, `pages/`, and `scripts/`
 - Next.js `app/` and `pages/` routes
@@ -50,6 +50,8 @@ For large Node/TypeScript repositories, source groups are recursively split by
 directory and then chunked so one feature owns at most a small bounded set of
 files. Package-local tests and package context files are attached when they can
 be found cheaply.
+Selected `package.json` scripts are mapped for the root package and discovered
+workspace packages, with workspace script titles including the package name.
 
 Native app mappers use the same bounded grouping model. SwiftPM packages can be
 discovered below the repo root, Apple projects are grouped by Swift source area,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,7 +42,7 @@ clawpatch map
 
 This discovers reviewable features:
 
-- npm package bins and scripts
+- npm package bins and root/workspace scripts
 - Next.js routes
 - Go packages and commands
 - Java/Kotlin Gradle modules

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -214,7 +214,15 @@ describe("mapFeatures", () => {
       root,
       "packages/core/package.json",
       JSON.stringify(
-        { name: "@scope/core", bin: { corecli: "src/cli.ts" }, scripts: { test: "vitest run" } },
+        {
+          name: "@scope/core",
+          bin: { corecli: "src/cli.ts" },
+          scripts: {
+            build: "tsc -p tsconfig.json",
+            lint: "oxlint .",
+            test: "vitest run",
+          },
+        },
         null,
         2,
       ),
@@ -314,6 +322,15 @@ describe("mapFeatures", () => {
       (feature) => feature.entrypoints[0]?.symbol === "packages/core/src/gateway",
     );
     const cli = result.features.find((feature) => feature.title === "CLI command corecli");
+    const workspaceBuild = result.features.find(
+      (feature) => feature.title === "Package script build (@scope/core)",
+    );
+    const workspaceLint = result.features.find(
+      (feature) => feature.title === "Package script lint (@scope/core)",
+    );
+    const workspaceTest = result.features.find(
+      (feature) => feature.title === "Package script test (@scope/core)",
+    );
 
     expect(titles).toContain("Node package @scope/core");
     expect(titles).toContain("Node package chat-plugin");
@@ -325,6 +342,11 @@ describe("mapFeatures", () => {
     expect(titles).not.toContain("Node package outside-workspace");
     expect(titles).not.toContain("Node package evil-package");
     expect(titles).toContain("Node source plugins/chat/src");
+    expect(titles).toContain("Package script test");
+    expect(workspaceBuild?.entrypoints[0]?.path).toBe("packages/core/package.json");
+    expect(workspaceBuild?.summary).toContain("packages/core/package.json");
+    expect(workspaceLint?.entrypoints[0]?.path).toBe("packages/core/package.json");
+    expect(workspaceTest?.entrypoints[0]?.path).toBe("packages/core/package.json");
     expect(agentGroups.length).toBeGreaterThan(1);
     expect(agentGroups.every((feature) => feature.ownedFiles.length <= 12)).toBe(true);
     expect(gateway?.ownedFiles).toEqual([

--- a/src/mappers/node.ts
+++ b/src/mappers/node.ts
@@ -45,7 +45,7 @@ export async function nodeSeeds(root: string): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
 
   for (const info of packages) {
-    seeds.push(...(await packageSeeds(root, info, packageManager, info.root === ".")));
+    seeds.push(...(await packageSeeds(root, info, packageManager)));
     seeds.push(...(await sourceGroupSeeds(root, info, packageManager)));
   }
 
@@ -56,7 +56,6 @@ async function packageSeeds(
   root: string,
   info: PackageInfo,
   packageManager: string,
-  includeCommonScripts: boolean,
 ): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
   const packageName = packageDisplayName(info);
@@ -105,18 +104,19 @@ async function packageSeeds(
     });
   }
 
-  if (!includeCommonScripts) {
-    seeds.unshift(manifestSeed);
-    return seeds;
-  }
-
   for (const [script, command] of Object.entries(packageScripts(info.packageJson))) {
     if (!["start", "build", "test", "lint", "typecheck", "format"].includes(script)) {
       continue;
     }
     seeds.push({
-      title: `Package script ${script}`,
-      summary: `Package script '${script}': ${command}`,
+      title:
+        info.root === "."
+          ? `Package script ${script}`
+          : `Package script ${script} (${packageName})`,
+      summary:
+        info.root === "."
+          ? `Package script '${script}': ${command}`
+          : `Package script '${script}' in ${info.packageJsonPath}: ${command}`,
       kind: script === "test" ? "test-suite" : "release",
       source: "package-json-script",
       confidence: "medium",


### PR DESCRIPTION
## Summary

This extends the existing Node workspace mapper so selected package scripts are mapped for discovered workspace packages, not only the root package.

The change keeps root package script titles unchanged, and scopes workspace script titles with the package name so monorepos get distinguishable feature slices such as `Package script build (@scope/core)`.

## Test Plan

- `pnpm vitest run src/mapper.test.ts`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- Smoke-tested the built CLI against a Remnic monorepo worktree with an isolated state dir: `clawpatch map` produced 230 features, including 33 `package-json-script` features across workspace packages.