### PR TITLE
feat(mapper): add JVM role mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added JVM semantic role mapping from Java annotations, imports, inheritance, interfaces, and method signatures.
 - Detected Java/Kotlin language and default Gradle build/test commands for root Gradle projects.
 - Added FastAPI route feature mapping and kept root/web Python project detection in sync.
 - Added Flask route feature mapping for Python projects, including `web/` source roots, common root entry files, non-list method literals, and Python framework detection.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ validation commands and records a patch attempt under `.clawpatch/`.
 - Go package slices from `go list ./...`, including command packages
 - Go package tests and same-repo imports as review context
 - Java/Kotlin Gradle source groups and root Gradle build/test commands
+- JVM semantic roles from Java code evidence such as annotations, imports,
+  interfaces, inheritance, and method signatures
 - Rust `src/main.rs`, `src/bin/*.rs`, `src/lib.rs`, `crates/*`, and
   `tests/*.rs`
 - Python project metadata, console scripts, bounded source groups, pytest suites,

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -35,6 +35,7 @@ Supported deterministic mappers today:
 - Go `internal/*` packages
 - Python project metadata, console scripts, root app files, bounded source groups,
   pytest suites, and Flask/FastAPI routes
+- JVM semantic role groups from Java annotations, imports, inheritance, interfaces, and method signatures
 - Rust Cargo commands, libraries, workspace crates, and integration tests
 - SwiftPM executable targets, library targets, and test suites
 - nested SwiftPM packages
@@ -54,6 +55,9 @@ Native app mappers use the same bounded grouping model. SwiftPM packages can be
 discovered below the repo root, Apple projects are grouped by Swift source area,
 and Gradle modules are grouped from `src/main`, `src/test`, and `src/androidTest`.
 Root Gradle projects get default `gradle`/`./gradlew` build and test commands.
+Java files in Gradle modules also get role-oriented review slices when code
+evidence identifies web entrypoints, services, persistence boundaries, external
+clients, configuration, framework components, or extension boundaries.
 
 Python mapping covers `pyproject.toml` metadata, `[project.scripts]` and
 `[tool.poetry.scripts]` console scripts, root app files, source groups under

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,6 +47,7 @@ This discovers reviewable features:
 - Go packages and commands
 - Java/Kotlin Gradle modules
 - Python packages, console scripts, Flask routes, and pytest suites
+- JVM semantic role groups
 - Rust crates and binaries
 - SwiftPM targets and tests
 - Config files

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -581,6 +581,219 @@ describe("mapFeatures", () => {
     expect(titles).toContain("Gradle source apps/android/src");
   });
 
