### PR TITLE
fix: run feature validation during fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Improved Node/TypeScript mapping for large workspaces by splitting package source trees into bounded review groups with package-local tests.
 - Added generic nested SwiftPM, Apple/Xcode, and Gradle/Android app mapping.
 - Fixed Codex provider execution on Windows paths with spaces and npm `.cmd` shims, thanks @1berto.
+- Fixed `clawpatch fix` so feature-specific validation commands run during dry-run previews and applied fix validation, thanks @rohitjavvadi.
 
 ## 0.1.0 - 2026-05-15
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -618,7 +618,7 @@ export async function fixCommand(
   };
   const prompt = await buildFixPrompt(loaded.root, finding, feature);
   if (flags["dryRun"] === true) {
-    const validationCommands = collectValidationCommands(config.commands);
+    const validationCommands = validationCommandsForFeature(feature, config.commands);
     return {
       finding: finding.findingId,
       dryRun: true,
@@ -657,7 +657,7 @@ export async function fixCommand(
     });
     throw error;
   }
-  const validationCommands = collectValidationCommands(config.commands);
+  const validationCommands = validationCommandsForFeature(feature, config.commands);
   const commandsRun: CommandResult[] = [];
   for (const command of validationCommands) {
     commandsRun.push(await runCommand(command, loaded.root));
@@ -788,18 +788,6 @@ function applyProviderFlags(
   };
 }
 
