### PR TITLE
feat(review): add --since flag to review only features touched by a diff range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Detected Java/Kotlin language and default Gradle build/test commands for root Gradle projects.
 - Added FastAPI route feature mapping and kept root/web Python project detection in sync.
+- Added `--since <ref>` on `clawpatch review` and `clawpatch revalidate` to restrict runs to features whose owned or context files changed since the given git ref, thanks @mvanhorn.
 - Added Flask route feature mapping for Python projects, including `web/` source roots, common root entry files, non-list method literals, and Python framework detection.
 - Added Next.js route mapping for `src/app` and `src/pages` layouts, thanks @obatried.
 - Added first-pass Python mapping for project metadata, console scripts, source groups, pytest suites, and conservative validation defaults, thanks @xiamx.

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -11,6 +11,7 @@ description: "How clawpatch reviews features with AI providers and persists find
 clawpatch review --limit 3
 clawpatch review --limit 12 --jobs 4
 clawpatch review --feature <featureId>
+clawpatch review --since origin/main
 clawpatch review --provider codex --model <model>
 ```
 
@@ -26,6 +27,22 @@ Current behavior:
 - writes findings under `.clawpatch/findings/`
 - appends analysis history to the feature record
 - releases the feature lock
+
+## Flags
+
+### --since <ref>
+
+Restrict review to features whose owned or context files have changed in
+`git diff --name-only <ref>...HEAD`. Useful for CI:
+
+```bash
+clawpatch review --since origin/main   # review what this branch changed
+clawpatch review --since HEAD~5        # review the last 5 commits
+```
+
+If no features are touched by the diff, `review` exits cleanly with no findings.
+The same flag is available on `revalidate`; revalidation scopes open findings to
+features whose owned files changed.
 
 Progress uses stderr so `--json` stdout remains machine-readable. The worker
 pool is per-process and still uses feature locks, so overlapping runs should not

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -33,7 +33,9 @@ Current behavior:
 ### --since <ref>
 
 Restrict review to features whose owned or context files have changed in
-`git diff --name-only <ref>...HEAD`. Useful for CI:
+`git diff --name-only --relative <ref>...HEAD`. Paths are compared relative to
+the selected project root, so `--root` may point at a subdirectory inside a
+larger Git repository. Useful for CI:
 
 ```bash
 clawpatch review --since origin/main   # review what this branch changed

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import { detectProject } from "./detect.js";
 import { ClawpatchError, assertDefined } from "./errors.js";
 import { runCommand } from "./exec.js";
 import { nowIso, writeJson } from "./fs.js";
-import { discoverGit, findProjectRoot } from "./git.js";
+import { changedFilesSince, discoverGit, findProjectRoot } from "./git.js";
 import { stableId, runId } from "./id.js";
 import { mapFeatures } from "./mapper.js";
 import { providerByName } from "./provider.js";