+  it("maps JVM role features from Java code evidence", async () => {
+    const root = await fixtureRoot("clawpatch-jvm-role-map-");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("java") }\n');
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/api/OrderController.java",
+      [
+        "package com.acme.api;",
+        "",
+        "import org.springframework.web.bind.annotation.GetMapping;",
+        "import org.springframework.web.bind.annotation.RestController;",
+        "",
+        "@RestController",
+        "public class OrderController {",
+        '  @GetMapping("/orders")',
+        '  public String list() { return "ok"; }',
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/app/BillingService.java",
+      [
+        "package com.acme.app;",
+        "",
+        "import org.springframework.stereotype.Service;",
+        "",
+        "@Service",
+        "public class BillingService {}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/db/OrderEntity.java",
+      [
+        "package com.acme.db;",
+        "",
+        "import jakarta.persistence.Entity;",
+        "",
+        "@Entity",
+        "public class OrderEntity {}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/client/RemoteClient.java",
+      [
+        "package com.acme.client;",
+        "",
+        "import java.net.http.HttpClient;",
+        "",
+        "public class RemoteClient {",
+        "  private final HttpClient client = HttpClient.newHttpClient();",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/client/UriHolder.java",
+      [
+        "package com.acme.client;",
+        "",
+        "import java.net.URI;",
+        "",
+        "public class UriHolder {",
+        "  private final URI endpoint;",
+        "  public UriHolder(URI endpoint) { this.endpoint = endpoint; }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/jobs/JobFactory.java",
+      [
+        "package com.acme.jobs;",
+        "",
+        "import org.scheduler.Job;",
+        "",
+        "public class JobFactory {",
+        "  public Job buildJob() { return null; }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/jobs/GenericJobFactory.java",
+      [
+        "package com.acme.jobs;",
+        "",
+        "import org.scheduler.Job;",
+        "import org.scheduler.JobFactoryBase;",
+        "",
+        "public class GenericJobFactory<T> extends JobFactoryBase<T> {",
+        "  public Job<T> buildJob() { return null; }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/ext/PluginAdapter.java",
+      [
+        "package com.acme.ext;",
+        "",
+        "import org.plugins.Plugin;",
+        "",
+        "public class PluginAdapter implements Plugin {}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/ext/RecordPlugin.java",
+      [
+        "package com.acme.ext;",
+        "",
+        "import org.plugins.Plugin;",
+        "",
+        "public record RecordPlugin(String name) implements Plugin {}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/ext/HelperFirstAdapter.java",
+      [
+        "package com.acme.ext;",
+        "",
+        "import org.plugins.Plugin;",
+        "",
+        "final class Helper {}",
+        "public class HelperFirstAdapter implements Plugin {}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/local/LocalCommandAdapter.java",
+      [
+        "package com.acme.local;",
+        "",
+        "import com.acme.local.Command;",
+        "",
+        "interface Command {}",
+        "public class LocalCommandAdapter implements Command {}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/java/com/google/myapp/GuavaAdapter.java",
+      [
+        "package com.google.myapp;",
+        "",
+        "import com.google.common.util.concurrent.Service;",
+        "",
+        "public class GuavaAdapter implements Service {}",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const bySource = new Map(result.features.map((feature) => [feature.source, feature]));
+
+    expect(project.detected.packageManagers).toContain("gradle");
+    expect(bySource.get("jvm-role-web-entrypoint")?.ownedFiles[0]?.path).toBe(
+      "src/main/java/com/acme/api/OrderController.java",
+    );
+    expect(bySource.get("jvm-role-application-service")?.ownedFiles[0]?.path).toBe(
+      "src/main/java/com/acme/app/BillingService.java",
+    );
+    expect(bySource.get("jvm-role-persistence-boundary")?.ownedFiles[0]?.path).toBe(
+      "src/main/java/com/acme/db/OrderEntity.java",
+    );
+    expect(bySource.get("jvm-role-external-client")?.ownedFiles[0]?.path).toBe(
+      "src/main/java/com/acme/client/RemoteClient.java",
+    );
+    expect(
+      bySource
+        .get("jvm-role-framework-component")
+        ?.ownedFiles.map((file) => file.path)
+        .toSorted(),
+    ).toEqual(
+      [
+        "src/main/java/com/google/myapp/GuavaAdapter.java",
+        "src/main/java/com/acme/ext/HelperFirstAdapter.java",
+        "src/main/java/com/acme/ext/PluginAdapter.java",
+        "src/main/java/com/acme/ext/RecordPlugin.java",
+        "src/main/java/com/acme/jobs/GenericJobFactory.java",
+        "src/main/java/com/acme/jobs/JobFactory.java",
+      ].toSorted(),
+    );
+    expect(
+      bySource
+        .get("jvm-role-extension-boundary")
+        ?.ownedFiles.map((file) => file.path)
+        .toSorted(),
+    ).toEqual([
+      "src/main/java/com/acme/ext/HelperFirstAdapter.java",
+      "src/main/java/com/acme/ext/PluginAdapter.java",
+      "src/main/java/com/acme/ext/RecordPlugin.java",
+      "src/main/java/com/acme/local/LocalCommandAdapter.java",
+      "src/main/java/com/google/myapp/GuavaAdapter.java",
+    ]);
+  });
+
   it("ignores vendored SwiftPM manifests during detection", async () => {
     const root = await fixtureRoot("clawpatch-vendored-swiftpm-detect-");
     await writeFixture(root, "package.json", JSON.stringify({ name: "host" }, null, 2));

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -1,4 +1,4 @@
-import { lstat, readdir } from "node:fs/promises";
+import { lstat, readFile, readdir } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { pathExists } from "../fs.js";
 import { partitionFileGroups } from "./grouping.js";
@@ -7,6 +7,76 @@ import { FeatureSeed, SeedTestRef } from "./types.js";
 
 const maxOwnedFiles = 12;
 const maxTests = 8;
+const jvmRoleDefinitions = {
+  "web-entrypoint": {
+    title: "web entrypoint",
+    kind: "route",
+    tags: ["jvm", "web"],
+    trustBoundaries: ["network", "user-input", "serialization"],
+  },
+  "application-service": {
+    title: "application service",
+    kind: "service",
+    tags: ["jvm", "service"],
+    trustBoundaries: [],
+  },
+  "persistence-boundary": {
+    title: "persistence boundary",
+    kind: "service",
+    tags: ["jvm", "persistence"],
+    trustBoundaries: ["database", "serialization"],
+  },
+  "external-client": {
+    title: "external client",
+    kind: "service",
+    tags: ["jvm", "external-api"],
+    trustBoundaries: ["network", "external-api", "serialization"],
+  },
+  configuration: {
+    title: "configuration",
+    kind: "config",
+    tags: ["jvm", "config"],
+    trustBoundaries: ["filesystem"],
+  },
+  "framework-component": {
+    title: "framework component",
+    kind: "library",
+    tags: ["jvm", "framework"],
+    trustBoundaries: [],
+  },
+  "extension-boundary": {
+    title: "extension boundary",
+    kind: "library",
+    tags: ["jvm", "interface"],
+    trustBoundaries: [],
+  },
+} as const satisfies Record<
+  string,
+  {
+    title: string;
+    kind: FeatureSeed["kind"];
+    tags: string[];
+    trustBoundaries: FeatureSeed["trustBoundaries"];
+  }
+>;
+type JvmRoleKey = keyof typeof jvmRoleDefinitions;
+type JvmRoleEvidence = {
+  role: JvmRoleKey;
+  reason: string;
+};
+type JavaDeclaration = {
+  kind: "class" | "interface" | "record" | "enum";
+  name: string;
+  extendsTypes: string[];
+  implementsTypes: string[];
+};
+type JavaFileInfo = {
+  packageName: string | null;
+  annotations: Set<string>;
+  imports: Map<string, string>;
+  declarations: JavaDeclaration[];
+  methodReturnTypes: Set<string>;
+};
 
 export async function gradleSeeds(root: string): Promise<FeatureSeed[]> {
   const roots = await discoverGradleRoots(root);
@@ -75,6 +145,8 @@ async function gradleProjectSeeds(root: string, gradleRoot: string): Promise<Fea
       });
     }
 
+    seeds.push(...(await jvmRoleSeeds(root, buildFile, sourceRoot, sourceFiles, testFiles, tags)));
+
     if (testFiles.length > 0) {
       for (const group of partitionFileGroups(sourceRoot, testFiles, maxOwnedFiles)) {
         seeds.push({
@@ -99,6 +171,336 @@ async function gradleProjectSeeds(root: string, gradleRoot: string): Promise<Fea
     }
   }
   return seeds;
+}
+
+async function jvmRoleSeeds(
+  root: string,
+  buildFile: string,
+  sourceRoot: string,
+  sourceFiles: string[],
+  testFiles: string[],
+  tags: string[],
+): Promise<FeatureSeed[]> {
+  const matches = new Map<JvmRoleKey, Map<string, string[]>>();
+  const javaFiles: Array<{ filePath: string; info: JavaFileInfo }> = [];
+  for (const filePath of sourceFiles.filter((file) => file.endsWith(".java"))) {
+    const source = await readFile(join(root, filePath), "utf8");
+    javaFiles.push({ filePath, info: parseJavaFile(source) });
+  }
+  const projectPackages = new Set(
+    javaFiles.flatMap(({ info }) => (info.packageName === null ? [] : [info.packageName])),
+  );
+
+  for (const { filePath, info } of javaFiles) {
+    for (const evidence of jvmRoleEvidence(info, projectPackages)) {
+      const byFile = matches.get(evidence.role) ?? new Map<string, string[]>();
+      const reasons = byFile.get(filePath) ?? [];
+      reasons.push(evidence.reason);
+      byFile.set(filePath, reasons);
+      matches.set(evidence.role, byFile);
+    }
+  }
+
+  const seeds: FeatureSeed[] = [];
+  for (const [role, byFile] of [...matches.entries()].toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    const definition = jvmRoleDefinitions[role];
+    for (const group of partitionFileGroups(sourceRoot, [...byFile.keys()], maxOwnedFiles)) {
+      const tests = associatedGradleTests(group.files, testFiles);
+      seeds.push({
+        title: `JVM role ${definition.title} ${group.label}`,
+        summary: `JVM ${definition.title} group ${group.label} with ${group.files.length} files, classified from Java code evidence.`,
+        kind: definition.kind,
+        source: `jvm-role-${role}`,
+        confidence: role === "extension-boundary" ? "medium" : "high",
+        entryPath: buildFile,
+        symbol: group.label,
+        route: null,
+        command: null,
+        ownedFiles: group.files.map((path) => ({
+          path,
+          reason: `jvm ${definition.title} evidence: ${unique(byFile.get(path) ?? []).join("; ")}`,
+        })),
+        contextFiles: tests.map((test) => ({ path: test.path, reason: "associated gradle test" })),
+        tests,
+        tags: [...tags, ...definition.tags],
+        trustBoundaries: definition.trustBoundaries,
+        skipNearbyTests: true,
+      });
+    }
+  }
+  return seeds;
+}
+
+function jvmRoleEvidence(info: JavaFileInfo, projectPackages: Set<string>): JvmRoleEvidence[] {
+  const evidence: JvmRoleEvidence[] = [];
+  evidence.push(...annotationEvidence(info));
+  evidence.push(...importEvidence(info));
+  evidence.push(...declarationEvidence(info, projectPackages));
+  evidence.push(...methodReturnEvidence(info, projectPackages));
+  return dedupeEvidence(evidence);
+}
+
+function parseJavaFile(source: string): JavaFileInfo {
+  const stripped = stripJavaComments(source);
+  const packageName = /^\s*package\s+([A-Za-z0-9_.]+)\s*;/mu.exec(stripped)?.[1] ?? null;
+  const imports = new Map<string, string>();
+  for (const match of stripped.matchAll(/^\s*import\s+(?:static\s+)?([A-Za-z0-9_.]+)\s*;/gmu)) {
+    const full = match[1];
+    const simple = full?.split(".").at(-1);
+    if (full !== undefined && simple !== undefined) {
+      imports.set(simple, full);
+    }
+  }
+
+  const annotations = new Set<string>();
+  for (const match of stripped.matchAll(/@([A-Za-z_][A-Za-z0-9_.]*)/gu)) {
+    const raw = match[1];
+    if (raw !== undefined) {
+      annotations.add(raw.split(".").at(-1) ?? raw);
+    }
+  }
+
+  const methodReturnTypes = new Set<string>();
+  for (const match of stripped.matchAll(
+    /\b(?:public|protected|private|static|final|abstract|synchronized|native|default|\s)+([A-Z][A-Za-z0-9_$.<>?]*)\s+[A-Za-z_][A-Za-z0-9_]*\s*\(/gu,
+  )) {
+    const type = match[1];
+    if (type !== undefined) {
+      methodReturnTypes.add(baseJavaTypeName(type));
+    }
+  }
+
+  return {
+    packageName,
+    annotations,
+    imports,
+    declarations: parseJavaDeclarations(stripped),
+    methodReturnTypes,
+  };
+}
+
+function parseJavaDeclarations(source: string): JavaDeclaration[] {
+  const declarations: JavaDeclaration[] = [];
+  const declarationPattern =
+    /\b(class|interface|record|enum)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*<[^{};]*>)?(?:\s*\([^{};]*\))?(?:\s+extends\s+([^{]+?))?(?:\s+implements\s+([^{]+?))?\s*\{/gsu;
+  for (const match of source.matchAll(declarationPattern)) {
+    const kind = match[1];
+    const name = match[2];
+    if (kind === undefined || name === undefined) {
+      continue;
+    }
+    declarations.push({
+      kind: kind as JavaDeclaration["kind"],
+      name,
+      extendsTypes: match[3] === undefined ? [] : javaTypeNames(match[3]),
+      implementsTypes: match[4] === undefined ? [] : javaTypeNames(match[4]),
+    });
+  }
+  return declarations;
+}
+
+function annotationEvidence(info: JavaFileInfo): JvmRoleEvidence[] {
+  const evidence: JvmRoleEvidence[] = [];
+  for (const annotation of info.annotations) {
+    if (
+      [
+        "Controller",
+        "RestController",
+        "RequestMapping",
+        "Path",
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+      ].includes(annotation)
+    ) {
+      evidence.push({ role: "web-entrypoint", reason: `annotation @${annotation}` });
+    }
+    if (["Service", "Component", "ApplicationScoped", "Singleton", "Named"].includes(annotation)) {
+      evidence.push({ role: "application-service", reason: `annotation @${annotation}` });
+    }
+    if (["Entity", "Repository", "Table", "MappedSuperclass"].includes(annotation)) {
+      evidence.push({ role: "persistence-boundary", reason: `annotation @${annotation}` });
+    }
+    if (["Configuration", "Bean", "ConfigurationProperties"].includes(annotation)) {
+      evidence.push({ role: "configuration", reason: `annotation @${annotation}` });
+    }
+  }
+  return evidence;
+}
+
+function importEvidence(info: JavaFileInfo): JvmRoleEvidence[] {
+  const evidence: JvmRoleEvidence[] = [];
+  for (const full of info.imports.values()) {
+    if (
+      full.startsWith("org.springframework.web.bind.annotation.") ||
+      /^(?:jakarta|javax)\.ws\.rs\./u.test(full)
+    ) {
+      evidence.push({ role: "web-entrypoint", reason: `web framework import ${full}` });
+    }
+    if (
+      /^(?:jakarta|javax)\.persistence\./u.test(full) ||
+      full.startsWith("org.hibernate.") ||
+      full.startsWith("java.sql.")
+    ) {
+      evidence.push({ role: "persistence-boundary", reason: `persistence import ${full}` });
+    }
+    if (
+      isNetworkClientImport(full) ||
+      full.startsWith("okhttp3.") ||
+      full.startsWith("retrofit2.") ||
+      full.startsWith("org.apache.http.") ||
+      full.startsWith("io.grpc.") ||
+      full.startsWith("software.amazon.awssdk.") ||
+      full.startsWith("com.google.cloud.") ||
+      full.startsWith("com.azure.")
+    ) {
+      evidence.push({ role: "external-client", reason: `external client import ${full}` });
+    }
+  }
+  return evidence;
+}
+
+function declarationEvidence(info: JavaFileInfo, projectPackages: Set<string>): JvmRoleEvidence[] {
+  const evidence: JvmRoleEvidence[] = [];
+  for (const declaration of info.declarations) {
+    if (declaration.kind === "interface") {
+      evidence.push({
+        role: "extension-boundary",
+        reason: `interface declaration ${declaration.name}`,
+      });
+    }
+    for (const type of [...declaration.extendsTypes, ...declaration.implementsTypes]) {
+      const full = info.imports.get(type);
+      if (full !== undefined && isExternalProjectImport(full, projectPackages)) {
+        evidence.push({ role: "framework-component", reason: `inherits external type ${full}` });
+      }
+      if (declaration.implementsTypes.includes(type)) {
+        evidence.push({ role: "extension-boundary", reason: `implements ${type}` });
+      }
+    }
+  }
+  return evidence;
+}
+
+function methodReturnEvidence(info: JavaFileInfo, projectPackages: Set<string>): JvmRoleEvidence[] {
+  const evidence: JvmRoleEvidence[] = [];
+  for (const type of info.methodReturnTypes) {
+    const full = info.imports.get(type);
+    if (full !== undefined && isExternalProjectImport(full, projectPackages)) {
+      evidence.push({ role: "framework-component", reason: `returns external type ${full}` });
+    }
+  }
+  return evidence;
+}
+
+function isExternalProjectImport(full: string, projectPackages: Set<string>): boolean {
+  if (/^(?:java|javax|jakarta)\./u.test(full)) {
+    return false;
+  }
+  for (const packageName of projectPackages) {
+    if (full.startsWith(`${packageName}.`)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isNetworkClientImport(full: string): boolean {
+  return (
+    full.startsWith("java.net.http.") ||
+    [
+      "java.net.DatagramSocket",
+      "java.net.HttpURLConnection",
+      "java.net.ServerSocket",
+      "java.net.Socket",
+      "java.net.URL",
+      "java.net.URLConnection",
+    ].includes(full)
+  );
+}
+
+function javaTypeNames(raw: string): string[] {
+  return splitJavaTypeList(raw)
+    .map((type) => baseJavaTypeName(stripGenericParameters(type)))
+    .filter((type) => type.length > 0);
+}
+
+function baseJavaTypeName(raw: string): string {
+  return (
+    raw
+      .replace(/<.*>/su, "")
+      .replace(/\?.*$/su, "")
+      .split(".")
+      .at(-1)
+      ?.replace(/[^A-Za-z0-9_$]/gu, "")
+      .trim() ?? ""
+  );
+}
+
+function splitJavaTypeList(raw: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const char of raw) {
+    if (char === "<") {
+      depth += 1;
+    } else if (char === ">") {
+      depth = Math.max(0, depth - 1);
+    }
+    if (char === "," && depth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current);
+  return parts;
+}
+
+function stripGenericParameters(raw: string): string {
+  let depth = 0;
+  let result = "";
+  for (const char of raw) {
+    if (char === "<") {
+      depth += 1;
+      continue;
+    }
+    if (char === ">") {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (depth === 0) {
+      result += char;
+    }
+  }
+  return result;
+}
+
+function stripJavaComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//gu, (value) => " ".repeat(value.length))
+    .replace(/\/\/.*$/gmu, "");
+}
+
+function dedupeEvidence(evidence: JvmRoleEvidence[]): JvmRoleEvidence[] {
+  const seen = new Set<string>();
+  return evidence.filter((item) => {
+    const key = `${item.role}:${item.reason}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
 }
 
 async function discoverGradleRoots(root: string): Promise<string[]> {


### PR DESCRIPTION
## Summary
- Add role-oriented JVM feature slices for Gradle Java sources.
- Classify Java files from code evidence: annotations, imports, inheritance/interfaces, and method return types.
- Cover generic roles such as web entrypoints, services, persistence boundaries, external clients, configuration, framework components, and extension boundaries.

## Why
Gradle source groups are useful but broad. Evidence-based JVM role features give review runs smaller, more meaningful slices without relying on project-specific naming conventions.

## Validation
- `pnpm typecheck`
- `pnpm test -- src/mapper.test.ts`
- `pnpm lint`
- `pnpm build`
- Local dry-run against a Java/Gradle repository confirmed additional JVM role features are produced while existing Gradle source/test groups remain

## Red-team notes
- This avoids filename-only role heuristics.
- Framework components require concrete code evidence such as external inherited/implemented/returned types.
- Plain URI/config-style imports do not trigger external-client classification by themselves.
- Same-project imports are identified from actual Java package declarations, so broad namespace projects are not confused with external libraries that share the first one or two package segments.
- Local same-project types with names like `Command` do not trigger framework-component classification.
- This does not add framework-specific support for any one robotics, web, or mobile ecosystem.