-function collectValidationCommands(commands: {
-  typecheck: string | null;
-  lint: string | null;
-  format: string | null;
-  test: string | null;
-}): string[] {
-  const ordered = [commands.format, commands.typecheck, commands.lint, commands.test].filter(
-    (command): command is string => command !== null && command.length > 0,
-  );
-  return Array.from(new Set(ordered));
-}
-
 function validationCommandsForFeature(
   feature: FeatureRecord | null,
   commands: {
@@ -809,12 +797,17 @@ function validationCommandsForFeature(
     test: string | null;
   },
 ): string[] {
-  return Array.from(
-    new Set([
-      ...(feature?.tests ?? []).flatMap((test) => (test.command === null ? [] : [test.command])),
-      ...collectValidationCommands(commands),
-    ]),
+  const featureCommands = (feature?.tests ?? []).flatMap((test) =>
+    test.command === null || test.command.length === 0 ? [] : [test.command],
   );
+  const ordered = [
+    commands.format,
+    ...featureCommands,
+    commands.typecheck,
+    commands.lint,
+    commands.test,
+  ].filter((command): command is string => command !== null && command.length > 0);
+  return Array.from(new Set(ordered));
 }
 
 async function selectRevalidationFindings(

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -995,6 +995,132 @@ describe("workflow", () => {
     delete process.env["CLAWPATCH_PROVIDER"];
   });
 
+  it("includes feature-specific validation in fix dry-run output", async () => {
+    const root = await fixtureRoot("clawpatch-feature-validation-dry-run-");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify({ name: "buggy", bin: { buggy: "src/index.ts" } }),
+    );
+    await writeFixture(root, "src/index.ts", "export const value = 'TODO_BUG';\n");
+    process.env["CLAWPATCH_PROVIDER"] = "mock";
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    const reviewed = (await reviewCommand(context, { limit: "1" })) as { next: string };
+    const finding = reviewed.next.split(" ").at(-1) ?? "";
+    const paths = statePaths(join(root, ".clawpatch"));
+    const feature = (await readFeatures(paths))[0];
+    const featureCommand = 'node -e "process.exit(0)"';
+    await writeFeature(paths, {
+      ...feature!,
+      tests: [{ path: "src/index.test.ts", command: featureCommand }],
+    });
+    const fixed = await fixCommand(context, { finding, dryRun: true });
+    const patches = await readPatchAttempts(paths);
+
+    expect(fixed).toMatchObject({ dryRun: true, validation: featureCommand });
+    expect(patches).toEqual([]);
+    delete process.env["CLAWPATCH_PROVIDER"];
+  });
+
+  it("fails fix when feature-specific validation fails", async () => {
+    const root = await fixtureRoot("clawpatch-feature-validation-fail-");
+    await runCommand(
+      "git init -q && git config user.email test@example.com && git config user.name Test",
+      root,
+    );
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify({ name: "buggy", bin: { buggy: "src/index.ts" } }),
+    );
+    await writeFixture(root, "src/index.ts", "export const value = 'TODO_BUG';\n");
+    await runCommand(
+      "git add package.json src/index.ts && git -c commit.gpgsign=false commit -q -m init",
+      root,
+    );
+    process.env["CLAWPATCH_PROVIDER"] = "mock";
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    const reviewed = (await reviewCommand(context, { limit: "1" })) as { next: string };
+    const finding = reviewed.next.split(" ").at(-1) ?? "";
+    const paths = statePaths(join(root, ".clawpatch"));
+    const feature = (await readFeatures(paths))[0];
+    const featureCommand = 'node -e "process.exit(7)"';
+    await writeFeature(paths, {
+      ...feature!,
+      tests: [{ path: "src/index.test.ts", command: featureCommand }],
+    });
+    await expect(fixCommand(context, { finding })).rejects.toMatchObject({ exitCode: 6 });
+    const [patches, updatedFinding] = await Promise.all([
+      readPatchAttempts(paths),
+      readFinding(paths, finding),
+    ]);
+
+    expect(patches[0]?.status).toBe("failed");
+    expect(patches[0]?.commandsRun).toHaveLength(1);
+    expect(patches[0]?.commandsRun[0]).toMatchObject({ command: featureCommand, exitCode: 7 });
+    expect(updatedFinding?.status).toBe("open");
+    delete process.env["CLAWPATCH_PROVIDER"];
+  });
+
+  it("deduplicates feature-specific and configured fix validation commands", async () => {
+    const root = await fixtureRoot("clawpatch-feature-validation-dedupe-");
+    await runCommand(
+      "git init -q && git config user.email test@example.com && git config user.name Test",
+      root,
+    );
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify({
+        name: "buggy",
+        bin: { buggy: "src/index.ts" },
+        scripts: {
+          format: 'node -e "process.exit(0)"',
+          test: 'node -e "process.exit(0)"',
+        },
+      }),
+    );
+    await writeFixture(root, "src/index.ts", "export const value = 'TODO_BUG';\n");
+    await runCommand(
+      "git add package.json src/index.ts && git -c commit.gpgsign=false commit -q -m init",
+      root,
+    );
+    process.env["CLAWPATCH_PROVIDER"] = "mock";
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    const reviewed = (await reviewCommand(context, { limit: "1" })) as { next: string };
+    const finding = reviewed.next.split(" ").at(-1) ?? "";
+    const paths = statePaths(join(root, ".clawpatch"));
+    const feature = (await readFeatures(paths))[0];
+    const featureCommand = 'node -e "process.exit(0)"';
+    await writeFeature(paths, {
+      ...feature!,
+      tests: [
+        { path: "src/index.test.ts", command: "" },
+        { path: "src/index.test.ts", command: featureCommand },
+        { path: "src/index.test.ts", command: "npm run test" },
+      ],
+    });
+    const fixed = await fixCommand(context, { finding });
+    const patches = await readPatchAttempts(paths);
+
+    expect(fixed).toMatchObject({ status: "applied", commands: 3 });
+    expect(patches[0]?.commandsRun.map((result) => result.command)).toEqual([
+      "npm run format",
+      featureCommand,
+      "npm run test",
+    ]);
+    delete process.env["CLAWPATCH_PROVIDER"];
+  });
+
   it("blocks fix when git cleanliness cannot be verified", async () => {
     const root = await fixtureRoot("clawpatch-non-git-fix-");
     await writeFixture(


### PR DESCRIPTION
Fixes #23

## Summary

- make `clawpatch fix` use feature-aware validation commands in dry-run and real execution
- preserve the intended validation order: formatter, targeted feature tests, typecheck, lint, broader tests
- ignore empty feature test commands and deduplicate repeated validation commands
- add workflow regression tests for dry-run output, failed targeted validation, empty-command filtering, dedupe, and command ordering

## Why

`clawpatch show` already surfaced feature-specific validation commands, but `clawpatch fix` only ran global configured commands. A fix could therefore be recorded as applied without running the targeted test attached to that feature.

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm format:check`
- `corepack pnpm test`
- `corepack pnpm build`
- Claude Review approved the final diff
- three independent edge-case/robustness reviews found no blocking issues