@@ -138,7 +138,10 @@ export async function reviewCommand(
   const loaded = await loadProjectState(context);
   const config = applyProviderFlags(loaded.config, flags);
   const provider = providerByName(config.provider.name);
-  const features = selectFeatures(await readFeatures(loaded.paths), flags);
+  const features = await selectReviewFeatures(loaded, flags);
+  if (features.length === 0 && typeof flags["since"] === "string") {
+    return { next: "no features touched by diff" };
+  }
   if (flags["dryRun"] === true) {
     return {
       dryRun: true,
@@ -468,7 +471,7 @@ export async function revalidateCommand(
   const loaded = await loadProjectState(context);
   const config = applyProviderFlags(loaded.config, flags);
   const provider = providerByName(config.provider.name);
-  const findings = await selectRevalidationFindings(loaded.paths, flags);
+  const findings = await selectRevalidationFindings(loaded, flags);
   const currentRunId = runId();
   const currentGit = await discoverGit(loaded.root);
   const run = newRun(currentRunId, "revalidate", context, loaded.root, currentGit.headSha);
@@ -551,7 +554,7 @@ export async function revalidateCommand(
     });
     throw error;
   }
-  if (flags["all"] === true) {
+  if (flags["all"] === true || typeof flags["since"] === "string") {
     return {
       revalidated: results.length,
       open: results.filter((result) => result.outcome === "open").length,
@@ -815,19 +818,32 @@ function validationCommandsForFeature(
 }
 
 async function selectRevalidationFindings(
-  paths: ReturnType<typeof statePaths>,
+  loaded: Awaited<ReturnType<typeof loadProjectState>>,
   flags: Record<string, string | boolean>,
 ): Promise<FindingRecord[]> {
-  if (flags["all"] === true) {
-    const filtered = filterFindings(await readFindings(paths), {
+  const findingId = stringFlag(flags, "finding");
+  if (flags["all"] === true || findingId === undefined) {
+    const filtered = filterFindings(await readFindings(loaded.paths), {
       ...flags,
       status: stringFlag(flags, "status") ?? "open",
     });
-    const limit = Number(stringFlag(flags, "limit") ?? String(filtered.length));
-    return filtered.slice(0, Number.isFinite(limit) && limit > 0 ? limit : filtered.length);
+    const sinceFiltered = await filterFindingsByOwnedFilesSince(loaded, filtered, flags);
+    const limit = Number(stringFlag(flags, "limit") ?? String(sinceFiltered.length));
+    return sinceFiltered.slice(
+      0,
+      Number.isFinite(limit) && limit > 0 ? limit : sinceFiltered.length,
+    );
   }
-  const findingId = assertDefined(stringFlag(flags, "finding"), "missing --finding");
-  return [assertDefined(await readFinding(paths, findingId), `finding not found: ${findingId}`)];
+  return filterFindingsByOwnedFilesSince(
+    loaded,
+    [
+      assertDefined(
+        await readFinding(loaded.paths, findingId),
+        `finding not found: ${findingId}`,
+      ),
+    ],
+    flags,
+  );
 }
 
 async function refreshFeatureStatus(
@@ -900,17 +916,79 @@ function normalizePath(path: string): string {
   return path.replace(/\\/gu, "/").replace(/\/$/u, "");
 }
 
-function selectFeatures(
+async function selectReviewFeatures(
+  loaded: Awaited<ReturnType<typeof loadProjectState>>,
+  flags: Record<string, string | boolean>,
+): Promise<FeatureRecord[]> {
+  const candidates = selectReviewCandidates(await readFeatures(loaded.paths), flags);
+  const sinceFiltered = await filterFeaturesByFilesSince(loaded.root, candidates, flags);
+  return limitFeatures(sinceFiltered, flags);
+}
+
+function selectReviewCandidates(
   features: FeatureRecord[],
   flags: Record<string, string | boolean>,
 ): FeatureRecord[] {
   const featureId = stringFlag(flags, "feature");
+  return featureId === undefined
+    ? features.filter((feature) => ["pending", "error"].includes(feature.status))
+    : features.filter((feature) => feature.featureId === featureId);
+}
+
+async function filterFeaturesByFilesSince(
+  root: string,
+  features: FeatureRecord[],
+  flags: Record<string, string | boolean>,
+): Promise<FeatureRecord[]> {
+  const since = stringFlag(flags, "since");
+  if (since === undefined) {
+    return features;
+  }
+  const changed = await changedFilesSince(root, since);
+  return features.filter((feature) => featureTouchesFiles(feature, changed, true));
+}
+
+async function filterFindingsByOwnedFilesSince(
+  loaded: Awaited<ReturnType<typeof loadProjectState>>,
+  findings: FindingRecord[],
+  flags: Record<string, string | boolean>,
+): Promise<FindingRecord[]> {
+  const since = stringFlag(flags, "since");
+  if (since === undefined) {
+    return findings;
+  }
+  const changed = await changedFilesSince(loaded.root, since);
+  const features = await readFeatures(loaded.paths);
+  const featuresById = new Map(features.map((feature) => [feature.featureId, feature]));
+  return findings.filter((finding) => {
+    const feature = featuresById.get(finding.featureId);
+    return feature !== undefined && featureTouchesFiles(feature, changed, false);
+  });
+}
+
+function featureTouchesFiles(
+  feature: FeatureRecord,
+  changed: Set<string>,
+  includeContext: boolean,
+): boolean {
+  const featureFiles = new Set([
+    ...feature.ownedFiles.map((file) => file.path),
+    ...(includeContext ? feature.contextFiles.map((file) => file.path) : []),
+  ]);
+  for (const file of changed) {
+    if (featureFiles.has(file)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function limitFeatures(
+  features: FeatureRecord[],
+  flags: Record<string, string | boolean>,
+): FeatureRecord[] {
   const limit = Number(stringFlag(flags, "limit") ?? "1");
-  const selected =
-    featureId === undefined
-      ? features.filter((feature) => ["pending", "error"].includes(feature.status))
-      : features.filter((feature) => feature.featureId === featureId);
-  return selected.slice(0, Number.isFinite(limit) && limit > 0 ? limit : 1);
+  return features.slice(0, Number.isFinite(limit) && limit > 0 ? limit : 1);
 }
 
 function reviewJobs(flags: Record<string, string | boolean>): number {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import { GlobalOptions } from "./config.js";
 
 const moduleRequire = createRequire(import.meta.url);
 
-async function main(argv: string[]): Promise<void> {
+export async function main(argv: string[]): Promise<void> {
   const parsed = parseArgs(argv);
   if (parsed.help) {
     printHelp(parsed.command);
@@ -148,7 +148,7 @@ const commandFlags = {
   init: new Set(["force"]),
   map: new Set(["dryRun"]),
   status: new Set<string>(),
-  review: new Set(["feature", "limit", "jobs", "provider", "model", "dryRun"]),
+  review: new Set(["feature", "limit", "since", "jobs", "provider", "model", "dryRun"]),
   report: new Set(["status", "severity", "feature", "category", "triage", "output"]),
   show: new Set(["finding"]),
   next: new Set(["status"]),
@@ -163,6 +163,7 @@ const commandFlags = {
     "category",
     "triage",
     "limit",
+    "since",
     "provider",
     "model",
   ]),
@@ -183,6 +184,7 @@ const valueFlagNames = new Set([
   "feature",
   "finding",
   "limit",
+  "since",
   "jobs",
   "provider",
   "model",
@@ -243,7 +245,12 @@ function validateCommandRequirements(
       throw new ClawpatchError(`missing --${kebab(flag)}`, 2, "invalid-usage");
     }
   }
-  if (command === "revalidate" && typeof flags["finding"] !== "string" && flags["all"] !== true) {
+  if (
+    command === "revalidate" &&
+    typeof flags["finding"] !== "string" &&
+    flags["all"] !== true &&
+    typeof flags["since"] !== "string"
+  ) {
     throw new ClawpatchError("missing --finding or --all", 2, "invalid-usage");
   }
 }
@@ -346,6 +353,7 @@ Usage:
 Flags:
   --feature <id>
   --limit <n>
+  --since <ref>
   --jobs <n>        default: 10
   --provider <name>
   --model <name>
@@ -454,6 +462,7 @@ Flags:
 
 Usage:
   clawpatch revalidate --finding <id> [flags]
+  clawpatch revalidate --since <ref> [flags]
 
 Flags:
   --finding <id>
@@ -464,6 +473,7 @@ Flags:
   --category <category>
   --triage <triage>
   --limit <n>
+  --since <ref>
   --provider <name>
   --model <name>
   --json

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -5,6 +5,7 @@ export async function runCommand(
   command: string,
   cwd: string,
   input?: string,
+  options: { trimOutput?: boolean } = {},
 ): Promise<CommandResult> {
   const started = Date.now();
   const child = spawn(command, {
@@ -35,8 +36,8 @@ export async function runCommand(
     cwd,
     exitCode,
     durationMs: Date.now() - started,
-    stdout: trimOutput(stdout),
-    stderr: trimOutput(stderr),
+    stdout: options.trimOutput === false ? stdout : trimOutput(stdout),
+    stderr: options.trimOutput === false ? stderr : trimOutput(stderr),
   };
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -64,6 +64,23 @@ export function projectNameFromRoot(root: string, remoteUrl: string | null): str
   return basename(root);
 }
 
+export async function changedFilesSince(root: string, ref: string): Promise<Set<string>> {
+  const result = await runCommand(`git diff --name-only ${shellQuoteRef(ref)}...HEAD`, root);
+  if (result.exitCode !== 0) {
+    throw new ClawpatchError(
+      `git diff --since ${ref} failed: ${result.stderr || result.stdout}`,
+      2,
+      "git-failure",
+    );
+  }
+  return new Set(
+    result.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0),
+  );
+}
+
 async function gitLine(cwd: string, command: string): Promise<string | null> {
   const result = await runCommand(command, cwd);
   if (result.exitCode !== 0) {
@@ -76,4 +93,11 @@ async function gitLine(cwd: string, command: string): Promise<string | null> {
 async function gitText(cwd: string, command: string): Promise<string> {
   const result = await runCommand(command, cwd);
   return result.exitCode === 0 ? result.stdout : "";
+}
+
+function shellQuoteRef(ref: string): string {
+  if (!/^[A-Za-z0-9_./~^@-]+$/u.test(ref)) {
+    throw new ClawpatchError(`invalid git ref: ${ref}`, 2, "invalid-input");
+  }
+  return ref;
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -65,7 +65,12 @@ export function projectNameFromRoot(root: string, remoteUrl: string | null): str
 }
 
 export async function changedFilesSince(root: string, ref: string): Promise<Set<string>> {
-  const result = await runCommand(`git diff --name-only ${shellQuoteRef(ref)}...HEAD`, root);
+  const result = await runCommand(
+    `git diff --name-only --relative ${shellQuoteRef(ref)}...HEAD`,
+    root,
+    undefined,
+    { trimOutput: false },
+  );
   if (result.exitCode !== 0) {
     throw new ClawpatchError(
       `git diff --since ${ref} failed: ${result.stderr || result.stdout}`,

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -18,6 +18,7 @@ import {
 import { main as cliMain, packageVersion, parseArgs } from "./cli.js";
 import { loadConfig } from "./config.js";
 import { runCommand } from "./exec.js";
+import { changedFilesSince } from "./git.js";
 import {
   readFeatures,
   readFinding,
@@ -403,6 +404,88 @@ describe("workflow", () => {
       featureIds: expectedFeatureIds(features, new Set(["src/two.ts"]), true),
     });
     expect(reviewed.stderr).toBe("");
+  });
+
+  it("keeps the full changed file list for large --since diffs", async () => {
+    const root = await fixtureRoot("clawpatch-since-large-");
+    const files = Array.from(
+      { length: 220 },
+      (_value, index) =>
+        `src/file-${String(index + 1).padStart(3, "0")}-abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz.ts`,
+    );
+    const targetPath = files[109]!;
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "since-large",
+        bin: { target: targetPath },
+        scripts: { test: "vitest run" },
+      }),
+    );
+    for (const file of files) {
+      await writeFixture(root, file, "export const value = 'base';\n");
+    }
+    await writeFixture(root, "tests/target.test.ts", "expect('target').toBe('target');\n");
+    await initGit(root);
+    await commitAll(root, "base");
+    await checkCommand(root, "git tag --no-sign base");
+    for (const file of files) {
+      await writeFixture(root, file, "export const value = 'changed';\n");
+    }
+    await commitAll(root, "change many files");
+    const changed = await changedFilesSince(root, "base");
+
+    const context = await makeContext(testOptions(root));
+    await initCommand(context, {});
+    await mapCommand(context);
+    const features = await readFeatures(statePaths(join(root, ".clawpatch")));
+    const targetFeature = features.find((feature) =>
+      feature.ownedFiles.some((file) => file.path === targetPath),
+    );
+    const reviewed = (await reviewCommand(context, {
+      since: "base",
+      limit: "250",
+      dryRun: true,
+    })) as { featureIds: string[] };
+
+    expect(changed.size).toBe(files.length);
+    expect(changed).toContain(targetPath);
+    expect(targetFeature).toBeDefined();
+    expect(reviewed.featureIds).toContain(targetFeature!.featureId);
+  });
+
+  it("matches --since paths relative to an explicit subdirectory root", async () => {
+    const repoRoot = await fixtureRoot("clawpatch-since-subdir-repo-");
+    const root = join(repoRoot, "packages", "app");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify({ name: "subdir", bin: { app: "src/app.ts" } }),
+    );
+    await writeFixture(root, "src/app.ts", "export const value = 'base';\n");
+    await initGit(repoRoot);
+    await checkCommand(repoRoot, "git add packages");
+    await checkCommand(repoRoot, 'git -c commit.gpgsign=false commit -q -m "base"');
+    await checkCommand(repoRoot, "git tag --no-sign base");
+    const context = await makeContext(testOptions(root));
+    await initCommand(context, {});
+    await mapCommand(context);
+    await writeFixture(root, "src/app.ts", "export const value = 'changed';\n");
+    await checkCommand(repoRoot, "git add packages/app/src/app.ts");
+    await checkCommand(repoRoot, 'git -c commit.gpgsign=false commit -q -m "change app"');
+    const features = await readFeatures(statePaths(join(root, ".clawpatch")));
+    const targetFeature = features.find((feature) =>
+      feature.ownedFiles.some((file) => file.path === "src/app.ts"),
+    );
+    const reviewed = (await reviewCommand(context, {
+      since: "base",
+      limit: "20",
+      dryRun: true,
+    })) as { featureIds: string[] };
+
+    expect(targetFeature).toBeDefined();
+    expect(reviewed.featureIds).toContain(targetFeature!.featureId);
   });
 
   it("revalidates only findings whose feature owned files overlap --since", async () => {

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -15,7 +15,7 @@ import {
   statusCommand,
   triageCommand,
 } from "./app.js";
-import { packageVersion, parseArgs } from "./cli.js";
+import { main as cliMain, packageVersion, parseArgs } from "./cli.js";
 import { loadConfig } from "./config.js";
 import { runCommand } from "./exec.js";
 import {
@@ -32,6 +32,100 @@ import {
 import { buildReviewPrompt } from "./prompt.js";
 import { fixtureRoot, testOptions, writeFixture } from "./test-helpers.js";
 import { findingRecordSchema } from "./types.js";
+import type { FeatureRecord } from "./types.js";
+
+async function sinceFixture(prefix: string): Promise<string> {
+  const root = await fixtureRoot(prefix);
+  await writeFixture(
+    root,
+    "package.json",
+    JSON.stringify({
+      name: "since",
+      bin: {
+        one: "src/one.ts",
+        two: "src/two.ts",
+        three: "src/three.ts",
+      },
+      scripts: { test: "vitest run" },
+    }),
+  );
+  await writeFixture(root, "src/one.ts", "export const one = 'TODO_BUG';\n");
+  await writeFixture(root, "src/two.ts", "export const two = 'TODO_BUG';\n");
+  await writeFixture(root, "src/three.ts", "export const three = 'TODO_BUG';\n");
+  await writeFixture(root, "tests/one.test.ts", "expect('one').toBe('one');\n");
+  await initGit(root);
+  await commitAll(root, "base");
+  await checkCommand(root, "git tag --no-sign base");
+  return root;
+}
+
+async function initGit(root: string): Promise<void> {
+  await checkCommand(root, "git init -q");
+  await checkCommand(root, "git config user.email test@example.com");
+  await checkCommand(root, "git config user.name Test");
+  await checkCommand(root, "git config commit.gpgsign false");
+  await checkCommand(root, "git config tag.gpgSign false");
+}
+
+async function commitAll(root: string, message: string): Promise<void> {
+  await checkCommand(root, "git add package.json src tests");
+  await checkCommand(root, `git -c commit.gpgsign=false commit -q -m "${message}"`);
+}
+
+async function checkCommand(root: string, command: string): Promise<void> {
+  const result = await runCommand(command, root);
+  if (result.exitCode !== 0) {
+    throw new Error(`${command} failed: ${result.stderr || result.stdout}`);
+  }
+}
+
+async function runCli(argv: string[]): Promise<{ stdout: string; stderr: string }> {
+  let stdout = "";
+  let stderr = "";
+  const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write);
+  const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write);
+  try {
+    await cliMain(argv);
+    return { stdout, stderr };
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+}
+
+function expectedFeatureIds(
+  features: FeatureRecord[],
+  changed: Set<string>,
+  includeContext: boolean,
+): string[] {
+  return features
+    .filter((feature) => ["pending", "error"].includes(feature.status))
+    .filter((feature) => featureTouches(feature, changed, includeContext))
+    .map((feature) => feature.featureId);
+}
+
+function featureTouches(
+  feature: FeatureRecord,
+  changed: Set<string>,
+  includeContext: boolean,
+): boolean {
+  const featureFiles = new Set([
+    ...feature.ownedFiles.map((file) => file.path),
+    ...(includeContext ? feature.contextFiles.map((file) => file.path) : []),
+  ]);
+  for (const file of changed) {
+    if (featureFiles.has(file)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 describe("workflow", () => {
   it("rejects unknown long flags", () => {
@@ -84,6 +178,12 @@ describe("workflow", () => {
     expect(parseArgs(["review", "--limit", "4", "--jobs", "3"]).flags).toMatchObject({
       limit: "4",
       jobs: "3",
+    });
+    expect(parseArgs(["review", "--since", "HEAD~5"]).flags).toMatchObject({
+      since: "HEAD~5",
+    });
+    expect(parseArgs(["revalidate", "--since", "origin/main"]).flags).toMatchObject({
+      since: "origin/main",
     });
     expect(parseArgs(["report", "--status", "open", "--severity", "high"]).flags).toMatchObject({
       status: "open",
@@ -185,6 +285,147 @@ describe("workflow", () => {
         },
       ],
     });
+    delete process.env["CLAWPATCH_PROVIDER"];
+  });
+
+  it("selects review features whose owned files overlap the diff range", async () => {
+    const root = await sinceFixture("clawpatch-since-owned-");
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    await writeFixture(root, "src/two.ts", "export const two = 'changed';\n");
+    await commitAll(root, "change two");
+    const paths = statePaths(join(root, ".clawpatch"));
+    const features = await readFeatures(paths);
+    const reviewed = await reviewCommand(context, { since: "base", limit: "20", dryRun: true });
+
+    expect(reviewed).toMatchObject({
+      dryRun: true,
+      featureIds: expectedFeatureIds(features, new Set(["src/two.ts"]), true),
+    });
+  });
+
+  it("selects review features whose context files overlap the diff range", async () => {
+    const root = await sinceFixture("clawpatch-since-context-");
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    await writeFixture(root, "tests/one.test.ts", "expect('changed').toBe('changed');\n");
+    await commitAll(root, "change test");
+    const paths = statePaths(join(root, ".clawpatch"));
+    const features = await readFeatures(paths);
+    const reviewed = await reviewCommand(context, { since: "base", limit: "20", dryRun: true });
+    const selectedIds = (reviewed as { featureIds: string[] }).featureIds;
+
+    expect(selectedIds).toEqual(expectedFeatureIds(features, new Set(["tests/one.test.ts"]), true));
+    expect(selectedIds.length).toBeGreaterThan(0);
+    expect(
+      selectedIds.every((id) =>
+        features
+          .find((feature) => feature.featureId === id)
+          ?.contextFiles.some((file) => file.path === "tests/one.test.ts"),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns cleanly when --since touches no review features", async () => {
+    const root = await sinceFixture("clawpatch-since-empty-");
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    const reviewed = await reviewCommand(context, { since: "HEAD", dryRun: true });
+
+    expect(reviewed).toMatchObject({ next: "no features touched by diff" });
+  });
+
+  it("rejects invalid --since refs before running git diff", async () => {
+    const root = await sinceFixture("clawpatch-since-invalid-");
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+
+    await expect(reviewCommand(context, { since: "bad ref with spaces" })).rejects.toMatchObject({
+      code: "invalid-input",
+      exitCode: 2,
+    });
+  });
+
+  it("applies --since before --limit for review selection", async () => {
+    const root = await sinceFixture("clawpatch-since-limit-");
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    await writeFixture(root, "src/two.ts", "export const two = 'changed';\n");
+    await writeFixture(root, "src/three.ts", "export const three = 'changed';\n");
+    await commitAll(root, "change two and three");
+    const paths = statePaths(join(root, ".clawpatch"));
+    const features = await readFeatures(paths);
+    const reviewed = await reviewCommand(context, { since: "base", limit: "2", dryRun: true });
+
+    expect(reviewed).toMatchObject({
+      dryRun: true,
+      featureIds: expectedFeatureIds(features, new Set(["src/two.ts", "src/three.ts"]), true).slice(
+        0,
+        2,
+      ),
+    });
+  });
+
+  it("runs review --since through the CLI entrypoint", async () => {
+    const root = await sinceFixture("clawpatch-since-cli-");
+    await runCli(["--root", root, "--json", "--quiet", "init"]);
+    await runCli(["--root", root, "--json", "--quiet", "map"]);
+    await writeFixture(root, "src/two.ts", "export const two = 'changed';\n");
+    await commitAll(root, "change two");
+    const paths = statePaths(join(root, ".clawpatch"));
+    const features = await readFeatures(paths);
+
+    const reviewed = await runCli([
+      "--root",
+      root,
+      "--json",
+      "--quiet",
+      "review",
+      "--since",
+      "base",
+      "--limit",
+      "20",
+      "--dry-run",
+    ]);
+
+    expect(JSON.parse(reviewed.stdout)).toMatchObject({
+      dryRun: true,
+      featureIds: expectedFeatureIds(features, new Set(["src/two.ts"]), true),
+    });
+    expect(reviewed.stderr).toBe("");
+  });
+
+  it("revalidates only findings whose feature owned files overlap --since", async () => {
+    const root = await sinceFixture("clawpatch-since-revalidate-");
+    process.env["CLAWPATCH_PROVIDER"] = "mock";
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    await reviewCommand(context, { limit: "20", jobs: "2" });
+    await writeFixture(root, "src/two.ts", "export const two = 'changed';\n");
+    await commitAll(root, "change two");
+    const paths = statePaths(join(root, ".clawpatch"));
+    const [features, findings] = await Promise.all([readFeatures(paths), readFindings(paths)]);
+    const touchedFeatureIds = new Set(
+      features
+        .filter((feature) => featureTouches(feature, new Set(["src/two.ts"]), false))
+        .map((feature) => feature.featureId),
+    );
+    const expected = findings.filter((finding) => touchedFeatureIds.has(finding.featureId));
+    const result = await revalidateCommand(context, { since: "base" });
+
+    expect(result).toMatchObject({ revalidated: expected.length });
     delete process.env["CLAWPATCH_PROVIDER"];
   });
 


### PR DESCRIPTION
## Summary

- Adds `--since <ref>` to `clawpatch review` and `clawpatch revalidate`. Restricts the run to features whose owned or context files have changed since the given git ref. Designed for CI (`--since origin/main`) and pre-push hooks (`--since HEAD~5`).
- Implementation is a thin filter on top of existing data structures. The mapper already keys features by `ownedFiles` and `contextFiles`; the new `changedFilesSince` helper in `src/git.ts` runs `git diff --name-only <ref>...HEAD` and intersects.
- Empty diff range returns a clean exit with `next: "no features touched by diff"` instead of an error. Combines with `--limit` (intersect first, then limit).
- Refs are validated against a strict pattern (`[A-Za-z0-9_./~^@-]+`) before any git command runs. Shell metacharacters get rejected with exit code 2 and `code: "invalid-input"` — no escaping, no surprises.

## Why this matters

For a CI integration, `clawpatch review` today has no way to scope to "what this branch changed." You either review every mapped feature (slow, costly) or look up feature IDs manually for `--feature`. `--since` closes that gap with one flag:

```bash
# CI on a PR branch:
clawpatch review --since origin/main

# Pre-push hook:
clawpatch review --since HEAD~5

# CI with budget cap:
clawpatch review --since origin/main --limit 3
```

Same flag flows into `revalidate`, so post-merge re-checks can target the same diff range.

## Demo

Simulated demo:

![diff-aware review demo](https://files.catbox.moe/bwnmb0.gif)

The demo shows a 4-feature repo with a 2-file diff (`src/cli.js`, `package.json`). With `--since HEAD~5`, clawpatch reviews only the 2 features whose owned files appear in the diff and skips the other 2 — saving 50% of the LLM calls on a typical CI run.

## Testing

- `corepack pnpm typecheck`
- `corepack pnpm lint` (0 warnings, 0 errors)
- `corepack pnpm test` — 122 tests pass; new tests in `src/workflow.test.ts` cover:
  - `--since` selects only features whose ownedFiles overlap the diff range
  - features selected by contextFiles (e.g., test files) are included
  - empty diff range returns clean exit, not error
  - invalid refs (shell metacharacters) throw `ClawpatchError` with `code: "invalid-input"`
  - `--since` + `--limit` intersect first, then limit
  - `revalidate --since` filters findings to features touched by the diff
