### PR TITLE
Add generic C/C++ feature mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Unreleased
 
-- Added generic C/C++ feature mapping for standalone `main()` files, CMake
-  `add_executable` / `add_library` targets, and autotools `bin_PROGRAMS` /
-  `lib_LTLIBRARIES` targets.
+- Added generic C/C++ feature mapping for standalone `main()` files, CMake `add_executable` / `add_library` targets, and autotools `bin_PROGRAMS` / `lib_LTLIBRARIES` targets, thanks @iliaal.
 - Added JVM semantic role mapping from Java annotations, imports, inheritance, interfaces, and method signatures.
 - Added selected package script mapping for Node workspace packages.
 - Detected Java/Kotlin language and default Gradle build/test commands for root Gradle projects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added generic C/C++ feature mapping for standalone `main()` files, CMake
+  `add_executable` / `add_library` targets, and autotools `bin_PROGRAMS` /
+  `lib_LTLIBRARIES` targets.
 - Added JVM semantic role mapping from Java annotations, imports, inheritance, interfaces, and method signatures.
 - Added selected package script mapping for Node workspace packages.
 - Detected Java/Kotlin language and default Gradle build/test commands for root Gradle projects.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ validation commands and records a patch attempt under `.clawpatch/`.
   interfaces, inheritance, and method signatures
 - Rust `src/main.rs`, `src/bin/*.rs`, `src/lib.rs`, `crates/*`, and
   `tests/*.rs`
+- C/C++ standalone `main()` files, CMake `add_executable` / `add_library`
+  targets, and autotools `bin_PROGRAMS` / `lib_LTLIBRARIES` targets
 - Python project metadata, console scripts, bounded source groups, pytest suites,
   and Flask routes
 - SwiftPM `Sources/*` targets and `Tests/*` suites

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -37,6 +37,7 @@ Supported deterministic mappers today:
   pytest suites, and Flask/FastAPI routes
 - JVM semantic role groups from Java annotations, imports, inheritance, interfaces, and method signatures
 - Rust Cargo commands, libraries, workspace crates, and integration tests
+- C/C++ standalone `main()` files, CMake targets, and autotools targets
 - SwiftPM executable targets, library targets, and test suites
 - nested SwiftPM packages
 - Apple/Xcode projects from `project.yml`, `.xcodeproj`, or `.xcworkspace`
@@ -60,6 +61,11 @@ Root Gradle projects get default `gradle`/`./gradlew` build and test commands.
 Java files in Gradle modules also get role-oriented review slices when code
 evidence identifies web entrypoints, services, persistence boundaries, external
 clients, configuration, framework components, or extension boundaries.
+
+C/C++ mapping covers generic project shapes only: standalone source files with
+`main()`, CMake `add_executable` / `add_library`, and autotools `bin_PROGRAMS` /
+`lib_LTLIBRARIES`. It deliberately avoids project-specific C dialects such as
+php-src extension metadata.
 
 Python mapping covers `pyproject.toml` metadata, `[project.scripts]` and
 `[tool.poetry.scripts]` console scripts, root app files, source groups under

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,12 +30,12 @@ stderr so pipes stay parseable.
 
 ## What clawpatch does
 
-- **Semantic feature mapping.** Detects npm bins, Next.js routes, Python packages and Flask routes, Go packages, Rust crates, SwiftPM targets, and common config files as reviewable slices.
+- **Semantic feature mapping.** Detects npm bins, Next.js routes, Python packages and Flask routes, Go packages, Rust crates, C/C++ build targets, SwiftPM targets, and common config files as reviewable slices.
 - **Automated code review.** Reviews features with AI providers (Codex CLI today), persists findings with severity, category, and line locations.
 - **Explicit fix workflow.** `clawpatch fix` runs validated patches for one finding at a time, never commits or pushes automatically.
 - **Stable state model.** All features, findings, patches live in `.clawpatch/` as JSON, resumable across runs.
 - **Safety first.** Review is read-only, fix refuses dirty worktrees, never auto-commits, validates before accepting patches.
-- **Multi-language.** JavaScript/TypeScript, Python, Go, Rust, Swift today; more mappers planned.
+- **Multi-language.** JavaScript/TypeScript, Python, Go, Rust, C/C++, Swift today; more mappers planned.
 
 ## Pick your path
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,6 +49,7 @@ This discovers reviewable features:
 - Python packages, console scripts, Flask routes, and pytest suites
 - JVM semantic role groups
 - Rust crates and binaries
+- C/C++ standalone binaries and CMake/autotools targets
 - SwiftPM targets and tests
 - Config files
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -703,6 +703,7 @@ Mappers:
 - Express/Fastify/Hono route registrations.
 - Go `cmd/*` commands and `internal/*` packages.
 - Rust Cargo commands, libraries, workspace crates, and integration tests.
+- C/C++ standalone `main()` files, CMake targets, and autotools targets.
 - SwiftPM executable targets, library targets, and test suites.
 - Test suites from common test file globs.
 - Config/release features from package/build/release files.

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1032,7 +1032,7 @@ async function containsReviewableKotlinFile(root: string): Promise<boolean> {
 
 async function containsReviewableJvmFile(root: string, extension: string): Promise<boolean> {
   for (const prefix of jvmSourceSearchRoots) {
-    if (await containsFileWithExtension(join(root, prefix), extension, 8)) {
+    if (await containsFileWithExtension(join(root, prefix), extension, 8, undefined, prefix)) {
       return true;
     }
   }
@@ -1067,7 +1067,15 @@ async function containsReviewablePythonFile(root: string): Promise<boolean> {
     return true;
   }
   for (const prefix of pythonSourceSearchRoots) {
-    if (await containsFileMatching(join(root, prefix), 4, isReviewablePythonFileName)) {
+    if (
+      await containsFileMatching(
+        join(root, prefix),
+        4,
+        isReviewablePythonFileName,
+        undefined,
+        prefix,
+      )
+    ) {
       return true;
     }
   }
@@ -1076,7 +1084,7 @@ async function containsReviewablePythonFile(root: string): Promise<boolean> {
 
 async function containsReviewablePhpFile(root: string): Promise<boolean> {
   for (const prefix of ["app", "routes", "config", "database", "tests"]) {
-    if (await containsFileWithExtension(join(root, prefix), ".php", 4)) {
+    if (await containsFileWithExtension(join(root, prefix), ".php", 4, undefined, prefix)) {
       return true;
     }
   }
@@ -1125,7 +1133,7 @@ async function pythonFrameworkScanFiles(root: string): Promise<string[]> {
     }
   }
   for (const prefix of pythonSourceSearchRoots) {
-    await collectPythonFrameworkScanFiles(join(root, prefix), 4, files);
+    await collectPythonFrameworkScanFiles(join(root, prefix), 4, files, prefix);
   }
   return [...new Set(files)].slice(0, 200);
 }
@@ -1134,6 +1142,7 @@ async function collectPythonFrameworkScanFiles(
   dir: string,
   remainingDepth: number,
   files: string[],
+  relativeDir = "",
 ): Promise<void> {
   if (remainingDepth < 0 || !(await pathExists(dir))) {
     return;
@@ -1143,7 +1152,8 @@ async function collectPythonFrameworkScanFiles(
     return;
   }
   for (const entry of await readdir(dir, { withFileTypes: true })) {
-    if (shouldSkipSearchEntry(entry.name)) {
+    const path = relativeDir === "" ? entry.name : `${relativeDir}/${entry.name}`;
+    if (shouldSkipSearchEntry(entry.name, path)) {
       continue;
     }
     const full = join(dir, entry.name);
@@ -1153,7 +1163,7 @@ async function collectPythonFrameworkScanFiles(
     if (entry.isFile() && isReviewablePythonFileName(entry.name)) {
       files.push(full);
     } else if (entry.isDirectory()) {
-      await collectPythonFrameworkScanFiles(full, remainingDepth - 1, files);
+      await collectPythonFrameworkScanFiles(full, remainingDepth - 1, files, path);
     }
   }
 }
@@ -1163,12 +1173,14 @@ async function containsReviewableRubyFile(root: string): Promise<boolean> {
     return true;
   }
   for (const prefix of ["app", "lib"]) {
-    if (await containsFileMatching(join(root, prefix), 4, isReviewableRubyFileName)) {
+    if (
+      await containsFileMatching(join(root, prefix), 4, isReviewableRubyFileName, undefined, prefix)
+    ) {
       return true;
     }
   }
   for (const prefix of ["scripts", "script", "exe", "bin"]) {
-    if (await containsRubyExecutableSource(join(root, prefix), 4)) {
+    if (await containsRubyExecutableSource(join(root, prefix), 4, prefix)) {
       return true;
     }
   }
@@ -1188,7 +1200,11 @@ function isRootReviewableRubyFileName(entry: string): boolean {
   return isReviewableRubyFileName(entry) && !entry.startsWith("test_");
 }
 
-async function containsRubyExecutableSource(dir: string, remainingDepth: number): Promise<boolean> {
+async function containsRubyExecutableSource(
+  dir: string,
+  remainingDepth: number,
+  relativeDir = "",
+): Promise<boolean> {
   if (remainingDepth < 0 || !(await pathExists(dir))) {
     return false;
   }
@@ -1197,7 +1213,8 @@ async function containsRubyExecutableSource(dir: string, remainingDepth: number)
     return false;
   }
   for (const entry of await readdir(dir)) {
-    if (shouldSkipSearchEntry(entry)) {
+    const path = relativeDir === "" ? entry : `${relativeDir}/${entry}`;
+    if (shouldSkipSearchEntry(entry, path)) {
       continue;
     }
     const full = join(dir, entry);
@@ -1212,7 +1229,10 @@ async function containsRubyExecutableSource(dir: string, remainingDepth: number)
     ) {
       return true;
     }
-    if (info.isDirectory() && (await containsRubyExecutableSource(full, remainingDepth - 1))) {
+    if (
+      info.isDirectory() &&
+      (await containsRubyExecutableSource(full, remainingDepth - 1, path))
+    ) {
       return true;
     }
   }
@@ -1291,8 +1311,15 @@ async function containsFileWithExtension(
   extension: string,
   maxDepth: number,
   skipEntry: (entry: string, relativePath: string) => boolean = shouldSkipSearchEntry,
+  relativeDir = "",
 ): Promise<boolean> {
-  return containsFileMatching(root, maxDepth, (entry) => entry.endsWith(extension), skipEntry);
+  return containsFileMatching(
+    root,
+    maxDepth,
+    (entry) => entry.endsWith(extension),
+    skipEntry,
+    relativeDir,
+  );
 }
 
 async function containsFileWithExtensionIgnoringCase(
@@ -1300,6 +1327,7 @@ async function containsFileWithExtensionIgnoringCase(
   extension: string,
   maxDepth: number,
   skipEntry: (entry: string, relativePath: string) => boolean = shouldSkipSearchEntry,
+  relativeDir = "",
 ): Promise<boolean> {
   const lowercaseExtension = extension.toLowerCase();
   return containsFileMatching(
@@ -1307,6 +1335,7 @@ async function containsFileWithExtensionIgnoringCase(
     maxDepth,
     (entry) => entry.toLowerCase().endsWith(lowercaseExtension),
     skipEntry,
+    relativeDir,
   );
 }
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -789,12 +789,14 @@ async function containsCFile(root: string): Promise<boolean> {
 
 async function containsCppFile(root: string): Promise<boolean> {
   return (
-    (await containsFileWithExtension(root, ".cpp", 5)) ||
-    (await containsFileWithExtension(root, ".cc", 5)) ||
-    (await containsFileWithExtension(root, ".cxx", 5)) ||
-    (await containsFileWithExtension(root, ".hpp", 5)) ||
-    (await containsFileWithExtension(root, ".hh", 5)) ||
-    (await containsFileWithExtension(root, ".hxx", 5))
+    (await containsFileWithExtension(root, ".C", 5)) ||
+    (await containsFileWithExtension(root, ".H", 5)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".cpp", 5)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".cc", 5)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".cxx", 5)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".hpp", 5)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".hh", 5)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".hxx", 5))
   );
 }
 
@@ -924,6 +926,17 @@ async function containsFileWithExtension(
   maxDepth: number,
 ): Promise<boolean> {
   return containsFileMatching(root, maxDepth, (entry) => entry.endsWith(extension));
+}
+
+async function containsFileWithExtensionIgnoringCase(
+  root: string,
+  extension: string,
+  maxDepth: number,
+): Promise<boolean> {
+  const lowercaseExtension = extension.toLowerCase();
+  return containsFileMatching(root, maxDepth, (entry) =>
+    entry.toLowerCase().endsWith(lowercaseExtension),
+  );
 }
 
 async function containsFileMatching(

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -791,7 +791,10 @@ async function containsCppFile(root: string): Promise<boolean> {
   return (
     (await containsFileWithExtension(root, ".cpp", 5)) ||
     (await containsFileWithExtension(root, ".cc", 5)) ||
-    (await containsFileWithExtension(root, ".cxx", 5))
+    (await containsFileWithExtension(root, ".cxx", 5)) ||
+    (await containsFileWithExtension(root, ".hpp", 5)) ||
+    (await containsFileWithExtension(root, ".hh", 5)) ||
+    (await containsFileWithExtension(root, ".hxx", 5))
   );
 }
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -222,6 +222,12 @@ async function detectPackageManagers(root: string): Promise<string[]> {
   ) {
     found.push("gradle");
   }
+  if (!found.includes("cmake") && (await containsFileNamed(root, "CMakeLists.txt", 5))) {
+    found.push("cmake");
+  }
+  if (!found.includes("autotools") && (await containsFileNamed(root, "Makefile.am", 5))) {
+    found.push("autotools");
+  }
   const pythonManagers: Array<[string, string]> = [
     ["uv", "uv.lock"],
     ["poetry", "poetry.lock"],
@@ -768,7 +774,25 @@ async function detectLanguages(root: string): Promise<string[]> {
   ) {
     languages.push("kotlin");
   }
+  if (!languages.includes("c") && (await containsCFile(root))) {
+    languages.push("c");
+  }
+  if (!languages.includes("cpp") && (await containsCppFile(root))) {
+    languages.push("cpp");
+  }
   return languages;
+}
+
+async function containsCFile(root: string): Promise<boolean> {
+  return containsFileWithExtension(root, ".c", 5);
+}
+
+async function containsCppFile(root: string): Promise<boolean> {
+  return (
+    (await containsFileWithExtension(root, ".cpp", 5)) ||
+    (await containsFileWithExtension(root, ".cc", 5)) ||
+    (await containsFileWithExtension(root, ".cxx", 5))
+  );
 }
 
 const jvmSourceSearchRoots = ["src", "app", "apps", "lib"] as const;

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -975,31 +975,34 @@ async function containsFileMatching(
 }
 
 function shouldSkipSearchEntry(entry: string): boolean {
-  return [
-    "node_modules",
-    "dist",
-    "build",
-    "target",
-    ".build",
-    ".swiftpm",
-    ".git",
-    ".clawpatch",
-    ".worktrees",
-    ".venv",
-    "venv",
-    "vendor",
-    "__pycache__",
-    ".mypy_cache",
-    ".ruff_cache",
-    ".pytest_cache",
-    "fixtures",
-    "__fixtures__",
-    "testdata",
-    "Pods",
-    "Carthage",
-    "SourcePackages",
-    "DerivedData",
-  ].includes(entry);
+  return (
+    [
+      "node_modules",
+      "dist",
+      "build",
+      "target",
+      ".build",
+      ".swiftpm",
+      ".git",
+      ".clawpatch",
+      ".worktrees",
+      ".venv",
+      "venv",
+      "vendor",
+      "CMakeFiles",
+      "__pycache__",
+      ".mypy_cache",
+      ".ruff_cache",
+      ".pytest_cache",
+      "fixtures",
+      "__fixtures__",
+      "testdata",
+      "Pods",
+      "Carthage",
+      "SourcePackages",
+      "DerivedData",
+    ].includes(entry) || /^cmake-build-[^/]+$/u.test(entry)
+  );
 }
 
 function stripLineComments(source: string, marker: "//"): string {

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1149,7 +1149,7 @@ async function containsFileNamed(
   root: string,
   name: string,
   maxDepth: number,
-  skipEntry: (entry: string) => boolean = shouldSkipSearchEntry,
+  skipEntry: (entry: string, relativePath: string) => boolean = shouldSkipSearchEntry,
 ): Promise<boolean> {
   return containsFileMatching(root, maxDepth, (entry) => entry === name, skipEntry);
 }
@@ -1158,7 +1158,7 @@ async function containsFileWithExtension(
   root: string,
   extension: string,
   maxDepth: number,
-  skipEntry: (entry: string) => boolean = shouldSkipSearchEntry,
+  skipEntry: (entry: string, relativePath: string) => boolean = shouldSkipSearchEntry,
 ): Promise<boolean> {
   return containsFileMatching(root, maxDepth, (entry) => entry.endsWith(extension), skipEntry);
 }
@@ -1167,7 +1167,7 @@ async function containsFileWithExtensionIgnoringCase(
   root: string,
   extension: string,
   maxDepth: number,
-  skipEntry: (entry: string) => boolean = shouldSkipSearchEntry,
+  skipEntry: (entry: string, relativePath: string) => boolean = shouldSkipSearchEntry,
 ): Promise<boolean> {
   const lowercaseExtension = extension.toLowerCase();
   return containsFileMatching(
@@ -1182,7 +1182,8 @@ async function containsFileMatching(
   dir: string,
   remainingDepth: number,
   predicate: (entry: string) => boolean,
-  skipEntry: (entry: string) => boolean = shouldSkipSearchEntry,
+  skipEntry: (entry: string, relativePath: string) => boolean = shouldSkipSearchEntry,
+  relativeDir = "",
 ): Promise<boolean> {
   if (remainingDepth < 0 || !(await pathExists(dir))) {
     return false;
@@ -1192,7 +1193,8 @@ async function containsFileMatching(
     return false;
   }
   for (const entry of await readdir(dir)) {
-    if (skipEntry(entry)) {
+    const relativePath = relativeDir.length === 0 ? entry : `${relativeDir}/${entry}`;
+    if (skipEntry(entry, relativePath)) {
       continue;
     }
     const full = join(dir, entry);
@@ -1205,7 +1207,7 @@ async function containsFileMatching(
     }
     if (
       info.isDirectory() &&
-      (await containsFileMatching(full, remainingDepth - 1, predicate, skipEntry))
+      (await containsFileMatching(full, remainingDepth - 1, predicate, skipEntry, relativePath))
     ) {
       return true;
     }
@@ -1213,7 +1215,10 @@ async function containsFileMatching(
   return false;
 }
 
-function shouldSkipSearchEntry(entry: string): boolean {
+function shouldSkipSearchEntry(entry: string, relativePath = entry): boolean {
+  if (entry === "vendor" && relativePath === "vendor") {
+    return true;
+  }
   return [
     "node_modules",
     "dist",

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -222,13 +222,16 @@ async function detectPackageManagers(root: string): Promise<string[]> {
   ) {
     found.push("gradle");
   }
-  if (!found.includes("cmake") && (await containsFileNamed(root, "CMakeLists.txt", 5))) {
+  if (
+    !found.includes("cmake") &&
+    (await containsFileNamed(root, "CMakeLists.txt", 5, shouldSkipCOrCppSearchEntry))
+  ) {
     found.push("cmake");
   }
   if (
     !found.includes("autotools") &&
-    ((await containsFileNamed(root, "Makefile.am", 5)) ||
-      (await containsFileNamed(root, "Makefile.in", 5)))
+    ((await containsFileNamed(root, "Makefile.am", 5, shouldSkipCOrCppSearchEntry)) ||
+      (await containsFileNamed(root, "Makefile.in", 5, shouldSkipCOrCppSearchEntry)))
   ) {
     found.push("autotools");
   }
@@ -788,19 +791,19 @@ async function detectLanguages(root: string): Promise<string[]> {
 }
 
 async function containsCFile(root: string): Promise<boolean> {
-  return containsFileWithExtension(root, ".c", 5);
+  return containsFileWithExtension(root, ".c", 5, shouldSkipCOrCppSearchEntry);
 }
 
 async function containsCppFile(root: string): Promise<boolean> {
   return (
-    (await containsFileWithExtension(root, ".C", 5)) ||
-    (await containsFileWithExtension(root, ".H", 5)) ||
-    (await containsFileWithExtensionIgnoringCase(root, ".cpp", 5)) ||
-    (await containsFileWithExtensionIgnoringCase(root, ".cc", 5)) ||
-    (await containsFileWithExtensionIgnoringCase(root, ".cxx", 5)) ||
-    (await containsFileWithExtensionIgnoringCase(root, ".hpp", 5)) ||
-    (await containsFileWithExtensionIgnoringCase(root, ".hh", 5)) ||
-    (await containsFileWithExtensionIgnoringCase(root, ".hxx", 5))
+    (await containsFileWithExtension(root, ".C", 5, shouldSkipCOrCppSearchEntry)) ||
+    (await containsFileWithExtension(root, ".H", 5, shouldSkipCOrCppSearchEntry)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".cpp", 5, shouldSkipCOrCppSearchEntry)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".cc", 5, shouldSkipCOrCppSearchEntry)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".cxx", 5, shouldSkipCOrCppSearchEntry)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".hpp", 5, shouldSkipCOrCppSearchEntry)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".hh", 5, shouldSkipCOrCppSearchEntry)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".hxx", 5, shouldSkipCOrCppSearchEntry))
   );
 }
 
@@ -920,26 +923,36 @@ async function collectPythonFrameworkScanFiles(
   }
 }
 
-async function containsFileNamed(root: string, name: string, maxDepth: number): Promise<boolean> {
-  return containsFileMatching(root, maxDepth, (entry) => entry === name);
+async function containsFileNamed(
+  root: string,
+  name: string,
+  maxDepth: number,
+  skipEntry: (entry: string) => boolean = shouldSkipSearchEntry,
+): Promise<boolean> {
+  return containsFileMatching(root, maxDepth, (entry) => entry === name, skipEntry);
 }
 
 async function containsFileWithExtension(
   root: string,
   extension: string,
   maxDepth: number,
+  skipEntry: (entry: string) => boolean = shouldSkipSearchEntry,
 ): Promise<boolean> {
-  return containsFileMatching(root, maxDepth, (entry) => entry.endsWith(extension));
+  return containsFileMatching(root, maxDepth, (entry) => entry.endsWith(extension), skipEntry);
 }
 
 async function containsFileWithExtensionIgnoringCase(
   root: string,
   extension: string,
   maxDepth: number,
+  skipEntry: (entry: string) => boolean = shouldSkipSearchEntry,
 ): Promise<boolean> {
   const lowercaseExtension = extension.toLowerCase();
-  return containsFileMatching(root, maxDepth, (entry) =>
-    entry.toLowerCase().endsWith(lowercaseExtension),
+  return containsFileMatching(
+    root,
+    maxDepth,
+    (entry) => entry.toLowerCase().endsWith(lowercaseExtension),
+    skipEntry,
   );
 }
 
@@ -947,6 +960,7 @@ async function containsFileMatching(
   dir: string,
   remainingDepth: number,
   predicate: (entry: string) => boolean,
+  skipEntry: (entry: string) => boolean = shouldSkipSearchEntry,
 ): Promise<boolean> {
   if (remainingDepth < 0 || !(await pathExists(dir))) {
     return false;
@@ -956,7 +970,7 @@ async function containsFileMatching(
     return false;
   }
   for (const entry of await readdir(dir)) {
-    if (shouldSkipSearchEntry(entry)) {
+    if (skipEntry(entry)) {
       continue;
     }
     const full = join(dir, entry);
@@ -967,7 +981,10 @@ async function containsFileMatching(
     if (info.isFile() && predicate(entry)) {
       return true;
     }
-    if (info.isDirectory() && (await containsFileMatching(full, remainingDepth - 1, predicate))) {
+    if (
+      info.isDirectory() &&
+      (await containsFileMatching(full, remainingDepth - 1, predicate, skipEntry))
+    ) {
       return true;
     }
   }
@@ -975,33 +992,38 @@ async function containsFileMatching(
 }
 
 function shouldSkipSearchEntry(entry: string): boolean {
+  return [
+    "node_modules",
+    "dist",
+    "build",
+    "target",
+    ".build",
+    ".swiftpm",
+    ".git",
+    ".clawpatch",
+    ".worktrees",
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    "fixtures",
+    "__fixtures__",
+    "testdata",
+    "Pods",
+    "Carthage",
+    "SourcePackages",
+    "DerivedData",
+  ].includes(entry);
+}
+
+function shouldSkipCOrCppSearchEntry(entry: string): boolean {
   return (
-    [
-      "node_modules",
-      "dist",
-      "build",
-      "target",
-      ".build",
-      ".swiftpm",
-      ".git",
-      ".clawpatch",
-      ".worktrees",
-      ".venv",
-      "venv",
-      "vendor",
-      "CMakeFiles",
-      "__pycache__",
-      ".mypy_cache",
-      ".ruff_cache",
-      ".pytest_cache",
-      "fixtures",
-      "__fixtures__",
-      "testdata",
-      "Pods",
-      "Carthage",
-      "SourcePackages",
-      "DerivedData",
-    ].includes(entry) || /^cmake-build-[^/]+$/u.test(entry)
+    shouldSkipSearchEntry(entry) ||
+    entry === "vendor" ||
+    entry === "CMakeFiles" ||
+    /^cmake-build-[^/]+$/u.test(entry)
   );
 }
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -967,6 +967,7 @@ function shouldSkipSearchEntry(entry: string): boolean {
     ".worktrees",
     ".venv",
     "venv",
+    "vendor",
     "__pycache__",
     ".mypy_cache",
     ".ruff_cache",

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -225,7 +225,11 @@ async function detectPackageManagers(root: string): Promise<string[]> {
   if (!found.includes("cmake") && (await containsFileNamed(root, "CMakeLists.txt", 5))) {
     found.push("cmake");
   }
-  if (!found.includes("autotools") && (await containsFileNamed(root, "Makefile.am", 5))) {
+  if (
+    !found.includes("autotools") &&
+    ((await containsFileNamed(root, "Makefile.am", 5)) ||
+      (await containsFileNamed(root, "Makefile.in", 5)))
+  ) {
     found.push("autotools");
   }
   const pythonManagers: Array<[string, string]> = [

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3522,6 +3522,19 @@ add_executable(headerapp include/headers.hpp)
     expect(coreShared?.entrypoints[0]?.symbol).toBe("core_shared");
   });
 
+  it("prefers exact target-name source stems before prefix matches", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-target-stem-entry-");
+    await writeFixture(root, "CMakeLists.txt", "add_library(app src/apple.c src/app.c)\n");
+    await writeFixture(root, "src/apple.c", "int apple(void) { return 1; }\n");
+    await writeFixture(root, "src/app.c", "int app(void) { return 1; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake library app");
+
+    expect(app?.entrypoints[0]?.path).toBe("src/app.c");
+  });
+
   it("keeps existing CMake library ids when a target starts sharing sources", async () => {
     const root = await fixtureRoot("clawpatch-cmake-shared-source-stability-");
     await writeFixture(root, "CMakeLists.txt", "add_library(core_static STATIC src/core.c)\n");
@@ -3702,6 +3715,31 @@ add_executable(headerapp include/headers.hpp)
       { path: "cmake/local.c", reason: "target source" },
       { path: "cmake/extra.c", reason: "target source" },
     ]);
+  });
+
+  it("resolves CMake source dir variables from nested project roots", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-nested-project-vars-");
+    await writeFixture(
+      root,
+      "sub/CMakeLists.txt",
+      "add_executable(project_app ${PROJECT_SOURCE_DIR}/src/project.c)\nadd_executable(source_app ${CMAKE_SOURCE_DIR}/src/source.c)\n",
+    );
+    await writeFixture(root, "src/project.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/source.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "sub/src/project.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "sub/src/source.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const projectApp = result.features.find(
+      (feature) => feature.title === "CMake binary project_app",
+    );
+    const sourceApp = result.features.find(
+      (feature) => feature.title === "CMake binary source_app",
+    );
+
+    expect(projectApp?.entrypoints[0]?.path).toBe("sub/src/project.c");
+    expect(sourceApp?.entrypoints[0]?.path).toBe("sub/src/source.c");
   });
 
   it("resolves nested CMake includes relative to the source dir", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -4124,6 +4124,34 @@ add_executable(headerapp include/headers.hpp)
     expect(core?.ownedFiles).toEqual([{ path: "core.c", reason: "target source" }]);
   });
 
+  it("maps autotools sources with source-directory variables", async () => {
+    const root = await fixtureRoot("clawpatch-autotools-srcdir-sources-");
+    await writeFixture(
+      root,
+      "src/Makefile.am",
+      "bin_PROGRAMS = app\napp_SOURCES = $(srcdir)/main.c $(top_srcdir)/shared/util.c\nlib_LTLIBRARIES = libcore.la\nlibcore_la_SOURCES = ${srcdir}/core.c @top_srcdir@/include/core.h\n",
+    );
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
+    await writeFixture(root, "shared/util.c", "int util(void) { return 1; }\n");
+    await writeFixture(root, "include/core.h", "int core(void);\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "Autotools binary app");
+    const core = result.features.find((feature) => feature.title === "Autotools library libcore");
+
+    expect(app?.entrypoints[0]).toMatchObject({ path: "src/main.c", command: "app" });
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/main.c", reason: "target source" },
+      { path: "shared/util.c", reason: "target source" },
+    ]);
+    expect(core?.ownedFiles).toEqual([
+      { path: "src/core.c", reason: "target source" },
+      { path: "include/core.h", reason: "target source" },
+    ]);
+  });
+
   it("honors Automake assignment overrides", async () => {
     const root = await fixtureRoot("clawpatch-autotools-override-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1352,10 +1352,10 @@ add_executable(headerapp include/headers.hpp)
     await writeFixture(
       root,
       "CMakeLists.txt",
-      "add_executable(app src/app.cpp)\nadd_executable(unit_tests tests/unit_tests.cpp)\n",
+      "add_executable(app src/app.cpp)\nadd_executable(unit_tests src/unit.cpp)\n",
     );
     await writeFixture(root, "src/app.cpp", "int main(void) { return 0; }\n");
-    await writeFixture(root, "tests/unit_tests.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/unit.cpp", "int main(void) { return 0; }\n");
 
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
@@ -1366,11 +1366,12 @@ add_executable(headerapp include/headers.hpp)
 
     expect(titles).toContain("CMake binary app");
     expect(titles).not.toContain("CMake binary unit_tests");
+    expect(titles).not.toContain("C++ binary unit");
     expect(suite).toMatchObject({
       kind: "test-suite",
       source: "cmake-test",
-      entrypoints: [{ path: "tests/unit_tests.cpp", symbol: null, route: null, command: null }],
-      tests: [{ path: "tests/unit_tests.cpp", command: null }],
+      entrypoints: [{ path: "src/unit.cpp", symbol: null, route: null, command: null }],
+      ownedFiles: [{ path: "src/unit.cpp", reason: "target source" }],
     });
   });
 
@@ -1830,6 +1831,29 @@ add_executable(headerapp include/headers.hpp)
       { path: "util.c", reason: "target source" },
     ]);
     expect(core?.ownedFiles).toEqual([{ path: "core.c", reason: "target source" }]);
+  });
+
+  it("honors Automake assignment overrides", async () => {
+    const root = await fixtureRoot("clawpatch-autotools-override-");
+    await writeFixture(
+      root,
+      "Makefile.am",
+      "bin_PROGRAMS = old cleared\nbin_PROGRAMS = new\nold_SOURCES = old.c\nnew_SOURCES = stale.c\nnew_SOURCES = new.c\ncleared_SOURCES = cleared.c\ncleared_SOURCES =\n",
+    );
+    await writeFixture(root, "old.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "new.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "stale.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "cleared.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const target = result.features.find((feature) => feature.title === "Autotools binary new");
+
+    expect(titles).toContain("Autotools binary new");
+    expect(titles).not.toContain("Autotools binary old");
+    expect(titles).not.toContain("Autotools binary cleared");
+    expect(target?.ownedFiles).toEqual([{ path: "new.c", reason: "target source" }]);
   });
 
   it("maps standalone C main files without php-src extension semantics", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1263,29 +1263,67 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     ).not.toContain("../outside.c");
   });
 
+  it("uses the CMake source that defines main as the executable entrypoint", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-cpp-main-entry-");
+    await writeFixture(root, "CMakeLists.txt", "add_executable(app src/app.cpp src/main.cpp)\n");
+    await writeFixture(root, "src/app.cpp", "int helper(void) { return 0; }\n");
+    await writeFixture(root, "src/main.cpp", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+    const mainFeatures = result.features.filter(
+      (feature) =>
+        feature.kind === "cli-command" && feature.entrypoints[0]?.path === "src/main.cpp",
+    );
+
+    expect(app?.entrypoints[0]?.path).toBe("src/main.cpp");
+    expect(mainFeatures).toHaveLength(1);
+    expect(result.features.map((feature) => feature.title)).not.toContain("C++ binary main");
+  });
+
   it("maps autotools C and C++ binary and library targets", async () => {
     const root = await fixtureRoot("clawpatch-autotools-cpp-map-");
     await writeFixture(
       root,
       "Makefile.am",
-      "bin_PROGRAMS = thing\nthing_SOURCES = thing.c \\\n  util.c\nlib_LTLIBRARIES = libcore.la\nlibcore_la_SOURCES = core.cc core_util.cc\n",
+      "bin_PROGRAMS = thing my-tool # installed helpers\nthing_SOURCES = thing.c \\\n  util.c\nmy_tool_SOURCES = main.c tool-util.c\nlib_LTLIBRARIES = libcore.la libcore-extra.la\nlibcore_la_SOURCES = core.cc core_util.cc\nlibcore_extra_la_SOURCES = extra.cc\n",
     );
     await writeFixture(root, "thing.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "util.c", "int util(void) { return 1; }\n");
+    await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "tool-util.c", "int tool_util(void) { return 1; }\n");
     await writeFixture(root, "core.cc", "int core() { return 1; }\n");
     await writeFixture(root, "core_util.cc", "int coreUtil() { return 2; }\n");
+    await writeFixture(root, "extra.cc", "int extra() { return 3; }\n");
 
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
     const thing = result.features.find((feature) => feature.title === "Autotools binary thing");
+    const myTool = result.features.find((feature) => feature.title === "Autotools binary my-tool");
     const core = result.features.find((feature) => feature.title === "Autotools library libcore");
+    const extra = result.features.find(
+      (feature) => feature.title === "Autotools library libcore-extra",
+    );
+    const titles = result.features.map((feature) => feature.title);
 
     expect(project.detected.packageManagers).toContain("autotools");
+    expect(titles).not.toContain("Autotools binary installed");
+    expect(titles).not.toContain("Autotools binary helpers");
     expect(thing?.entrypoints[0]).toMatchObject({
       path: "thing.c",
       symbol: "main",
       command: "thing",
     });
+    expect(myTool?.entrypoints[0]).toMatchObject({
+      path: "main.c",
+      symbol: "main",
+      command: "my-tool",
+    });
+    expect(myTool?.ownedFiles).toEqual([
+      { path: "main.c", reason: "target source" },
+      { path: "tool-util.c", reason: "target source" },
+    ]);
     expect(thing?.ownedFiles).toEqual([
       { path: "thing.c", reason: "target source" },
       { path: "util.c", reason: "target source" },
@@ -1295,6 +1333,7 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
       { path: "core.cc", reason: "target source" },
       { path: "core_util.cc", reason: "target source" },
     ]);
+    expect(extra?.ownedFiles).toEqual([{ path: "extra.cc", reason: "target source" }]);
   });
 
   it("maps standalone C main files without php-src extension semantics", async () => {
@@ -1321,6 +1360,41 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     expect(
       result.features.some((feature) => feature.entrypoints[0]?.path === "ext/iconv/config.m4"),
     ).toBe(false);
+  });
+
+  it("skips C and C++ sample project paths", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-sample-paths-");
+    await writeFixture(root, "fixtures/example/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "testdata/CMakeLists.txt", "add_executable(sample main.c)\n");
+    await writeFixture(root, "testdata/main.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(
+      result.features.some((feature) =>
+        ["c-main", "cmake-bin", "cmake-lib", "autotools-bin", "autotools-lib"].includes(
+          feature.source,
+        ),
+      ),
+    ).toBe(false);
+    expect(
+      result.features.some((feature) => feature.entrypoints[0]?.path.includes("fixtures/")),
+    ).toBe(false);
+  });
+
+  it("does not attach JavaScript tests to C and C++ entries", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-js-test-");
+    await writeFixture(root, "package.json", JSON.stringify({ scripts: { test: "vitest" } }));
+    await writeFixture(root, "src/app.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/app.test.ts", "test('app', () => {});\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "C++ binary app");
+
+    expect(app?.tests).toEqual([]);
+    expect(app?.contextFiles).toEqual([]);
   });
 
   it("maps Python project metadata, console scripts, source groups, and tests", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3403,6 +3403,26 @@ add_executable(headerapp include/headers.hpp)
     expect(titles).toContain("CMake binary real");
   });
 
+  it("ignores CMake commands inside uncalled function and macro bodies", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-uncalled-function-body-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "function(make_fake)\nadd_executable(fake src/fake.c)\nendfunction()\nmacro(make_fake_lib)\nadd_library(fake_lib src/lib.c)\nendmacro()\nadd_executable(real src/real.c)\n",
+    );
+    await writeFixture(root, "src/fake.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/lib.c", "int lib(void) { return 0; }\n");
+    await writeFixture(root, "src/real.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(titles).not.toContain("CMake binary fake");
+    expect(titles).not.toContain("CMake library fake_lib");
+    expect(titles).toContain("CMake binary real");
+  });
+
   it("keeps CMake targets after bracket arguments containing hashes", async () => {
     const root = await fixtureRoot("clawpatch-cmake-bracket-hash-");
     await writeFixture(
@@ -4315,6 +4335,7 @@ add_executable(headerapp include/headers.hpp)
 
   it("detects non-C and C++ languages under vendor path components", async () => {
     const root = await fixtureRoot("clawpatch-vendor-language-detect-");
+    await writeFixture(root, "src/vendor/worker.py", "def main():\n    pass\n");
     await writeFixture(root, "src/pkg/vendor/app.py", "def main():\n    pass\n");
     await writeFixture(root, "src/main/vendor/App.java", "class App {}\n");
 

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1374,6 +1374,37 @@ add_executable(headerapp include/headers.hpp)
     ]);
   });
 
+  it("keeps target_sources scoped to standalone CMake projects", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-target-sources-scope-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_executable(app)\ntarget_sources(app PRIVATE src/main.c)\n",
+    );
+    await writeFixture(
+      root,
+      "sub/CMakeLists.txt",
+      "add_executable(app)\ntarget_sources(app PRIVATE src/main.c)\n",
+    );
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "sub/src/main.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const apps = result.features.filter((feature) => feature.title === "CMake binary app");
+
+    expect(apps.map((feature) => feature.entrypoints[0]?.path).toSorted()).toEqual([
+      "src/main.c",
+      "sub/src/main.c",
+    ]);
+    expect(
+      apps.find((feature) => feature.entrypoints[0]?.path === "src/main.c")?.ownedFiles,
+    ).toEqual([{ path: "src/main.c", reason: "target source" }]);
+    expect(
+      apps.find((feature) => feature.entrypoints[0]?.path === "sub/src/main.c")?.ownedFiles,
+    ).toEqual([{ path: "sub/src/main.c", reason: "target source" }]);
+  });
+
   it("detects header-only C++ CMake libraries as C++ projects", async () => {
     const root = await fixtureRoot("clawpatch-cmake-header-only-cpp-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2021,6 +2021,20 @@ add_executable(headerapp include/headers.hpp)
     expect(result.features.map((feature) => feature.title)).toContain("C++ binary app");
   });
 
+  it("detects C and C++ main functions after comments containing quotes", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-comment-quotes-");
+    await writeFixture(
+      root,
+      "src/app.cpp",
+      '// TODO parse "flag\n/* disabled "quoted" branch */\nint main(void) { return 0; }\n',
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(result.features.map((feature) => feature.title)).toContain("C++ binary app");
+  });
+
   it("ignores comment-only C and C++ sources", async () => {
     const root = await fixtureRoot("clawpatch-cpp-comment-only-");
     await writeFixture(root, "src/placeholder.cpp", `// ${"x".repeat(200)}\n`);

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2021,6 +2021,16 @@ add_executable(headerapp include/headers.hpp)
     expect(result.features.map((feature) => feature.title)).toContain("C++ binary app");
   });
 
+  it("ignores comment-only C and C++ sources", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-comment-only-");
+    await writeFixture(root, "src/placeholder.cpp", `// ${"x".repeat(200)}\n`);
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(result.features.map((feature) => feature.title)).not.toContain("C++ binary placeholder");
+  });
+
   it("does not attach dependency C and C++ tests from skipped paths", async () => {
     const root = await fixtureRoot("clawpatch-cpp-skipped-nearby-tests-");
     await writeFixture(root, "app.c", "int main(void) { return 0; }\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -138,6 +138,25 @@ describe("mapFeatures", () => {
     expect(titles).not.toContain("Route /_error");
   });
 
+  it("maps application routes in vendor directories", async () => {
+    const root = await fixtureRoot("clawpatch-next-vendor-route-");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify({ name: "fixture-app", dependencies: { next: "1.0.0" } }, null, 2),
+    );
+    await writeFixture(
+      root,
+      "app/vendor/page.tsx",
+      "export default function VendorPage() { return null; }\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(result.features.map((feature) => feature.title)).toContain("Route /vendor");
+  });
+
   it("does not map src app-shaped routes without a Next project signal", async () => {
     const root = await fixtureRoot("clawpatch-map-src-non-next-");
     await writeFixture(root, "package.json", JSON.stringify({ name: "plain-app" }, null, 2));
@@ -1306,6 +1325,26 @@ add_executable(headerapp include/headers.hpp)
       { path: "include/late_lib.hpp", reason: "target source" },
     ]);
     expect(headers?.ownedFiles).toEqual([{ path: "include/headers.hpp", reason: "target source" }]);
+  });
+
+  it("does not attach unrelated top-level CMake tests to every target", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-cpp-test-scope-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_executable(app src/app.cpp)\nadd_executable(tool src/tool.cpp)\n",
+    );
+    await writeFixture(root, "src/app.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/tool.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "tests/tool_test.cpp", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+    const tool = result.features.find((feature) => feature.title === "CMake binary tool");
+
+    expect(app?.tests).toEqual([]);
+    expect(tool?.tests).toEqual([{ path: "tests/tool_test.cpp", command: null }]);
   });
 
   it("detects header-only C++ CMake libraries as C++ projects", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3667,6 +3667,43 @@ add_executable(headerapp include/headers.hpp)
     ]);
   });
 
+  it("resolves built-in CMake dir variables in includes and sources", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-built-in-dir-vars-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Targets.cmake)\n",
+    );
+    await writeFixture(
+      root,
+      "cmake/Targets.cmake",
+      "include(${CMAKE_CURRENT_LIST_DIR}/More.cmake)\nadd_executable(app ${CMAKE_SOURCE_DIR}/src/main.c ${PROJECT_SOURCE_DIR}/src/project.c ${CMAKE_CURRENT_SOURCE_DIR}/src/util.c ${CMAKE_CURRENT_LIST_DIR}/local.c)\n",
+    );
+    await writeFixture(
+      root,
+      "cmake/More.cmake",
+      "target_sources(app PRIVATE ${CMAKE_CURRENT_LIST_DIR}/extra.c)\n",
+    );
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/project.c", "int project(void) { return 0; }\n");
+    await writeFixture(root, "src/util.c", "int util(void) { return 0; }\n");
+    await writeFixture(root, "cmake/local.c", "int local(void) { return 0; }\n");
+    await writeFixture(root, "cmake/extra.c", "int extra(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+
+    expect(app?.entrypoints[0]?.path).toBe("src/main.c");
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/main.c", reason: "target source" },
+      { path: "src/project.c", reason: "target source" },
+      { path: "src/util.c", reason: "target source" },
+      { path: "cmake/local.c", reason: "target source" },
+      { path: "cmake/extra.c", reason: "target source" },
+    ]);
+  });
+
   it("resolves nested CMake includes relative to the source dir", async () => {
     const root = await fixtureRoot("clawpatch-cmake-nested-include-source-dir-");
     await writeFixture(root, "CMakeLists.txt", "include(cmake/A.cmake)\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1516,7 +1516,7 @@ add_executable(headerapp include/headers.hpp)
   it("uses the CMake source that defines main as the executable entrypoint", async () => {
     const root = await fixtureRoot("clawpatch-cmake-cpp-main-entry-");
     await writeFixture(root, "CMakeLists.txt", "add_executable(app src/app.cpp src/main.cpp)\n");
-    await writeFixture(root, "src/app.cpp", "int helper(void) { return 0; }\n");
+    await writeFixture(root, "src/app.cpp", "struct App { int main(void) { return 0; } };\n");
     await writeFixture(root, "src/main.cpp", "int main(void) { return 0; }\n");
 
     const project = await detectProject(root);
@@ -1530,6 +1530,16 @@ add_executable(headerapp include/headers.hpp)
     expect(app?.entrypoints[0]?.path).toBe("src/main.cpp");
     expect(mainFeatures).toHaveLength(1);
     expect(result.features.map((feature) => feature.title)).not.toContain("C++ binary main");
+  });
+
+  it("does not map member main methods as standalone C++ binaries", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-member-main-");
+    await writeFixture(root, "src/app.cpp", "struct App { int main(void) { return 0; } };\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(result.features.map((feature) => feature.title)).not.toContain("C++ binary app");
   });
 
   it("resolves targets from included CMake modules relative to the source dir", async () => {
@@ -1548,6 +1558,21 @@ add_executable(headerapp include/headers.hpp)
       { path: "src/main.c", reason: "target source" },
       { path: "src/util.c", reason: "target source" },
     ]);
+  });
+
+  it("ignores unreferenced CMake modules", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-unreferenced-module-");
+    await writeFixture(root, "CMakeLists.txt", "add_executable(app src/main.c)\n");
+    await writeFixture(root, "cmake/Dead.cmake", "add_executable(dead src/dead.c)\n");
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/dead.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(titles).toContain("CMake binary app");
+    expect(titles).not.toContain("CMake binary dead");
   });
 
   it("maps autotools C and C++ binary and library targets", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1199,6 +1199,111 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     ]);
   });
 
+  it("maps CMake C and C++ targets without duplicating main files", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-cpp-map-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_executable(myapp src/main.cpp src/util.cpp)\nadd_library(core STATIC src/core.c src/core_util.c)\n",
+    );
+    await writeFixture(root, "src/main.cpp", "int main(int argc, char **argv) { return 0; }\n");
+    await writeFixture(root, "src/util.cpp", "int util() { return 1; }\n");
+    await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
+    await writeFixture(root, "src/core_util.c", "int core_util(void) { return 2; }\n");
+    await writeFixture(root, "tests/main_test.cpp", "int main() { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const myapp = result.features.find((feature) => feature.title === "CMake binary myapp");
+    const core = result.features.find((feature) => feature.title === "CMake library core");
+    const mainFeatures = result.features.filter(
+      (feature) =>
+        feature.kind === "cli-command" && feature.entrypoints[0]?.path === "src/main.cpp",
+    );
+
+    expect(project.detected.languages).toEqual(expect.arrayContaining(["c", "cpp"]));
+    expect(project.detected.packageManagers).toContain("cmake");
+    expect(titles).toContain("CMake binary myapp");
+    expect(titles).toContain("CMake library core");
+    expect(titles).not.toContain("C++ binary main_test");
+    expect(mainFeatures).toHaveLength(1);
+    expect(myapp?.source).toBe("cmake-bin");
+    expect(myapp?.ownedFiles).toEqual([
+      { path: "src/main.cpp", reason: "target source" },
+      { path: "src/util.cpp", reason: "target source" },
+    ]);
+    expect(myapp?.contextFiles).toEqual([
+      { path: "CMakeLists.txt", reason: "CMake target declaration" },
+      { path: "tests/main_test.cpp", reason: "nearby test" },
+    ]);
+    expect(myapp?.tests).toEqual([{ path: "tests/main_test.cpp", command: null }]);
+    expect(core?.ownedFiles).toEqual([
+      { path: "src/core.c", reason: "target source" },
+      { path: "src/core_util.c", reason: "target source" },
+    ]);
+  });
+
+  it("maps autotools C and C++ binary and library targets", async () => {
+    const root = await fixtureRoot("clawpatch-autotools-cpp-map-");
+    await writeFixture(
+      root,
+      "Makefile.am",
+      "bin_PROGRAMS = thing\nthing_SOURCES = thing.c \\\n  util.c\nlib_LTLIBRARIES = libcore.la\nlibcore_la_SOURCES = core.cc core_util.cc\n",
+    );
+    await writeFixture(root, "thing.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "util.c", "int util(void) { return 1; }\n");
+    await writeFixture(root, "core.cc", "int core() { return 1; }\n");
+    await writeFixture(root, "core_util.cc", "int coreUtil() { return 2; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const thing = result.features.find((feature) => feature.title === "Autotools binary thing");
+    const core = result.features.find((feature) => feature.title === "Autotools library libcore");
+
+    expect(project.detected.packageManagers).toContain("autotools");
+    expect(thing?.entrypoints[0]).toMatchObject({
+      path: "thing.c",
+      symbol: "main",
+      command: "thing",
+    });
+    expect(thing?.ownedFiles).toEqual([
+      { path: "thing.c", reason: "target source" },
+      { path: "util.c", reason: "target source" },
+    ]);
+    expect(core?.entrypoints[0]?.path).toBe("core.cc");
+    expect(core?.ownedFiles).toEqual([
+      { path: "core.cc", reason: "target source" },
+      { path: "core_util.cc", reason: "target source" },
+    ]);
+  });
+
+  it("maps standalone C main files without php-src extension semantics", async () => {
+    const root = await fixtureRoot("clawpatch-c-main-map-");
+    await writeFixture(root, "src/tool.c", "int main(void) { return 0; }\n");
+    await writeFixture(
+      root,
+      "ext/iconv/config.m4",
+      "PHP_NEW_EXTENSION(iconv, iconv.c, $ext_shared)\n",
+    );
+    await writeFixture(root, "ext/iconv/iconv.c", "int iconv_helper(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const tool = result.features.find((feature) => feature.title === "C binary tool");
+
+    expect(project.detected.languages).toContain("c");
+    expect(tool?.entrypoints[0]).toMatchObject({
+      path: "src/tool.c",
+      symbol: "main",
+      command: "tool",
+    });
+    expect(result.features.some((feature) => feature.source === "php-ext")).toBe(false);
+    expect(
+      result.features.some((feature) => feature.entrypoints[0]?.path === "ext/iconv/config.m4"),
+    ).toBe(false);
+  });
+
   it("maps Python project metadata, console scripts, source groups, and tests", async () => {
     const root = await fixtureRoot("clawpatch-python-map-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1209,10 +1209,12 @@ add_executable(quoted "src/quoted.cpp")
 ADD_EXECUTABLE(upper src/upper.c)
 add_executable(absin ${root}/src/absin.cpp)
 add_executable(absout /src/main.cpp)
+add_executable(7zip src/seven.c)
 #[[
 add_executable(commented src/commented.c)
 ]]
 add_library(core STATIC include/core.hpp src/core.c src/core_util.c)
+add_library(foo.bar STATIC src/dot.c)
 ADD_LIBRARY(upperlib STATIC src/upperlib.c)
 add_library(headers INTERFACE include/headers.hpp)
 add_library(vendored INTERFACE vendor/dep.hpp)
@@ -1224,11 +1226,13 @@ add_executable(headerapp include/headers.hpp)
     await writeFixture(root, "src/quoted.cpp", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/upper.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/absin.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/seven.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/commented.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/util.cpp", "int util() { return 1; }\n");
     await writeFixture(root, "include/core.hpp", "int core(void);\n");
     await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
     await writeFixture(root, "src/core_util.c", "int core_util(void) { return 2; }\n");
+    await writeFixture(root, "src/dot.c", "int dot(void) { return 1; }\n");
     await writeFixture(root, "src/upperlib.c", "int upperlib(void) { return 1; }\n");
     await writeFixture(root, "include/headers.hpp", "int header_only(void);\n");
     await writeFixture(root, "vendor/dep.hpp", "int dep(void);\n");
@@ -1251,9 +1255,11 @@ add_executable(headerapp include/headers.hpp)
     expect(titles).toContain("CMake binary quoted");
     expect(titles).toContain("CMake binary upper");
     expect(titles).toContain("CMake binary absin");
+    expect(titles).toContain("CMake binary 7zip");
     expect(titles).not.toContain("CMake binary absout");
     expect(titles).not.toContain("CMake binary commented");
     expect(titles).toContain("CMake library core");
+    expect(titles).toContain("CMake library foo.bar");
     expect(titles).toContain("CMake library upperlib");
     expect(titles).toContain("CMake library headers");
     expect(titles).not.toContain("CMake library vendored");
@@ -1279,6 +1285,22 @@ add_executable(headerapp include/headers.hpp)
       { path: "src/core_util.c", reason: "target source" },
     ]);
     expect(headers?.ownedFiles).toEqual([{ path: "include/headers.hpp", reason: "target source" }]);
+  });
+
+  it("detects header-only C++ CMake libraries as C++ projects", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-header-only-cpp-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_library(headers INTERFACE include/headers.hpp)\n",
+    );
+    await writeFixture(root, "include/headers.hpp", "int header_only(void);\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(project.detected.languages).toContain("cpp");
+    expect(result.features.map((feature) => feature.title)).toContain("CMake library headers");
   });
 
   it("preserves CMake targets that share the same source list", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3331,6 +3331,29 @@ add_executable(headerapp include/headers.hpp)
     ]);
   });
 
+  it("keeps CMake binaries when a test-like helper comes before main", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-test-like-helper-before-main-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_executable(app src/test_mode.c src/runner.c)\n",
+    );
+    await writeFixture(root, "src/test_mode.c", "int helper(void) { return 0; }\n");
+    await writeFixture(root, "src/runner.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+
+    expect(titles).not.toContain("CMake test suite app");
+    expect(app?.entrypoints[0]?.path).toBe("src/runner.c");
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/test_mode.c", reason: "target source" },
+      { path: "src/runner.c", reason: "target source" },
+    ]);
+  });
+
   it("attaches CMake tests named after the target", async () => {
     const root = await fixtureRoot("clawpatch-cmake-target-named-tests-");
     await writeFixture(root, "CMakeLists.txt", "add_executable(app src/main.c)\n");
@@ -3591,6 +3614,23 @@ add_executable(headerapp include/headers.hpp)
       { path: "src/main.c", reason: "target source" },
       { path: "src/util.c", reason: "target source" },
     ]);
+  });
+
+  it("resolves PROJECT_NAME inside composed CMake target names", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-composed-project-name-target-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "project(foo C)\nadd_executable(${PROJECT_NAME}_cli src/main.c)\n",
+    );
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary foo_cli");
+
+    expect(app?.entrypoints[0]).toMatchObject({ path: "src/main.c", command: "foo_cli" });
+    expect(app?.ownedFiles).toEqual([{ path: "src/main.c", reason: "target source" }]);
   });
 
   it("detects header-only C++ CMake libraries as C++ projects", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1747,6 +1747,16 @@ add_executable(headerapp include/headers.hpp)
     await writeFixture(root, "src/app.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "vendor/tool/main.c", "int main(void) { return 0; }\n");
     await writeFixture(root, ".venv/native/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(
+      root,
+      "CMakeFiles/CompilerIdCXX/CMakeCXXCompilerId.cpp",
+      "int main(void) { return 0; }\n",
+    );
+    await writeFixture(
+      root,
+      "cmake-build-debug/generated/tool.cpp",
+      "int main(void) { return 0; }\n",
+    );
 
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
@@ -1757,6 +1767,8 @@ add_executable(headerapp include/headers.hpp)
     expect(paths).toContain("src/app.c");
     expect(paths.some((path) => path.startsWith("vendor/"))).toBe(false);
     expect(paths.some((path) => path.startsWith(".venv/"))).toBe(false);
+    expect(paths.some((path) => path.startsWith("CMakeFiles/"))).toBe(false);
+    expect(paths.some((path) => path.startsWith("cmake-build-debug/"))).toBe(false);
   });
 
   it("ignores vendored C and C++ files during detection", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3742,6 +3742,38 @@ add_executable(headerapp include/headers.hpp)
     expect(sourceApp?.entrypoints[0]?.path).toBe("sub/src/source.c");
   });
 
+  it("resets PROJECT_SOURCE_DIR when nested CMakeLists declares project", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-nested-project-source-dir-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "cmake_minimum_required(VERSION 3.20)\nproject(Root C)\nadd_subdirectory(sub)\n",
+    );
+    await writeFixture(
+      root,
+      "sub/CMakeLists.txt",
+      "project(Sub C)\nadd_executable(project_app ${PROJECT_SOURCE_DIR}/src/project.c)\nadd_executable(source_app ${CMAKE_SOURCE_DIR}/src/source.c)\n",
+    );
+    await writeFixture(root, "src/project.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/source.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "sub/src/project.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "sub/src/source.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const projectApp = result.features.find(
+      (feature) => feature.title === "CMake binary project_app",
+    );
+    const sourceApp = result.features.find(
+      (feature) =>
+        feature.title === "CMake binary source_app" &&
+        feature.entrypoints[0]?.path === "src/source.c",
+    );
+
+    expect(projectApp?.entrypoints[0]?.path).toBe("sub/src/project.c");
+    expect(sourceApp?.entrypoints[0]?.path).toBe("src/source.c");
+  });
+
   it("resolves nested CMake includes relative to the source dir", async () => {
     const root = await fixtureRoot("clawpatch-cmake-nested-include-source-dir-");
     await writeFixture(root, "CMakeLists.txt", "include(cmake/A.cmake)\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3292,6 +3292,25 @@ add_executable(headerapp include/headers.hpp)
     });
   });
 
+  it("keeps CMake binaries with helper source names that look test-like", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-test-like-helper-");
+    await writeFixture(root, "CMakeLists.txt", "add_executable(app src/main.c src/test_mode.c)\n");
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/test_mode.c", "int helper(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(titles).not.toContain("CMake test suite app");
+    expect(app?.entrypoints[0]?.path).toBe("src/main.c");
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/main.c", reason: "target source" },
+      { path: "src/test_mode.c", reason: "target source" },
+    ]);
+  });
+
   it("maps semicolon-separated CMake source lists", async () => {
     const root = await fixtureRoot("clawpatch-cmake-semicolon-sources-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1856,6 +1856,33 @@ add_executable(headerapp include/headers.hpp)
     expect(target?.ownedFiles).toEqual([{ path: "new.c", reason: "target source" }]);
   });
 
+  it("keeps same-named CMake and Autotools targets", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-autotools-same-target-");
+    await writeFixture(root, "CMakeLists.txt", "add_executable(app main.c cmake_only.c)\n");
+    await writeFixture(
+      root,
+      "Makefile.am",
+      "bin_PROGRAMS = app\napp_SOURCES = main.c auto_only.c\n",
+    );
+    await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "cmake_only.c", "int cmake_only(void) { return 0; }\n");
+    await writeFixture(root, "auto_only.c", "int auto_only(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const cmake = result.features.find((feature) => feature.title === "CMake binary app");
+    const autotools = result.features.find((feature) => feature.title === "Autotools binary app");
+
+    expect(cmake?.ownedFiles).toEqual([
+      { path: "main.c", reason: "target source" },
+      { path: "cmake_only.c", reason: "target source" },
+    ]);
+    expect(autotools?.ownedFiles).toEqual([
+      { path: "main.c", reason: "target source" },
+      { path: "auto_only.c", reason: "target source" },
+    ]);
+  });
+
   it("maps standalone C main files without php-src extension semantics", async () => {
     const root = await fixtureRoot("clawpatch-c-main-map-");
     await writeFixture(root, "src/tool.c", "int main(void) { return 0; }\n");
@@ -1972,6 +1999,20 @@ add_executable(headerapp include/headers.hpp)
       root,
       "src/app.cpp",
       'const char *url = R"json({"url":"http://example.com"})json";\nconst char *open = "/*";\nint main(void) { return 0; }\nconst char *close = "*/";\n',
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(result.features.map((feature) => feature.title)).toContain("C++ binary app");
+  });
+
+  it("ignores C and C++ block markers inside line comments", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-line-comment-block-marker-");
+    await writeFixture(
+      root,
+      "src/app.cpp",
+      "// /* disabled guard\nint main(void) { return 0; }\n// */\n",
     );
 
     const project = await detectProject(root);

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1204,12 +1204,16 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     await writeFixture(
       root,
       "CMakeLists.txt",
-      "add_executable(myapp src/main.cpp src/util.cpp)\nadd_library(core STATIC src/core.c src/core_util.c)\n",
+      'add_executable(myapp src/main.cpp src/util.cpp)\nadd_executable(quoted "src/quoted.cpp")\nadd_library(core STATIC include/core.hpp src/core.c src/core_util.c)\nadd_library(headers INTERFACE include/headers.hpp)\nadd_library(vendored INTERFACE vendor/dep.hpp)\nadd_executable(varapp ${APP_SOURCES})\nadd_executable(headerapp include/headers.hpp)\n',
     );
     await writeFixture(root, "src/main.cpp", "int main(int argc, char **argv) { return 0; }\n");
+    await writeFixture(root, "src/quoted.cpp", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/util.cpp", "int util() { return 1; }\n");
+    await writeFixture(root, "include/core.hpp", "int core(void);\n");
     await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
     await writeFixture(root, "src/core_util.c", "int core_util(void) { return 2; }\n");
+    await writeFixture(root, "include/headers.hpp", "int header_only(void);\n");
+    await writeFixture(root, "vendor/dep.hpp", "int dep(void);\n");
     await writeFixture(root, "tests/main_test.cpp", "int main() { return 0; }\n");
 
     const project = await detectProject(root);
@@ -1217,6 +1221,7 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     const titles = result.features.map((feature) => feature.title);
     const myapp = result.features.find((feature) => feature.title === "CMake binary myapp");
     const core = result.features.find((feature) => feature.title === "CMake library core");
+    const headers = result.features.find((feature) => feature.title === "CMake library headers");
     const mainFeatures = result.features.filter(
       (feature) =>
         feature.kind === "cli-command" && feature.entrypoints[0]?.path === "src/main.cpp",
@@ -1225,7 +1230,12 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     expect(project.detected.languages).toEqual(expect.arrayContaining(["c", "cpp"]));
     expect(project.detected.packageManagers).toContain("cmake");
     expect(titles).toContain("CMake binary myapp");
+    expect(titles).toContain("CMake binary quoted");
     expect(titles).toContain("CMake library core");
+    expect(titles).toContain("CMake library headers");
+    expect(titles).not.toContain("CMake library vendored");
+    expect(titles).not.toContain("CMake binary varapp");
+    expect(titles).not.toContain("CMake binary headerapp");
     expect(titles).not.toContain("C++ binary main_test");
     expect(mainFeatures).toHaveLength(1);
     expect(myapp?.source).toBe("cmake-bin");
@@ -1238,10 +1248,118 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
       { path: "tests/main_test.cpp", reason: "nearby test" },
     ]);
     expect(myapp?.tests).toEqual([{ path: "tests/main_test.cpp", command: null }]);
+    expect(core?.entrypoints[0]?.path).toBe("src/core.c");
+    expect(core?.entrypoints[0]?.symbol).toBeNull();
     expect(core?.ownedFiles).toEqual([
+      { path: "include/core.hpp", reason: "target source" },
       { path: "src/core.c", reason: "target source" },
       { path: "src/core_util.c", reason: "target source" },
     ]);
+    expect(headers?.ownedFiles).toEqual([{ path: "include/headers.hpp", reason: "target source" }]);
+  });
+
+  it("preserves CMake targets that share the same source list", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-shared-sources-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_library(core_static STATIC src/core.c)\nadd_library(core_shared SHARED src/core.c)\n",
+    );
+    await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const coreStatic = result.features.find(
+      (feature) => feature.title === "CMake library core_static",
+    );
+    const coreShared = result.features.find(
+      (feature) => feature.title === "CMake library core_shared",
+    );
+
+    expect(titles).toContain("CMake library core_static");
+    expect(titles).toContain("CMake library core_shared");
+    expect(coreStatic?.entrypoints[0]?.symbol).toBe("core_static");
+    expect(coreShared?.entrypoints[0]?.symbol).toBe("core_shared");
+  });
+
+  it("keeps existing CMake library ids when a target starts sharing sources", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-shared-source-stability-");
+    await writeFixture(root, "CMakeLists.txt", "add_library(core_static STATIC src/core.c)\n");
+    await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
+
+    const project = await detectProject(root);
+    const first = await mapFeatures(root, project, []);
+    const firstCore = first.features.find(
+      (feature) => feature.title === "CMake library core_static",
+    );
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_library(core_shared SHARED src/core.c)\nadd_library(core_static STATIC src/core.c)\n",
+    );
+    const second = await mapFeatures(root, project, first.features);
+    const secondCore = second.features.find(
+      (feature) => feature.title === "CMake library core_static",
+    );
+    const shared = second.features.find((feature) => feature.title === "CMake library core_shared");
+
+    expect(secondCore?.featureId).toBe(firstCore?.featureId);
+    expect(secondCore?.entrypoints[0]?.symbol).toBeNull();
+    expect(shared?.entrypoints[0]?.symbol).toBe("core_shared");
+    expect(second.stale).toBe(0);
+  });
+
+  it("keeps disambiguated CMake library ids when source sharing stops", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-shared-source-removal-");
+    await writeFixture(root, "CMakeLists.txt", "add_library(core_static STATIC src/core.c)\n");
+    await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
+
+    const project = await detectProject(root);
+    const first = await mapFeatures(root, project, []);
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_library(core_static STATIC src/core.c)\nadd_library(core_shared SHARED src/core.c)\n",
+    );
+    const second = await mapFeatures(root, project, first.features);
+    const sharedDuringCollision = second.features.find(
+      (feature) => feature.title === "CMake library core_shared",
+    );
+    await writeFixture(root, "CMakeLists.txt", "add_library(core_shared SHARED src/core.c)\n");
+    const third = await mapFeatures(root, project, second.features);
+    const sharedAfterRemoval = third.features.find(
+      (feature) => feature.title === "CMake library core_shared",
+    );
+
+    expect(sharedAfterRemoval?.featureId).toBe(sharedDuringCollision?.featureId);
+    expect(sharedAfterRemoval?.entrypoints[0]?.symbol).toBe("core_shared");
+    expect(third.stale).toBe(1);
+  });
+
+  it("keeps initially disambiguated CMake library ids after source sharing stops", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-initial-shared-source-removal-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_library(core_static STATIC src/core.c)\nadd_library(core_shared SHARED src/core.c)\n",
+    );
+    await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
+
+    const project = await detectProject(root);
+    const first = await mapFeatures(root, project, []);
+    const sharedDuringCollision = first.features.find(
+      (feature) => feature.title === "CMake library core_shared",
+    );
+    await writeFixture(root, "CMakeLists.txt", "add_library(core_shared SHARED src/core.c)\n");
+    const second = await mapFeatures(root, project, first.features);
+    const sharedAfterRemoval = second.features.find(
+      (feature) => feature.title === "CMake library core_shared",
+    );
+
+    expect(sharedAfterRemoval?.featureId).toBe(sharedDuringCollision?.featureId);
+    expect(sharedAfterRemoval?.entrypoints[0]?.symbol).toBe("core_shared");
+    expect(second.stale).toBe(1);
   });
 
   it("does not map CMake target sources outside the project root", async () => {
@@ -1287,12 +1405,15 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     await writeFixture(
       root,
       "Makefile.am",
-      "bin_PROGRAMS = thing my-tool # installed helpers\nthing_SOURCES = thing.c \\\n  util.c\nmy_tool_SOURCES = main.c tool-util.c\nlib_LTLIBRARIES = libcore.la libcore-extra.la\nlibcore_la_SOURCES = core.cc core_util.cc\nlibcore_extra_la_SOURCES = extra.cc\n",
+      "bin_PROGRAMS = thing my-tool defaulted header-tool # installed helpers\nthing_SOURCES = thing.c \\\n  util.c\nmy_tool_SOURCES = main.c tool-util.c\nheader_tool_SOURCES = include/header.hpp\nlib_LTLIBRARIES = libcore.la libcore-extra.la\nlibcore_la_SOURCES = core.cc core_util.cc\nlibcore_extra_la_SOURCES = extra.cc\n",
     );
     await writeFixture(root, "thing.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "util.c", "int util(void) { return 1; }\n");
     await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "tool-util.c", "int tool_util(void) { return 1; }\n");
+    await writeFixture(root, "defaulted.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "cppdefault.cpp", "int main() { return 0; }\n");
+    await writeFixture(root, "include/header.hpp", "int header(void);\n");
     await writeFixture(root, "core.cc", "int core() { return 1; }\n");
     await writeFixture(root, "core_util.cc", "int coreUtil() { return 2; }\n");
     await writeFixture(root, "extra.cc", "int extra() { return 3; }\n");
@@ -1301,6 +1422,9 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     const result = await mapFeatures(root, project, []);
     const thing = result.features.find((feature) => feature.title === "Autotools binary thing");
     const myTool = result.features.find((feature) => feature.title === "Autotools binary my-tool");
+    const defaulted = result.features.find(
+      (feature) => feature.title === "Autotools binary defaulted",
+    );
     const core = result.features.find((feature) => feature.title === "Autotools library libcore");
     const extra = result.features.find(
       (feature) => feature.title === "Autotools library libcore-extra",
@@ -1310,6 +1434,9 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     expect(project.detected.packageManagers).toContain("autotools");
     expect(titles).not.toContain("Autotools binary installed");
     expect(titles).not.toContain("Autotools binary helpers");
+    expect(titles).not.toContain("Autotools binary header-tool");
+    expect(titles).not.toContain("Autotools binary cppdefault");
+    expect(titles).toContain("C++ binary cppdefault");
     expect(thing?.entrypoints[0]).toMatchObject({
       path: "thing.c",
       symbol: "main",
@@ -1324,6 +1451,12 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
       { path: "main.c", reason: "target source" },
       { path: "tool-util.c", reason: "target source" },
     ]);
+    expect(defaulted?.entrypoints[0]).toMatchObject({
+      path: "defaulted.c",
+      symbol: "main",
+      command: "defaulted",
+    });
+    expect(titles).not.toContain("C binary defaulted");
     expect(thing?.ownedFiles).toEqual([
       { path: "thing.c", reason: "target source" },
       { path: "util.c", reason: "target source" },
@@ -1395,6 +1528,35 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
 
     expect(app?.tests).toEqual([]);
     expect(app?.contextFiles).toEqual([]);
+  });
+
+  it("skips dependency trees during C and C++ discovery", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-dependency-paths-");
+    await writeFixture(root, "src/app.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "vendor/tool/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, ".venv/native/main.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const paths = result.features.flatMap((feature) =>
+      feature.entrypoints.map((entrypoint) => entrypoint.path),
+    );
+
+    expect(paths).toContain("src/app.c");
+    expect(paths.some((path) => path.startsWith("vendor/"))).toBe(false);
+    expect(paths.some((path) => path.startsWith(".venv/"))).toBe(false);
+  });
+
+  it("ignores vendored C and C++ files during detection", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-vendor-detect-");
+    await writeFixture(root, "vendor/CMakeLists.txt", "add_executable(vendor main.c)\n");
+    await writeFixture(root, "vendor/main.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+
+    expect(project.detected.languages).not.toContain("c");
+    expect(project.detected.languages).not.toContain("cpp");
+    expect(project.detected.packageManagers).not.toContain("cmake");
   });
 
   it("maps Python project metadata, console scripts, source groups, and tests", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3180,7 +3180,7 @@ add_executable(headerapp include/headers.hpp)
     await writeFixture(root, "src/upperlib.c", "int upperlib(void) { return 1; }\n");
     await writeFixture(root, "include/headers.hpp", "int header_only(void);\n");
     await writeFixture(root, "vendor/dep.hpp", "int dep(void);\n");
-    await writeFixture(root, "tests/main_test.cpp", "int main() { return 0; }\n");
+    await writeFixture(root, "tests/myapp_test.cpp", "int main() { return 0; }\n");
 
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
@@ -3222,9 +3222,9 @@ add_executable(headerapp include/headers.hpp)
     ]);
     expect(myapp?.contextFiles).toEqual([
       { path: "CMakeLists.txt", reason: "CMake target declaration" },
-      { path: "tests/main_test.cpp", reason: "nearby test" },
+      { path: "tests/myapp_test.cpp", reason: "nearby test" },
     ]);
-    expect(myapp?.tests).toEqual([{ path: "tests/main_test.cpp", command: null }]);
+    expect(myapp?.tests).toEqual([{ path: "tests/myapp_test.cpp", command: null }]);
     expect(latebin?.entrypoints[0]?.path).toBe("src/late_main.c");
     expect(latebin?.ownedFiles).toEqual([
       { path: "src/late_main.c", reason: "target source" },
@@ -3262,6 +3262,26 @@ add_executable(headerapp include/headers.hpp)
 
     expect(app?.tests).toEqual([]);
     expect(tool?.tests).toEqual([{ path: "tests/tool_test.cpp", command: null }]);
+  });
+
+  it("does not attach generic main CMake tests to every target", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-generic-main-test-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_executable(foo foo/main.c)\nadd_executable(bar bar/main.c)\n",
+    );
+    await writeFixture(root, "foo/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "bar/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "tests/main_test.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const foo = result.features.find((feature) => feature.title === "CMake binary foo");
+    const bar = result.features.find((feature) => feature.title === "CMake binary bar");
+
+    expect(foo?.tests).toEqual([]);
+    expect(bar?.tests).toEqual([]);
   });
 
   it("maps CMake test executables as test suites", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3364,6 +3364,25 @@ add_executable(headerapp include/headers.hpp)
     expect(titles).toContain("CMake binary real");
   });
 
+  it("keeps CMake targets after bracket arguments containing hashes", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-bracket-hash-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "message([[# generated]])\nmessage([=[# also generated]=])\n#[[add_executable(fake src/fake.c)]]\nadd_executable(real src/real.c)\n",
+    );
+    await writeFixture(root, "src/fake.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/real.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(titles).not.toContain("CMake binary fake");
+    expect(titles).toContain("CMake binary real");
+    expect(titles).not.toContain("C binary real");
+  });
+
   it("maps quoted CMake source paths containing spaces", async () => {
     const root = await fixtureRoot("clawpatch-cmake-quoted-space-source-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1761,6 +1761,34 @@ add_executable(headerapp include/headers.hpp)
     expect(titles).toContain("C++ binary latest");
   });
 
+  it("attaches capitalized C and C++ test directories without mapping them as binaries", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-capitalized-tests-");
+    await writeFixture(root, "src/parser.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "Tests/parser.cpp", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const parser = result.features.find((feature) => feature.title === "C++ binary parser");
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(parser?.tests).toEqual([{ path: "Tests/parser.cpp", command: null }]);
+    expect(titles.filter((title) => title === "C++ binary parser")).toHaveLength(1);
+  });
+
+  it("detects C and C++ main functions after literals containing braces", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-literal-braces-");
+    await writeFixture(
+      root,
+      "src/app.cpp",
+      'const char *json = "{\\"ok\\": true}";\nconst char *raw = R"tag({raw})tag";\nint main(void) { return 0; }\n',
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(result.features.map((feature) => feature.title)).toContain("C++ binary app");
+  });
+
   it("skips dependency trees during C and C++ discovery", async () => {
     const root = await fixtureRoot("clawpatch-cpp-dependency-paths-");
     await writeFixture(root, "src/app.c", "int main(void) { return 0; }\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1423,28 +1423,53 @@ add_executable(headerapp include/headers.hpp)
     expect(result.features.map((feature) => feature.title)).not.toContain("C++ binary main");
   });
 
+  it("resolves targets from included CMake modules relative to the source dir", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-include-source-dir-");
+    await writeFixture(root, "CMakeLists.txt", "include(cmake/Targets.cmake)\n");
+    await writeFixture(root, "cmake/Targets.cmake", "add_executable(app src/main.c src/util.c)\n");
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/util.c", "int util(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+
+    expect(app?.entrypoints[0]?.path).toBe("src/main.c");
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/main.c", reason: "target source" },
+      { path: "src/util.c", reason: "target source" },
+    ]);
+  });
+
   it("maps autotools C and C++ binary and library targets", async () => {
     const root = await fixtureRoot("clawpatch-autotools-cpp-map-");
     await writeFixture(
       root,
       "Makefile.am",
-      "bin_PROGRAMS = thing my-tool defaulted header-tool # installed helpers\nthing_SOURCES = thing.c \\\n  util.c\nmy_tool_SOURCES = main.c tool-util.c\nheader_tool_SOURCES = include/header.hpp\nlib_LTLIBRARIES = libcore.la libcore-extra.la\nlibcore_la_SOURCES = core.cc core_util.cc\nlibcore_extra_la_SOURCES = extra.cc\n",
+      "bin_PROGRAMS = thing my-tool defaulted header-tool # installed helpers\nbin_PROGRAMS += appended\nthing_SOURCES = thing.c \\\n  util.c\nmy_tool_SOURCES = main.c tool-util.c\nappended_SOURCES = appended.c\nappended_SOURCES += appended_util.c\nheader_tool_SOURCES = include/header.hpp\nlib_LTLIBRARIES = libcore.la libcore-extra.la\nlib_LTLIBRARIES += libmore.la\nlibcore_la_SOURCES = core.cc core_util.cc\nlibcore_extra_la_SOURCES = extra.cc\nlibmore_la_SOURCES = more.c\nlibmore_la_SOURCES += more_util.c\n",
     );
     await writeFixture(root, "thing.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "util.c", "int util(void) { return 1; }\n");
     await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "tool-util.c", "int tool_util(void) { return 1; }\n");
+    await writeFixture(root, "appended.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "appended_util.c", "int appended_util(void) { return 1; }\n");
     await writeFixture(root, "defaulted.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "cppdefault.cpp", "int main() { return 0; }\n");
     await writeFixture(root, "include/header.hpp", "int header(void);\n");
     await writeFixture(root, "core.cc", "int core() { return 1; }\n");
     await writeFixture(root, "core_util.cc", "int coreUtil() { return 2; }\n");
     await writeFixture(root, "extra.cc", "int extra() { return 3; }\n");
+    await writeFixture(root, "more.c", "int more(void) { return 3; }\n");
+    await writeFixture(root, "more_util.c", "int more_util(void) { return 4; }\n");
 
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
     const thing = result.features.find((feature) => feature.title === "Autotools binary thing");
     const myTool = result.features.find((feature) => feature.title === "Autotools binary my-tool");
+    const appended = result.features.find(
+      (feature) => feature.title === "Autotools binary appended",
+    );
     const defaulted = result.features.find(
       (feature) => feature.title === "Autotools binary defaulted",
     );
@@ -1452,6 +1477,7 @@ add_executable(headerapp include/headers.hpp)
     const extra = result.features.find(
       (feature) => feature.title === "Autotools library libcore-extra",
     );
+    const more = result.features.find((feature) => feature.title === "Autotools library libmore");
     const titles = result.features.map((feature) => feature.title);
 
     expect(project.detected.packageManagers).toContain("autotools");
@@ -1474,6 +1500,10 @@ add_executable(headerapp include/headers.hpp)
       { path: "main.c", reason: "target source" },
       { path: "tool-util.c", reason: "target source" },
     ]);
+    expect(appended?.ownedFiles).toEqual([
+      { path: "appended.c", reason: "target source" },
+      { path: "appended_util.c", reason: "target source" },
+    ]);
     expect(defaulted?.entrypoints[0]).toMatchObject({
       path: "defaulted.c",
       symbol: "main",
@@ -1490,6 +1520,10 @@ add_executable(headerapp include/headers.hpp)
       { path: "core_util.cc", reason: "target source" },
     ]);
     expect(extra?.ownedFiles).toEqual([{ path: "extra.cc", reason: "target source" }]);
+    expect(more?.ownedFiles).toEqual([
+      { path: "more.c", reason: "target source" },
+      { path: "more_util.c", reason: "target source" },
+    ]);
   });
 
   it("maps standalone C main files without php-src extension semantics", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1402,6 +1402,31 @@ add_executable(headerapp include/headers.hpp)
     ]);
   });
 
+  it("ignores CMake helper names ending with built-in commands", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-helper-command-names-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "my_add_executable(app src/main.c)\nmy_add_library(core src/core.c)\nadd_executable(real src/real.c)\nmy_target_sources(real PRIVATE src/helper.c)\nmy_include(cmake/Extra.cmake)\n",
+    );
+    await writeFixture(root, "cmake/Extra.cmake", "add_executable(extra src/extra.c)\n");
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/real.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/core.c", "int core(void) { return 0; }\n");
+    await writeFixture(root, "src/helper.c", "int helper(void) { return 0; }\n");
+    await writeFixture(root, "src/extra.c", "int extra(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const real = result.features.find((feature) => feature.title === "CMake binary real");
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(titles).not.toContain("CMake binary app");
+    expect(titles).not.toContain("CMake library core");
+    expect(titles).not.toContain("CMake binary extra");
+    expect(real?.ownedFiles).toEqual([{ path: "src/real.c", reason: "target source" }]);
+  });
+
   it("keeps target_sources scoped to standalone CMake projects", async () => {
     const root = await fixtureRoot("clawpatch-cmake-target-sources-scope-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1324,6 +1324,33 @@ add_executable(headerapp include/headers.hpp)
     expect(result.features.map((feature) => feature.title)).toContain("CMake library headers");
   });
 
+  it("maps uppercase C++ source extensions", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-uppercase-cpp-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_executable(uppercpp src/MAIN.CPP src/HELPER.HPP)\n",
+    );
+    await writeFixture(root, "src/MAIN.CPP", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/HELPER.HPP", "int helper(void);\n");
+    await writeFixture(root, "src/tool.C", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const uppercpp = result.features.find((feature) => feature.title === "CMake binary uppercpp");
+    const tool = result.features.find((feature) => feature.title === "C++ binary tool");
+
+    expect(project.detected.languages).toContain("cpp");
+    expect(uppercpp?.entrypoints[0]).toMatchObject({ path: "src/MAIN.CPP", symbol: "main" });
+    expect(uppercpp?.tags).toContain("cpp");
+    expect(uppercpp?.ownedFiles).toEqual([
+      { path: "src/MAIN.CPP", reason: "target source" },
+      { path: "src/HELPER.HPP", reason: "target source" },
+    ]);
+    expect(tool?.entrypoints[0]).toMatchObject({ path: "src/tool.C", symbol: "main" });
+    expect(tool?.tags).toContain("cpp");
+  });
+
   it("preserves CMake targets that share the same source list", async () => {
     const root = await fixtureRoot("clawpatch-cmake-shared-sources-");
     await writeFixture(
@@ -1597,6 +1624,7 @@ add_executable(headerapp include/headers.hpp)
 
   it("skips C and C++ sample project paths", async () => {
     const root = await fixtureRoot("clawpatch-cpp-sample-paths-");
+    await writeFixture(root, "CMakeLists.txt", "add_executable(sample fixtures/example/main.c)\n");
     await writeFixture(root, "fixtures/example/main.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "testdata/CMakeLists.txt", "add_executable(sample main.c)\n");
     await writeFixture(root, "testdata/main.c", "int main(void) { return 0; }\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2117,6 +2117,16 @@ add_executable(headerapp include/headers.hpp)
     expect(project.detected.packageManagers).not.toContain("cmake");
   });
 
+  it("detects non-C and C++ languages under vendor path components", async () => {
+    const root = await fixtureRoot("clawpatch-vendor-language-detect-");
+    await writeFixture(root, "src/pkg/vendor/app.py", "def main():\n    pass\n");
+    await writeFixture(root, "src/main/vendor/App.java", "class App {}\n");
+
+    const project = await detectProject(root);
+
+    expect(project.detected.languages).toEqual(expect.arrayContaining(["python", "java"]));
+  });
+
   it("maps Python project metadata, console scripts, source groups, and tests", async () => {
     const root = await fixtureRoot("clawpatch-python-map-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1560,6 +1560,25 @@ add_executable(headerapp include/headers.hpp)
     ]);
   });
 
+  it("resolves nested CMake includes relative to the source dir", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-nested-include-source-dir-");
+    await writeFixture(root, "CMakeLists.txt", "include(cmake/A.cmake)\n");
+    await writeFixture(root, "cmake/A.cmake", "include(cmake/B.cmake)\n");
+    await writeFixture(root, "cmake/B.cmake", "add_executable(app src/main.c src/util.c)\n");
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/util.c", "int util(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+
+    expect(app?.entrypoints[0]?.path).toBe("src/main.c");
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/main.c", reason: "target source" },
+      { path: "src/util.c", reason: "target source" },
+    ]);
+  });
+
   it("ignores unreferenced CMake modules", async () => {
     const root = await fixtureRoot("clawpatch-cmake-unreferenced-module-");
     await writeFixture(root, "CMakeLists.txt", "add_executable(app src/main.c)\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1737,6 +1737,30 @@ add_executable(headerapp include/headers.hpp)
     ]);
   });
 
+  it("maps autotools targets from Makefile.in", async () => {
+    const root = await fixtureRoot("clawpatch-autotools-makefile-in-");
+    await writeFixture(
+      root,
+      "Makefile.in",
+      "bin_PROGRAMS = app\napp_SOURCES = main.c util.c\nlib_LTLIBRARIES = libcore.la\nlibcore_la_SOURCES = core.c\n",
+    );
+    await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "util.c", "int util(void) { return 1; }\n");
+    await writeFixture(root, "core.c", "int core(void) { return 1; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "Autotools binary app");
+    const core = result.features.find((feature) => feature.title === "Autotools library libcore");
+
+    expect(project.detected.packageManagers).toContain("autotools");
+    expect(app?.ownedFiles).toEqual([
+      { path: "main.c", reason: "target source" },
+      { path: "util.c", reason: "target source" },
+    ]);
+    expect(core?.ownedFiles).toEqual([{ path: "core.c", reason: "target source" }]);
+  });
+
   it("maps standalone C main files without php-src extension semantics", async () => {
     const root = await fixtureRoot("clawpatch-c-main-map-");
     await writeFixture(root, "src/tool.c", "int main(void) { return 0; }\n");
@@ -1839,6 +1863,20 @@ add_executable(headerapp include/headers.hpp)
       root,
       "src/app.cpp",
       'const char *json = "{\\"ok\\": true}";\nconst char *raw = R"tag({raw})tag";\nint main(void) { return 0; }\n',
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(result.features.map((feature) => feature.title)).toContain("C++ binary app");
+  });
+
+  it("detects C and C++ main functions after literals containing comment markers", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-literal-comments-");
+    await writeFixture(
+      root,
+      "src/app.cpp",
+      'const char *url = R"json({"url":"http://example.com"})json";\nconst char *open = "/*";\nint main(void) { return 0; }\nconst char *close = "*/";\n',
     );
 
     const project = await detectProject(root);

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3510,7 +3510,32 @@ add_executable(headerapp include/headers.hpp)
       { path: "src/main.c", reason: "target source" },
       { path: "src/util.c", reason: "target source" },
     ]);
+    expect(app?.contextFiles).toEqual([
+      { path: "CMakeLists.txt", reason: "CMake target declaration" },
+      { path: "src/CMakeLists.txt", reason: "CMake target source declaration" },
+    ]);
     expect(titles).not.toContain("C binary main");
+  });
+
+  it("resolves PROJECT_NAME CMake targets", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-project-name-target-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "project(app C)\nadd_executable(${PROJECT_NAME})\ntarget_sources(${PROJECT_NAME} PRIVATE src/main.c src/util.c)\n",
+    );
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/util.c", "int util(void) { return 1; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+
+    expect(app?.entrypoints[0]).toMatchObject({ path: "src/main.c", command: "app" });
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/main.c", reason: "target source" },
+      { path: "src/util.c", reason: "target source" },
+    ]);
   });
 
   it("detects header-only C++ CMake libraries as C++ projects", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1204,14 +1204,32 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     await writeFixture(
       root,
       "CMakeLists.txt",
-      'add_executable(myapp src/main.cpp src/util.cpp)\nadd_executable(quoted "src/quoted.cpp")\nadd_library(core STATIC include/core.hpp src/core.c src/core_util.c)\nadd_library(headers INTERFACE include/headers.hpp)\nadd_library(vendored INTERFACE vendor/dep.hpp)\nadd_executable(varapp ${APP_SOURCES})\nadd_executable(headerapp include/headers.hpp)\n',
+      `add_executable(myapp src/main.cpp src/util.cpp)
+add_executable(quoted "src/quoted.cpp")
+ADD_EXECUTABLE(upper src/upper.c)
+add_executable(absin ${root}/src/absin.cpp)
+add_executable(absout /src/main.cpp)
+#[[
+add_executable(commented src/commented.c)
+]]
+add_library(core STATIC include/core.hpp src/core.c src/core_util.c)
+ADD_LIBRARY(upperlib STATIC src/upperlib.c)
+add_library(headers INTERFACE include/headers.hpp)
+add_library(vendored INTERFACE vendor/dep.hpp)
+add_executable(varapp \${APP_SOURCES})
+add_executable(headerapp include/headers.hpp)
+`,
     );
     await writeFixture(root, "src/main.cpp", "int main(int argc, char **argv) { return 0; }\n");
     await writeFixture(root, "src/quoted.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/upper.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/absin.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/commented.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/util.cpp", "int util() { return 1; }\n");
     await writeFixture(root, "include/core.hpp", "int core(void);\n");
     await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
     await writeFixture(root, "src/core_util.c", "int core_util(void) { return 2; }\n");
+    await writeFixture(root, "src/upperlib.c", "int upperlib(void) { return 1; }\n");
     await writeFixture(root, "include/headers.hpp", "int header_only(void);\n");
     await writeFixture(root, "vendor/dep.hpp", "int dep(void);\n");
     await writeFixture(root, "tests/main_test.cpp", "int main() { return 0; }\n");
@@ -1231,7 +1249,12 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     expect(project.detected.packageManagers).toContain("cmake");
     expect(titles).toContain("CMake binary myapp");
     expect(titles).toContain("CMake binary quoted");
+    expect(titles).toContain("CMake binary upper");
+    expect(titles).toContain("CMake binary absin");
+    expect(titles).not.toContain("CMake binary absout");
+    expect(titles).not.toContain("CMake binary commented");
     expect(titles).toContain("CMake library core");
+    expect(titles).toContain("CMake library upperlib");
     expect(titles).toContain("CMake library headers");
     expect(titles).not.toContain("CMake library vendored");
     expect(titles).not.toContain("CMake binary varapp");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3383,6 +3383,26 @@ add_executable(headerapp include/headers.hpp)
     expect(titles).toContain("CMake binary real");
   });
 
+  it("ignores CMake command text inside unquoted command arguments", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-nested-command-text-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "message(STATUS add_executable(fake src/fake.c))\nset(x add_library(fake_lib src/lib.c))\nadd_executable(real src/real.c)\n",
+    );
+    await writeFixture(root, "src/fake.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/lib.c", "int lib(void) { return 0; }\n");
+    await writeFixture(root, "src/real.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(titles).not.toContain("CMake binary fake");
+    expect(titles).not.toContain("CMake library fake_lib");
+    expect(titles).toContain("CMake binary real");
+  });
+
   it("keeps CMake targets after bracket arguments containing hashes", async () => {
     const root = await fixtureRoot("clawpatch-cmake-bracket-hash-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1347,6 +1347,33 @@ add_executable(headerapp include/headers.hpp)
     expect(tool?.tests).toEqual([{ path: "tests/tool_test.cpp", command: null }]);
   });
 
+  it("maps CMake test executables as test suites", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-test-executable-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_executable(app src/app.cpp)\nadd_executable(unit_tests tests/unit_tests.cpp)\n",
+    );
+    await writeFixture(root, "src/app.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "tests/unit_tests.cpp", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const suite = result.features.find(
+      (feature) => feature.title === "CMake test suite unit_tests",
+    );
+
+    expect(titles).toContain("CMake binary app");
+    expect(titles).not.toContain("CMake binary unit_tests");
+    expect(suite).toMatchObject({
+      kind: "test-suite",
+      source: "cmake-test",
+      entrypoints: [{ path: "tests/unit_tests.cpp", symbol: null, route: null, command: null }],
+      tests: [{ path: "tests/unit_tests.cpp", command: null }],
+    });
+  });
+
   it("maps semicolon-separated CMake source lists", async () => {
     const root = await fixtureRoot("clawpatch-cmake-semicolon-sources-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3311,6 +3311,21 @@ add_executable(headerapp include/headers.hpp)
     ]);
   });
 
+  it("attaches CMake tests named after the target", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-target-named-tests-");
+    await writeFixture(root, "CMakeLists.txt", "add_executable(app src/main.c)\n");
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "tests/app_test.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+
+    expect(app?.entrypoints[0]?.path).toBe("src/main.c");
+    expect(app?.tests).toEqual([{ path: "tests/app_test.c", command: null }]);
+    expect(app?.contextFiles).toContainEqual({ path: "tests/app_test.c", reason: "nearby test" });
+  });
+
   it("maps semicolon-separated CMake source lists", async () => {
     const root = await fixtureRoot("clawpatch-cmake-semicolon-sources-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1244,6 +1244,25 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
     ]);
   });
 
+  it("does not map CMake target sources outside the project root", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-cpp-safe-sources-");
+    await writeFixture(root, "CMakeLists.txt", "add_executable(tool ../outside.c src/main.c)\n");
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const tool = result.features.find((feature) => feature.title === "CMake binary tool");
+
+    expect(tool?.entrypoints[0]?.path).toBe("src/main.c");
+    expect(tool?.ownedFiles).toEqual([{ path: "src/main.c", reason: "target source" }]);
+    expect(
+      result.features.flatMap((feature) => [
+        ...feature.entrypoints.map((entrypoint) => entrypoint.path),
+        ...feature.ownedFiles.map((file) => file.path),
+      ]),
+    ).not.toContain("../outside.c");
+  });
+
   it("maps autotools C and C++ binary and library targets", async () => {
     const root = await fixtureRoot("clawpatch-autotools-cpp-map-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1657,6 +1657,30 @@ add_executable(headerapp include/headers.hpp)
     ]);
   });
 
+  it("resolves repeated CMake includes relative to each source dir", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-repeated-include-source-dir-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_executable(app)\nadd_subdirectory(a)\nadd_subdirectory(b)\n",
+    );
+    await writeFixture(root, "a/CMakeLists.txt", "include(../cmake/Part.cmake)\n");
+    await writeFixture(root, "b/CMakeLists.txt", "include(../cmake/Part.cmake)\n");
+    await writeFixture(root, "cmake/Part.cmake", "target_sources(app PRIVATE local.c)\n");
+    await writeFixture(root, "a/local.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "b/local.c", "int helper(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+
+    expect(app?.entrypoints[0]?.path).toBe("a/local.c");
+    expect(app?.ownedFiles).toEqual([
+      { path: "a/local.c", reason: "target source" },
+      { path: "b/local.c", reason: "target source" },
+    ]);
+  });
+
   it("ignores unreferenced CMake modules", async () => {
     const root = await fixtureRoot("clawpatch-cmake-unreferenced-module-");
     await writeFixture(root, "CMakeLists.txt", "add_executable(app src/main.c)\n");
@@ -1950,10 +1974,25 @@ add_executable(headerapp include/headers.hpp)
     expect(paths.some((path) => path.startsWith("cmake-build-debug/"))).toBe(false);
   });
 
-  it("ignores vendored C and C++ files during detection", async () => {
-    const root = await fixtureRoot("clawpatch-cpp-vendor-detect-");
+  it("ignores dependency and generated C and C++ files during detection", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-dependency-detect-");
     await writeFixture(root, "vendor/CMakeLists.txt", "add_executable(vendor main.c)\n");
     await writeFixture(root, "vendor/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(
+      root,
+      "CMakeFiles/CompilerIdCXX/CMakeCXXCompilerId.cpp",
+      "int main(void) { return 0; }\n",
+    );
+    await writeFixture(
+      root,
+      "cmake-build-debug/_deps/foo-src/CMakeLists.txt",
+      "add_executable(foo main.cpp)\n",
+    );
+    await writeFixture(
+      root,
+      "cmake-build-debug/_deps/foo-src/main.cpp",
+      "int main(void) { return 0; }\n",
+    );
 
     const project = await detectProject(root);
 

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3442,6 +3442,26 @@ add_executable(headerapp include/headers.hpp)
     ]);
   });
 
+  it("maps escaped CMake source paths containing spaces and semicolons", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-escaped-source-path-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_executable(app src/main\\ file.cpp src/helper\\;part.cpp)\n",
+    );
+    await writeFixture(root, "src/main file.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/helper;part.cpp", "int helper(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/main file.cpp", reason: "target source" },
+      { path: "src/helper;part.cpp", reason: "target source" },
+    ]);
+  });
+
   it("keeps target_sources scoped to standalone CMake projects", async () => {
     const root = await fixtureRoot("clawpatch-cmake-target-sources-scope-");
     await writeFixture(
@@ -4272,6 +4292,23 @@ add_executable(headerapp include/headers.hpp)
     const project = await detectProject(root);
 
     expect(project.detected.languages).toEqual(expect.arrayContaining(["python", "java"]));
+  });
+
+  it("ignores top-level vendored native project metadata during detection", async () => {
+    const root = await fixtureRoot("clawpatch-top-vendor-native-detect-");
+    await writeFixture(root, "package.json", JSON.stringify({ name: "host" }, null, 2));
+    await writeFixture(
+      root,
+      "vendor/Dependency/Package.swift",
+      'import PackageDescription\nlet package = Package(name: "Dependency")\n',
+    );
+    await writeFixture(root, "vendor/Dependency/build.gradle.kts", 'plugins { id("java") }\n');
+
+    const project = await detectProject(root);
+
+    expect(project.detected.languages).not.toContain("swift");
+    expect(project.detected.packageManagers).not.toContain("swiftpm");
+    expect(project.detected.packageManagers).not.toContain("gradle");
   });
 
   it("maps Python project metadata, console scripts, source groups, and tests", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3853,9 +3853,13 @@ add_executable(headerapp include/headers.hpp)
         feature.title === "CMake binary source_app" &&
         feature.entrypoints[0]?.path === "src/source.c",
     );
+    const sourceAppPaths = result.features
+      .filter((feature) => feature.title === "CMake binary source_app")
+      .map((feature) => feature.entrypoints[0]?.path);
 
     expect(projectApp?.entrypoints[0]?.path).toBe("sub/src/project.c");
     expect(sourceApp?.entrypoints[0]?.path).toBe("src/source.c");
+    expect(sourceAppPaths).toEqual(["src/source.c"]);
   });
 
   it("resolves nested CMake includes relative to the source dir", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1427,6 +1427,46 @@ add_executable(headerapp include/headers.hpp)
     expect(real?.ownedFiles).toEqual([{ path: "src/real.c", reason: "target source" }]);
   });
 
+  it("ignores CMake command text inside strings", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-command-string-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      'message("add_executable(fake src/main.c)")\nmessage([[add_library(fake_lib src/lib.c)]])\nadd_executable(real src/real.c)\n',
+    );
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/lib.c", "int lib(void) { return 0; }\n");
+    await writeFixture(root, "src/real.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(titles).not.toContain("CMake binary fake");
+    expect(titles).not.toContain("CMake library fake_lib");
+    expect(titles).toContain("CMake binary real");
+  });
+
+  it("maps quoted CMake source paths containing spaces", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-quoted-space-source-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      'add_executable(app "src/main file.cpp" "src/helper file.cpp")\n',
+    );
+    await writeFixture(root, "src/main file.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/helper file.cpp", "int helper(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/main file.cpp", reason: "target source" },
+      { path: "src/helper file.cpp", reason: "target source" },
+    ]);
+  });
+
   it("keeps target_sources scoped to standalone CMake projects", async () => {
     const root = await fixtureRoot("clawpatch-cmake-target-sources-scope-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1347,6 +1347,33 @@ add_executable(headerapp include/headers.hpp)
     expect(tool?.tests).toEqual([{ path: "tests/tool_test.cpp", command: null }]);
   });
 
+  it("maps semicolon-separated CMake source lists", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-semicolon-sources-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "add_executable(app src/main.c;src/util.c)\nadd_library(core)\ntarget_sources(core PRIVATE src/core.c;include/core.h)\n",
+    );
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/util.c", "int util(void) { return 1; }\n");
+    await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
+    await writeFixture(root, "include/core.h", "int core(void);\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+    const core = result.features.find((feature) => feature.title === "CMake library core");
+
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/main.c", reason: "target source" },
+      { path: "src/util.c", reason: "target source" },
+    ]);
+    expect(core?.ownedFiles).toEqual([
+      { path: "src/core.c", reason: "target source" },
+      { path: "include/core.h", reason: "target source" },
+    ]);
+  });
+
   it("detects header-only C++ CMake libraries as C++ projects", async () => {
     const root = await fixtureRoot("clawpatch-cmake-header-only-cpp-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1663,6 +1663,8 @@ add_executable(headerapp include/headers.hpp)
     await writeFixture(root, "src/app.cpp", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/app_tests.cpp", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/FooTests.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/Contest.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/latest.cpp", "int main(void) { return 0; }\n");
 
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
@@ -1672,6 +1674,8 @@ add_executable(headerapp include/headers.hpp)
     expect(app?.tests).toEqual([{ path: "src/app_tests.cpp", command: null }]);
     expect(titles).not.toContain("C++ binary app_tests");
     expect(titles).not.toContain("C++ binary FooTests");
+    expect(titles).toContain("C++ binary Contest");
+    expect(titles).toContain("C++ binary latest");
   });
 
   it("skips dependency trees during C and C++ discovery", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1405,6 +1405,26 @@ add_executable(headerapp include/headers.hpp)
     ).toEqual([{ path: "sub/src/main.c", reason: "target source" }]);
   });
 
+  it("attaches target_sources from CMake subdirectories", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-subdir-target-sources-");
+    await writeFixture(root, "CMakeLists.txt", "add_executable(app)\nadd_subdirectory(src)\n");
+    await writeFixture(root, "src/CMakeLists.txt", "target_sources(app PRIVATE main.c util.c)\n");
+    await writeFixture(root, "src/main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/util.c", "int util(void) { return 1; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "CMake binary app");
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(app?.entrypoints[0]).toMatchObject({ path: "src/main.c", command: "app" });
+    expect(app?.ownedFiles).toEqual([
+      { path: "src/main.c", reason: "target source" },
+      { path: "src/util.c", reason: "target source" },
+    ]);
+    expect(titles).not.toContain("C binary main");
+  });
+
   it("detects header-only C++ CMake libraries as C++ projects", async () => {
     const root = await fixtureRoot("clawpatch-cmake-header-only-cpp-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1210,11 +1210,15 @@ ADD_EXECUTABLE(upper src/upper.c)
 add_executable(absin ${root}/src/absin.cpp)
 add_executable(absout /src/main.cpp)
 add_executable(7zip src/seven.c)
+add_executable(latebin)
+target_sources(latebin PRIVATE src/late_main.c src/late_util.c)
 #[[
 add_executable(commented src/commented.c)
 ]]
 add_library(core STATIC include/core.hpp src/core.c src/core_util.c)
 add_library(foo.bar STATIC src/dot.c)
+add_library(latelib)
+target_sources(latelib PUBLIC src/late_lib.c include/late_lib.hpp)
 ADD_LIBRARY(upperlib STATIC src/upperlib.c)
 add_library(headers INTERFACE include/headers.hpp)
 add_library(vendored INTERFACE vendor/dep.hpp)
@@ -1227,12 +1231,16 @@ add_executable(headerapp include/headers.hpp)
     await writeFixture(root, "src/upper.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/absin.cpp", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/seven.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/late_main.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/late_util.c", "int late_util(void) { return 0; }\n");
     await writeFixture(root, "src/commented.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "src/util.cpp", "int util() { return 1; }\n");
     await writeFixture(root, "include/core.hpp", "int core(void);\n");
     await writeFixture(root, "src/core.c", "int core(void) { return 1; }\n");
     await writeFixture(root, "src/core_util.c", "int core_util(void) { return 2; }\n");
     await writeFixture(root, "src/dot.c", "int dot(void) { return 1; }\n");
+    await writeFixture(root, "src/late_lib.c", "int late_lib(void) { return 1; }\n");
+    await writeFixture(root, "include/late_lib.hpp", "int late_lib(void);\n");
     await writeFixture(root, "src/upperlib.c", "int upperlib(void) { return 1; }\n");
     await writeFixture(root, "include/headers.hpp", "int header_only(void);\n");
     await writeFixture(root, "vendor/dep.hpp", "int dep(void);\n");
@@ -1242,7 +1250,9 @@ add_executable(headerapp include/headers.hpp)
     const result = await mapFeatures(root, project, []);
     const titles = result.features.map((feature) => feature.title);
     const myapp = result.features.find((feature) => feature.title === "CMake binary myapp");
+    const latebin = result.features.find((feature) => feature.title === "CMake binary latebin");
     const core = result.features.find((feature) => feature.title === "CMake library core");
+    const latelib = result.features.find((feature) => feature.title === "CMake library latelib");
     const headers = result.features.find((feature) => feature.title === "CMake library headers");
     const mainFeatures = result.features.filter(
       (feature) =>
@@ -1256,10 +1266,12 @@ add_executable(headerapp include/headers.hpp)
     expect(titles).toContain("CMake binary upper");
     expect(titles).toContain("CMake binary absin");
     expect(titles).toContain("CMake binary 7zip");
+    expect(titles).toContain("CMake binary latebin");
     expect(titles).not.toContain("CMake binary absout");
     expect(titles).not.toContain("CMake binary commented");
     expect(titles).toContain("CMake library core");
     expect(titles).toContain("CMake library foo.bar");
+    expect(titles).toContain("CMake library latelib");
     expect(titles).toContain("CMake library upperlib");
     expect(titles).toContain("CMake library headers");
     expect(titles).not.toContain("CMake library vendored");
@@ -1277,12 +1289,21 @@ add_executable(headerapp include/headers.hpp)
       { path: "tests/main_test.cpp", reason: "nearby test" },
     ]);
     expect(myapp?.tests).toEqual([{ path: "tests/main_test.cpp", command: null }]);
+    expect(latebin?.entrypoints[0]?.path).toBe("src/late_main.c");
+    expect(latebin?.ownedFiles).toEqual([
+      { path: "src/late_main.c", reason: "target source" },
+      { path: "src/late_util.c", reason: "target source" },
+    ]);
     expect(core?.entrypoints[0]?.path).toBe("src/core.c");
     expect(core?.entrypoints[0]?.symbol).toBeNull();
     expect(core?.ownedFiles).toEqual([
       { path: "include/core.hpp", reason: "target source" },
       { path: "src/core.c", reason: "target source" },
       { path: "src/core_util.c", reason: "target source" },
+    ]);
+    expect(latelib?.ownedFiles).toEqual([
+      { path: "src/late_lib.c", reason: "target source" },
+      { path: "include/late_lib.hpp", reason: "target source" },
     ]);
     expect(headers?.ownedFiles).toEqual([{ path: "include/headers.hpp", reason: "target source" }]);
   });
@@ -1607,6 +1628,22 @@ add_executable(headerapp include/headers.hpp)
 
     expect(app?.tests).toEqual([]);
     expect(app?.contextFiles).toEqual([]);
+  });
+
+  it("attaches plural-suffixed C and C++ tests without mapping them as binaries", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-plural-tests-");
+    await writeFixture(root, "src/app.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/app_tests.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/FooTests.cpp", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "C++ binary app");
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(app?.tests).toEqual([{ path: "src/app_tests.cpp", command: null }]);
+    expect(titles).not.toContain("C++ binary app_tests");
+    expect(titles).not.toContain("C++ binary FooTests");
   });
 
   it("skips dependency trees during C and C++ discovery", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1742,7 +1742,7 @@ add_executable(headerapp include/headers.hpp)
     await writeFixture(
       root,
       "Makefile.in",
-      "bin_PROGRAMS = app\napp_SOURCES = main.c util.c\nlib_LTLIBRARIES = libcore.la\nlibcore_la_SOURCES = core.c\n",
+      "bin_PROGRAMS = app$(EXEEXT)\napp_SOURCES = main.c util.c\nlib_LTLIBRARIES = libcore.la\nlibcore_la_SOURCES = core.c\n",
     );
     await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
     await writeFixture(root, "util.c", "int util(void) { return 1; }\n");
@@ -1883,6 +1883,22 @@ add_executable(headerapp include/headers.hpp)
     const result = await mapFeatures(root, project, []);
 
     expect(result.features.map((feature) => feature.title)).toContain("C++ binary app");
+  });
+
+  it("does not attach dependency C and C++ tests from skipped paths", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-skipped-nearby-tests-");
+    await writeFixture(root, "app.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "vendor/app_test.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "CMakeFiles/app_test.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "cmake-build-debug/app_test.c", "int main(void) { return 0; }\n");
+    await writeFixture(root, "fixtures/app_test.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === "C binary app");
+
+    expect(app?.tests).toEqual([]);
+    expect(app?.contextFiles).toEqual([]);
   });
 
   it("skips dependency trees during C and C++ discovery", async () => {

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -46,12 +46,8 @@ export async function mapFeatures(
   let changed = 0;
   const now = nowIso();
   for (const seed of seeds) {
-    const featureId = stableId("feat", [
-      seed.kind,
-      seed.source,
-      seed.entryPath,
-      seed.command ?? seed.route ?? seed.symbol ?? "",
-    ]);
+    const identity = featureIdentity(seed, existingById);
+    const featureId = identity.featureId;
     const previous = existingById.get(featureId);
     const discoveredTests =
       seed.skipNearbyTests === true
@@ -78,7 +74,7 @@ export async function mapFeatures(
       entrypoints: [
         {
           path: seed.entryPath,
-          symbol: seed.symbol,
+          symbol: identity.symbol,
           route: seed.route,
           command: seed.command,
         },
@@ -119,6 +115,47 @@ export async function mapFeatures(
       (feature) => !features.some((mapped) => mapped.featureId === feature.featureId),
     ).length,
   };
+}
+
+function featureIdentity(
+  seed: FeatureSeed,
+  existingById: Map<string, FeatureRecord>,
+): { featureId: string; symbol: string | null } {
+  const symbol = effectiveSymbol(seed, existingById);
+  return {
+    featureId: stableId("feat", [
+      seed.kind,
+      seed.source,
+      seed.entryPath,
+      seed.command ?? seed.route ?? symbol ?? "",
+    ]),
+    symbol,
+  };
+}
+
+function effectiveSymbol(
+  seed: FeatureSeed,
+  existingById: Map<string, FeatureRecord>,
+): string | null {
+  if (!isDisambiguatedCppLibrary(seed)) {
+    return seed.symbol;
+  }
+  const legacyId = stableId("feat", [seed.kind, seed.source, seed.entryPath, ""]);
+  const previous = existingById.get(legacyId);
+  if (seed.symbol !== null || previous?.title === seed.title) {
+    return previous?.title === seed.title ? null : seed.symbol;
+  }
+  const previousSymbol = disambiguatorFromTitle(seed.title);
+  const previousId = stableId("feat", [seed.kind, seed.source, seed.entryPath, previousSymbol]);
+  return existingById.get(previousId)?.title === seed.title ? previousSymbol : null;
+}
+
+function isDisambiguatedCppLibrary(seed: FeatureSeed): boolean {
+  return seed.kind === "library" && ["cmake-lib", "autotools-lib"].includes(seed.source);
+}
+
+function disambiguatorFromTitle(title: string): string {
+  return title.split(" ").at(-1) ?? title;
 }
 
 function uniqueFileRefs(refs: Array<{ path: string; reason: string }>): Array<{

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -1,5 +1,6 @@
 import { nowIso } from "./fs.js";
 import { stableId } from "./id.js";
+import { cCppSeeds } from "./mappers/c-cpp.js";
 import { configSeeds } from "./mappers/config.js";
 import { goSeeds } from "./mappers/go.js";
 import { appleSeeds } from "./mappers/apple.js";
@@ -26,6 +27,7 @@ const featureMappers: FeatureMapper[] = [
   { name: "go", map: goSeeds },
   { name: "python", map: pythonSeeds },
   { name: "rust", map: rustSeeds },
+  { name: "c-cpp", map: cCppSeeds },
   { name: "swift", map: swiftSeeds },
   { name: "apple", map: appleSeeds },
   { name: "gradle", map: gradleSeeds },

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -64,6 +64,9 @@ export async function mapFeatures(
             seed.entryPath,
             seed.testCommand ?? project.detected.commands.test,
             seed.testPrefixes ?? [],
+            [seed.command, seed.identityKey].filter(
+              (name): name is string => typeof name === "string",
+            ),
           );
     const tests = uniqueTests([...(seed.tests ?? []), ...discoveredTests]);
     const contextFiles = uniqueFileRefs([

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -809,7 +809,7 @@ type CMakeWord = {
 
 function splitWords(value: string): string[] {
   return cmakeWords(value)
-    .flatMap((word) => (word.quoted ? [word.value] : word.value.split(";")))
+    .flatMap((word) => (word.quoted ? [word.value] : splitCMakeUnquotedWord(word.value)))
     .filter((word) => word.length > 0);
 }
 
@@ -840,10 +840,37 @@ function cmakeWords(value: string): CMakeWord[] {
       continue;
     }
     const start = index;
-    while (index < value.length && !/\s/u.test(value[index] ?? "")) {
+    while (index < value.length) {
+      if (value[index] === "\\" && index + 1 < value.length) {
+        index += 2;
+        continue;
+      }
+      if (/\s/u.test(value[index] ?? "")) {
+        break;
+      }
       index += 1;
     }
     words.push({ value: value.slice(start, index), quoted: false });
+  }
+  return words;
+}
+
+function splitCMakeUnquotedWord(value: string): string[] {
+  const words = [""];
+  for (let index = 0; index < value.length; ) {
+    const char = value[index];
+    if (char === "\\" && index + 1 < value.length) {
+      words[words.length - 1] += value[index + 1] ?? "";
+      index += 2;
+      continue;
+    }
+    if (char === ";") {
+      words.push("");
+      index += 1;
+      continue;
+    }
+    words[words.length - 1] += char ?? "";
+    index += 1;
   }
   return words;
 }

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -3,6 +3,7 @@ import { join, relative } from "node:path";
 import {
   isSafeFile,
   isCOrCppTestPath,
+  isSampleProjectPath,
   normalize,
   packageTrustBoundaries,
   stripLineComments,
@@ -12,7 +13,8 @@ import { FeatureSeed } from "./types.js";
 
 export async function cCppSeeds(root: string): Promise<FeatureSeed[]> {
   const files = (await walk(root, [""])).filter(
-    (path) => isCOrCppSource(path) || isMakefile(path) || isCMake(path),
+    (path) =>
+      !isSampleProjectPath(path) && (isCOrCppSource(path) || isMakefile(path) || isCMake(path)),
   );
   if (files.length === 0) {
     return [];
@@ -21,7 +23,9 @@ export async function cCppSeeds(root: string): Promise<FeatureSeed[]> {
   seeds.push(...(await autotoolsTargets(root, files)));
   seeds.push(...(await cmakeTargets(root, files)));
   const alreadySeeded = new Set(
-    seeds.filter((seed) => seed.kind === "cli-command").map((seed) => seed.entryPath),
+    seeds
+      .filter((seed) => seed.kind === "cli-command")
+      .flatMap((seed) => [seed.entryPath, ...(seed.ownedFiles?.map((file) => file.path) ?? [])]),
   );
   seeds.push(...(await mainFunctionTargets(root, files, alreadySeeded)));
   return dedupeByEntry(seeds);
@@ -54,7 +58,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
   const libPattern = /^\s*lib_LTLIBRARIES\s*=\s*(.+)$/gmu;
   for (const makefile of makefiles) {
     const body = collapseBackslashContinuations(
-      await readFile(join(root, makefile), "utf8").catch(() => ""),
+      stripLineComments(await readFile(join(root, makefile), "utf8").catch(() => ""), "#"),
     );
     const dir = parentDir(makefile);
     for (const match of body.matchAll(binPattern)) {
@@ -62,9 +66,9 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
         if (!isValidTargetName(target)) {
           continue;
         }
-        const sources = readTargetSources(body, target);
+        const sources = readTargetSources(body, automakeVariableName(target));
         const sourcePaths = await targetSourcePaths(root, dir, sources);
-        const entryPath = pickEntry(sourcePaths, target) ?? makefile;
+        const entryPath = (await pickExecutableEntry(root, sourcePaths, target)) ?? makefile;
         const tag = languageTag(entryPath);
         seeds.push({
           title: `Autotools binary ${target}`,
@@ -90,7 +94,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
           continue;
         }
         const target = rawTarget.replace(/\.la$/u, "");
-        const sources = readTargetSources(body, rawTarget.replace(/\./gu, "_"));
+        const sources = readTargetSources(body, automakeVariableName(rawTarget));
         const sourcePaths = await targetSourcePaths(root, dir, sources);
         const entryPath = pickEntry(sourcePaths, target) ?? makefile;
         const tag = languageTag(entryPath);
@@ -134,7 +138,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         continue;
       }
       const sourcePaths = await targetSourcePaths(root, dir, splitWords(match[2] ?? ""));
-      const entryPath = pickEntry(sourcePaths, target) ?? cmakeFile;
+      const entryPath = (await pickExecutableEntry(root, sourcePaths, target)) ?? cmakeFile;
       const tag = languageTag(entryPath);
       seeds.push({
         title: `CMake binary ${target}`,
@@ -245,6 +249,20 @@ function splitWords(value: string): string[] {
   return value.split(/\s+/u).filter((word) => word.length > 0);
 }
 
+async function pickExecutableEntry(
+  root: string,
+  candidates: string[],
+  targetName: string,
+): Promise<string | null> {
+  for (const candidate of candidates) {
+    const source = await readFile(join(root, candidate), "utf8").catch(() => "");
+    if (source.length <= 2_000_000 && definesMain(source)) {
+      return candidate;
+    }
+  }
+  return pickEntry(candidates, targetName);
+}
+
 function pickEntry(candidates: string[], targetName: string): string | null {
   if (candidates.length === 0) {
     return null;
@@ -278,6 +296,10 @@ async function targetSourcePaths(root: string, dir: string, sources: string[]): 
 
 function targetSourceRefs(sources: string[]): Array<{ path: string; reason: string }> {
   return sources.map((source) => ({ path: source, reason: "target source" }));
+}
+
+function automakeVariableName(target: string): string {
+  return target.replace(/[^A-Za-z0-9@]/gu, "_");
 }
 
 function prefixDir(dir: string, file: string): string {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -55,76 +55,70 @@ function languageTag(path: string): "c" | "cpp" {
 async function autotoolsTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
   const makefiles = files.filter((file) => file.endsWith("Makefile.am"));
-  const binPattern = /^\s*bin_PROGRAMS\s*=\s*(.+)$/gmu;
-  const libPattern = /^\s*lib_LTLIBRARIES\s*=\s*(.+)$/gmu;
   for (const makefile of makefiles) {
     const body = collapseBackslashContinuations(
       stripLineComments(await readFile(join(root, makefile), "utf8").catch(() => ""), "#"),
     );
     const dir = parentDir(makefile);
-    for (const match of body.matchAll(binPattern)) {
-      for (const target of splitWords(match[1] ?? "")) {
-        if (!isValidTargetName(target)) {
-          continue;
-        }
-        const sources = await automakeTargetSources(root, dir, body, target);
-        const sourcePaths = await targetSourcePaths(root, dir, sources);
-        if (sourcePaths.length === 0) {
-          continue;
-        }
-        const entryPath = await pickExecutableEntry(root, sourcePaths, target);
-        if (entryPath === null) {
-          continue;
-        }
-        const tag = languageTag(entryPath);
-        seeds.push({
-          title: `Autotools binary ${target}`,
-          summary: `Autotools bin_PROGRAMS target declared in ${makefile}.`,
-          kind: "cli-command",
-          source: "autotools-bin",
-          confidence: "high",
-          entryPath,
-          symbol: "main",
-          route: null,
-          command: target,
-          tags: [tag, "cli"],
-          trustBoundaries: ["user-input", "filesystem", "process-exec"],
-          ownedFiles: targetSourceRefs(sourcePaths),
-          contextFiles: [{ path: makefile, reason: "build target declaration" }],
-          testPrefixes: [`${dir}tests`],
-        });
+    for (const target of readVariableWords(body, "bin_PROGRAMS")) {
+      if (!isValidTargetName(target)) {
+        continue;
       }
+      const sources = await automakeTargetSources(root, dir, body, target);
+      const sourcePaths = await targetSourcePaths(root, dir, sources);
+      if (sourcePaths.length === 0) {
+        continue;
+      }
+      const entryPath = await pickExecutableEntry(root, sourcePaths, target);
+      if (entryPath === null) {
+        continue;
+      }
+      const tag = languageTag(entryPath);
+      seeds.push({
+        title: `Autotools binary ${target}`,
+        summary: `Autotools bin_PROGRAMS target declared in ${makefile}.`,
+        kind: "cli-command",
+        source: "autotools-bin",
+        confidence: "high",
+        entryPath,
+        symbol: "main",
+        route: null,
+        command: target,
+        tags: [tag, "cli"],
+        trustBoundaries: ["user-input", "filesystem", "process-exec"],
+        ownedFiles: targetSourceRefs(sourcePaths),
+        contextFiles: [{ path: makefile, reason: "build target declaration" }],
+        testPrefixes: [`${dir}tests`],
+      });
     }
-    for (const match of body.matchAll(libPattern)) {
-      for (const rawTarget of splitWords(match[1] ?? "")) {
-        if (!isValidTargetName(rawTarget)) {
-          continue;
-        }
-        const target = rawTarget.replace(/\.la$/u, "");
-        const sources = readTargetSources(body, automakeVariableName(rawTarget));
-        const sourcePaths = await targetSourcePaths(root, dir, sources);
-        if (sourcePaths.length === 0) {
-          continue;
-        }
-        const entryPath = pickEntry(sourcePaths, target) ?? makefile;
-        const tag = languageTag(entryPath);
-        seeds.push({
-          title: `Autotools library ${target}`,
-          summary: `Autotools lib_LTLIBRARIES target declared in ${makefile}.`,
-          kind: "library",
-          source: "autotools-lib",
-          confidence: "high",
-          entryPath,
-          symbol: null,
-          route: null,
-          command: null,
-          tags: [tag, "library"],
-          trustBoundaries: packageTrustBoundaries(target),
-          ownedFiles: targetSourceRefs(sourcePaths),
-          contextFiles: [{ path: makefile, reason: "build target declaration" }],
-          testPrefixes: [`${dir}tests`],
-        });
+    for (const rawTarget of readVariableWords(body, "lib_LTLIBRARIES")) {
+      if (!isValidTargetName(rawTarget)) {
+        continue;
       }
+      const target = rawTarget.replace(/\.la$/u, "");
+      const sources = readTargetSources(body, automakeVariableName(rawTarget));
+      const sourcePaths = await targetSourcePaths(root, dir, sources);
+      if (sourcePaths.length === 0) {
+        continue;
+      }
+      const entryPath = pickEntry(sourcePaths, target) ?? makefile;
+      const tag = languageTag(entryPath);
+      seeds.push({
+        title: `Autotools library ${target}`,
+        summary: `Autotools lib_LTLIBRARIES target declared in ${makefile}.`,
+        kind: "library",
+        source: "autotools-lib",
+        confidence: "high",
+        entryPath,
+        symbol: null,
+        route: null,
+        command: null,
+        tags: [tag, "library"],
+        trustBoundaries: packageTrustBoundaries(target),
+        ownedFiles: targetSourceRefs(sourcePaths),
+        contextFiles: [{ path: makefile, reason: "build target declaration" }],
+        testPrefixes: [`${dir}tests`],
+      });
     }
   }
   return seeds;
@@ -133,12 +127,13 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
 async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
   const cmakeFiles = files.filter(isCMake);
+  const sourceDirs = await cmakeSourceDirs(root, cmakeFiles);
   const exePattern = /add_executable\s*\(\s*([A-Za-z_][\w-]*)\s+([^)]*)\)/gimsu;
   const libPattern =
     /add_library\s*\(\s*([A-Za-z_][\w-]*)(?:\s+(?:SHARED|STATIC|MODULE|OBJECT|INTERFACE))?\s+([^)]*)\)/gimsu;
   for (const cmakeFile of cmakeFiles) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
-    const dir = parentDir(cmakeFile);
+    const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);
     for (const match of body.matchAll(exePattern)) {
       const target = match[1] ?? "";
       if (!isValidTargetName(target)) {
@@ -202,6 +197,36 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
   return seeds;
 }
 
+async function cmakeSourceDirs(root: string, cmakeFiles: string[]): Promise<Map<string, string>> {
+  const dirs = new Map<string, string>();
+  const cmakeFileSet = new Set(cmakeFiles);
+  for (const cmakeFile of cmakeFiles.filter((file) => file.endsWith("CMakeLists.txt"))) {
+    const dir = parentDir(cmakeFile);
+    dirs.set(cmakeFile, dir);
+    const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
+    for (const include of cmakeIncludes(body)) {
+      const includePath = include.endsWith(".cmake") ? include : `${include}.cmake`;
+      const full = isAbsolute(includePath) ? includePath : join(root, prefixDir(dir, includePath));
+      const rel = normalize(relative(root, full));
+      if (cmakeFileSet.has(rel)) {
+        dirs.set(rel, dir);
+      }
+    }
+  }
+  return dirs;
+}
+
+function cmakeIncludes(body: string): string[] {
+  const includes: string[] = [];
+  for (const match of body.matchAll(/include\s*\(([^)]*)\)/gimsu)) {
+    const path = splitWords(match[1] ?? "")[0];
+    if (path !== undefined && !path.startsWith("$")) {
+      includes.push(path);
+    }
+  }
+  return includes;
+}
+
 async function mainFunctionTargets(
   root: string,
   files: string[],
@@ -255,10 +280,17 @@ function collapseBackslashContinuations(source: string): string {
 }
 
 function readTargetSources(body: string, target: string): string[] {
-  const escaped = target.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  const pattern = new RegExp(`^\\s*${escaped}_SOURCES\\s*=\\s*(.+)$`, "mu");
-  const raw = pattern.exec(body)?.[1] ?? "";
-  return splitWords(raw);
+  return readVariableWords(body, `${target}_SOURCES`);
+}
+
+function readVariableWords(body: string, variable: string): string[] {
+  const words: string[] = [];
+  const escaped = variable.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const pattern = new RegExp(`^\\s*${escaped}\\s*(?:\\+?=)\\s*(.+)$`, "gmu");
+  for (const match of body.matchAll(pattern)) {
+    words.push(...splitWords(match[1] ?? ""));
+  }
+  return words;
 }
 
 function stripCMakeComments(source: string): string {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -619,7 +619,44 @@ function readVariableWords(body: string, variable: string): string[] {
 }
 
 function stripCMakeComments(source: string): string {
-  return stripLineComments(source.replace(/#\[(=*)\[[\s\S]*?\]\1\]/gu, " "), "#");
+  let output = "";
+  for (let index = 0; index < source.length; ) {
+    if (source[index] === '"') {
+      const end = cmakeQuotedEnd(source, index);
+      output += source.slice(index, end);
+      index = end;
+      continue;
+    }
+    const bracketEnd = cmakeBracketEnd(source, index);
+    if (bracketEnd !== null) {
+      output += source.slice(index, bracketEnd);
+      index = bracketEnd;
+      continue;
+    }
+    const bracketComment = /^#\[(=*)\[/u.exec(source.slice(index));
+    if (bracketComment !== null) {
+      const terminator = `]${bracketComment[1] ?? ""}]`;
+      const start = index;
+      const end = source.indexOf(terminator, index + bracketComment[0].length);
+      index = end === -1 ? source.length : end + terminator.length;
+      output += blankComment(source.slice(start, index));
+      continue;
+    }
+    if (source[index] === "#") {
+      const end = source.indexOf("\n", index + 1);
+      const comment = source.slice(index, end === -1 ? source.length : end);
+      output += blankComment(comment);
+      index = end === -1 ? source.length : end;
+      continue;
+    }
+    output += source[index];
+    index += 1;
+  }
+  return output;
+}
+
+function blankComment(source: string): string {
+  return source.replace(/[^\n]/gu, " ");
 }
 
 async function automakeTargetSources(

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -136,7 +136,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         continue;
       }
       const sourcePaths = uniqueStrings([
-        ...(await targetSourcePaths(root, dir, sources, listDir)),
+        ...(await targetSourcePaths(root, dir, sources, listDir, scope)),
         ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
@@ -193,7 +193,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         continue;
       }
       const sourcePaths = uniqueStrings([
-        ...(await targetSourcePaths(root, dir, sources, listDir)),
+        ...(await targetSourcePaths(root, dir, sources, listDir, scope)),
         ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
@@ -249,7 +249,7 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     for (const include of cmakeIncludes(body)) {
       const includePath = include.endsWith(".cmake") ? include : `${include}.cmake`;
-      const full = resolveCMakePath(root, dir, listDir, includePath);
+      const full = resolveCMakePath(root, dir, listDir, scope, includePath);
       if (full === null) {
         continue;
       }
@@ -260,7 +260,7 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
       queueCMakeFile({ file: rel, sourceDir: dir, targetScope: scope }, contexts, pending);
     }
     for (const child of cmakeSubdirectories(body)) {
-      const childFull = resolveCMakePath(root, dir, listDir, child);
+      const childFull = resolveCMakePath(root, dir, listDir, scope, child);
       if (childFull === null) {
         continue;
       }
@@ -318,7 +318,7 @@ async function cmakeTargetSources(
         key,
         uniqueStrings([
           ...existing,
-          ...(await targetSourcePaths(root, dir, sourceTokens, listDir)),
+          ...(await targetSourcePaths(root, dir, sourceTokens, listDir, scope)),
         ]),
       );
     }
@@ -775,13 +775,16 @@ function pickEntry(candidates: string[], targetName: string): string | null {
     return null;
   }
   for (const candidate of candidatesToPick) {
-    if (candidate.split("/").at(-1) === targetName) {
+    const base = candidate.split("/").at(-1) ?? candidate;
+    const stem = base.replace(/\.[^.]+$/u, "");
+    if (stem === targetName) {
       return candidate;
     }
   }
   const preferred = candidatesToPick.find((candidate) => {
     const base = candidate.split("/").at(-1) ?? candidate;
-    return base.startsWith(targetName) || base.startsWith("main.");
+    const stem = base.replace(/\.[^.]+$/u, "");
+    return stem.startsWith(targetName) || base.startsWith("main.");
   });
   if (preferred !== undefined) {
     return preferred;
@@ -795,10 +798,11 @@ async function targetSourcePaths(
   dir: string,
   sources: string[],
   listDir = dir,
+  projectDir = dir,
 ): Promise<string[]> {
   const paths: string[] = [];
   for (const source of sources.filter(isCOrCppSource)) {
-    const full = resolveCMakePath(root, dir, listDir, source);
+    const full = resolveCMakePath(root, dir, listDir, projectDir, source);
     if (full === null) {
       continue;
     }
@@ -819,9 +823,10 @@ function resolveCMakePath(
   root: string,
   sourceDir: string,
   listDir: string,
+  projectDir: string,
   value: string,
 ): string | null {
-  const expanded = expandCMakeDirVariables(root, sourceDir, listDir, value);
+  const expanded = expandCMakeDirVariables(root, sourceDir, listDir, projectDir, value);
   if (expanded.includes("$")) {
     return null;
   }
@@ -832,15 +837,17 @@ function expandCMakeDirVariables(
   root: string,
   sourceDir: string,
   listDir: string,
+  projectDir: string,
   value: string,
 ): string {
   const sourceRoot = join(root, sourceDir);
   const listRoot = join(root, listDir);
+  const projectRoot = join(root, projectDir);
   return value
     .replace(/\$\{CMAKE_CURRENT_SOURCE_DIR\}/gu, sourceRoot)
     .replace(/\$\{CMAKE_CURRENT_LIST_DIR\}/gu, listRoot)
-    .replace(/\$\{CMAKE_SOURCE_DIR\}/gu, root)
-    .replace(/\$\{PROJECT_SOURCE_DIR\}/gu, root);
+    .replace(/\$\{CMAKE_SOURCE_DIR\}/gu, projectRoot)
+    .replace(/\$\{PROJECT_SOURCE_DIR\}/gu, projectRoot);
 }
 
 function isCOrCppDependencyPath(path: string): boolean {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -13,11 +13,9 @@ import {
 import { FeatureSeed } from "./types.js";
 
 export async function cCppSeeds(root: string): Promise<FeatureSeed[]> {
-  const files = (await walk(root, [""])).filter(
+  const files = (await walk(root, [""], shouldSkipCOrCppPath)).filter(
     (path) =>
-      !isCOrCppDependencyPath(path) &&
-      !isSampleProjectPath(path) &&
-      (isCOrCppSource(path) || isMakefile(path) || isCMake(path)),
+      !isSampleProjectPath(path) && (isCOrCppSource(path) || isMakefile(path) || isCMake(path)),
   );
   if (files.length === 0) {
     return [];
@@ -126,8 +124,8 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
 
 async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
-  const cmakeFiles = await referencedCMakeFiles(root, files);
-  const sourceDirs = await cmakeSourceDirs(root, cmakeFiles);
+  const sourceDirs = await referencedCMakeSourceDirs(root, files);
+  const cmakeFiles = [...sourceDirs.keys()];
   const extraSources = await cmakeTargetSources(root, cmakeFiles, sourceDirs);
   const exePattern = /add_executable\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
   const libPattern = /add_library\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
@@ -201,29 +199,38 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
   return seeds;
 }
 
-async function referencedCMakeFiles(root: string, files: string[]): Promise<string[]> {
+async function referencedCMakeSourceDirs(
+  root: string,
+  files: string[],
+): Promise<Map<string, string>> {
   const cmakeFileSet = new Set(files.filter(isCMake));
-  const referenced = new Set(files.filter((file) => file.endsWith("CMakeLists.txt")));
-  const pending = [...referenced];
+  const sourceDirs = new Map<string, string>();
+  const pending: string[] = [];
+  for (const cmakeList of files.filter((file) => file.endsWith("CMakeLists.txt"))) {
+    sourceDirs.set(cmakeList, parentDir(cmakeList));
+    pending.push(cmakeList);
+  }
   while (pending.length > 0) {
     const cmakeFile = pending.shift();
     if (cmakeFile === undefined) {
       continue;
     }
-    const dir = parentDir(cmakeFile);
+    const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     for (const include of cmakeIncludes(body)) {
       const includePath = include.endsWith(".cmake") ? include : `${include}.cmake`;
       const full = isAbsolute(includePath) ? includePath : join(root, prefixDir(dir, includePath));
       const rel = normalize(relative(root, full));
-      if (!cmakeFileSet.has(rel) || referenced.has(rel)) {
+      if (!cmakeFileSet.has(rel) || sourceDirs.has(rel)) {
         continue;
       }
-      referenced.add(rel);
+      sourceDirs.set(rel, dir);
       pending.push(rel);
     }
   }
-  return [...referenced].toSorted();
+  return new Map(
+    [...sourceDirs.entries()].toSorted(([left], [right]) => left.localeCompare(right)),
+  );
 }
 
 async function cmakeTargetSources(
@@ -252,25 +259,6 @@ async function cmakeTargetSources(
     }
   }
   return sources;
-}
-
-async function cmakeSourceDirs(root: string, cmakeFiles: string[]): Promise<Map<string, string>> {
-  const dirs = new Map<string, string>();
-  const cmakeFileSet = new Set(cmakeFiles);
-  for (const cmakeFile of cmakeFiles.filter((file) => file.endsWith("CMakeLists.txt"))) {
-    const dir = parentDir(cmakeFile);
-    dirs.set(cmakeFile, dir);
-    const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
-    for (const include of cmakeIncludes(body)) {
-      const includePath = include.endsWith(".cmake") ? include : `${include}.cmake`;
-      const full = isAbsolute(includePath) ? includePath : join(root, prefixDir(dir, includePath));
-      const rel = normalize(relative(root, full));
-      if (cmakeFileSet.has(rel)) {
-        dirs.set(rel, dir);
-      }
-    }
-  }
-  return dirs;
 }
 
 function cmakeIncludes(body: string): string[] {
@@ -471,6 +459,10 @@ async function targetSourcePaths(root: string, dir: string, sources: string[]): 
 
 function isCOrCppDependencyPath(path: string): boolean {
   return /(^|\/)(vendor|CMakeFiles|cmake-build-[^/]+)(\/|$)/u.test(path);
+}
+
+function shouldSkipCOrCppPath(path: string): boolean {
+  return shouldSkip(path) || isCOrCppDependencyPath(path);
 }
 
 function targetSourceRefs(sources: string[]): Array<{ path: string; reason: string }> {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -125,15 +125,12 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
 
 async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
-  const { sourceDirs, targetScopes } = await referencedCMakeFiles(root, files);
-  const cmakeFiles = [...sourceDirs.keys()];
-  const extraSources = await cmakeTargetSources(root, cmakeFiles, sourceDirs, targetScopes);
+  const { contexts } = await referencedCMakeFiles(root, files);
+  const extraSources = await cmakeTargetSources(root, contexts);
   const exePattern = /add_executable\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
   const libPattern = /add_library\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
-  for (const cmakeFile of cmakeFiles) {
+  for (const { file: cmakeFile, sourceDir: dir, targetScope: scope } of contexts) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
-    const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);
-    const scope = targetScopes.get(cmakeFile) ?? dir;
     for (const match of body.matchAll(exePattern)) {
       const target = match[1] ?? "";
       if (!isValidTargetName(target)) {
@@ -202,28 +199,29 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
 }
 
 type CMakeDiscovery = {
-  sourceDirs: Map<string, string>;
-  targetScopes: Map<string, string>;
+  contexts: CMakeContext[];
+};
+
+type CMakeContext = {
+  file: string;
+  sourceDir: string;
+  targetScope: string;
 };
 
 async function referencedCMakeFiles(root: string, files: string[]): Promise<CMakeDiscovery> {
   const cmakeFileSet = new Set(files.filter(isCMake));
-  const sourceDirs = new Map<string, string>();
-  const targetScopes = new Map<string, string>();
-  const pending: string[] = [];
+  const contexts = new Map<string, CMakeContext>();
+  const pending: CMakeContext[] = [];
   for (const cmakeList of files.filter((file) => file.endsWith("CMakeLists.txt"))) {
     const dir = parentDir(cmakeList);
-    sourceDirs.set(cmakeList, dir);
-    targetScopes.set(cmakeList, dir);
-    pending.push(cmakeList);
+    queueCMakeFile({ file: cmakeList, sourceDir: dir, targetScope: dir }, contexts, pending);
   }
   while (pending.length > 0) {
-    const cmakeFile = pending.shift();
-    if (cmakeFile === undefined) {
+    const context = pending.shift();
+    if (context === undefined) {
       continue;
     }
-    const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);
-    const scope = targetScopes.get(cmakeFile) ?? dir;
+    const { file: cmakeFile, sourceDir: dir, targetScope: scope } = context;
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     for (const include of cmakeIncludes(body)) {
       const includePath = include.endsWith(".cmake") ? include : `${include}.cmake`;
@@ -232,7 +230,7 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
       if (!cmakeFileSet.has(rel)) {
         continue;
       }
-      queueCMakeFile(rel, dir, scope, sourceDirs, targetScopes, pending);
+      queueCMakeFile({ file: rel, sourceDir: dir, targetScope: scope }, contexts, pending);
     }
     for (const child of cmakeSubdirectories(body)) {
       const full = isAbsolute(child) ? child : join(root, prefixDir(dir, child), "CMakeLists.txt");
@@ -240,46 +238,44 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
       if (!cmakeFileSet.has(rel)) {
         continue;
       }
-      queueCMakeFile(rel, parentDir(rel), scope, sourceDirs, targetScopes, pending);
+      queueCMakeFile(
+        { file: rel, sourceDir: parentDir(rel), targetScope: scope },
+        contexts,
+        pending,
+      );
     }
   }
   return {
-    sourceDirs: new Map(
-      [...sourceDirs.entries()].toSorted(([left], [right]) => left.localeCompare(right)),
+    contexts: [...contexts.values()].toSorted((left, right) =>
+      cmakeContextKey(left).localeCompare(cmakeContextKey(right)),
     ),
-    targetScopes,
   };
 }
 
 function queueCMakeFile(
-  file: string,
-  sourceDir: string,
-  targetScope: string,
-  sourceDirs: Map<string, string>,
-  targetScopes: Map<string, string>,
-  pending: string[],
+  context: CMakeContext,
+  contexts: Map<string, CMakeContext>,
+  pending: CMakeContext[],
 ): void {
-  const knownSourceDir = sourceDirs.get(file);
-  const knownScope = targetScopes.get(file);
-  sourceDirs.set(file, knownSourceDir ?? sourceDir);
-  if (knownScope !== targetScope) {
-    targetScopes.set(file, targetScope);
-    pending.push(file);
+  const key = cmakeContextKey(context);
+  if (!contexts.has(key)) {
+    contexts.set(key, context);
+    pending.push(context);
   }
+}
+
+function cmakeContextKey(context: CMakeContext): string {
+  return `${context.file}\0${context.sourceDir}\0${context.targetScope}`;
 }
 
 async function cmakeTargetSources(
   root: string,
-  cmakeFiles: string[],
-  sourceDirs: Map<string, string>,
-  targetScopes: Map<string, string>,
+  contexts: CMakeContext[],
 ): Promise<Map<string, string[]>> {
   const sources = new Map<string, string[]>();
   const pattern = /target_sources\s*\(\s*([A-Za-z0-9_.+-]+)\s+([^)]*)\)/gimsu;
-  for (const cmakeFile of cmakeFiles) {
+  for (const { file: cmakeFile, sourceDir: dir, targetScope: scope } of contexts) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
-    const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);
-    const scope = targetScopes.get(cmakeFile) ?? dir;
     for (const match of body.matchAll(pattern)) {
       const target = match[1] ?? "";
       if (!isValidTargetName(target)) {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -25,7 +25,7 @@ export async function cCppSeeds(root: string): Promise<FeatureSeed[]> {
   seeds.push(...(await cmakeTargets(root, files)));
   const alreadySeeded = new Set(
     seeds
-      .filter((seed) => seed.kind === "cli-command")
+      .filter((seed) => seed.kind === "cli-command" || seed.source === "cmake-test")
       .flatMap((seed) => [seed.entryPath, ...(seed.ownedFiles?.map((file) => file.path) ?? [])]),
   );
   seeds.push(...(await mainFunctionTargets(root, files, alreadySeeded)));
@@ -504,9 +504,12 @@ function readTargetSources(body: string, target: string): string[] {
 function readVariableWords(body: string, variable: string): string[] {
   const words: string[] = [];
   const escaped = variable.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  const pattern = new RegExp(`^\\s*${escaped}\\s*(?:\\+?=)\\s*(.+)$`, "gmu");
+  const pattern = new RegExp(`^\\s*${escaped}\\s*(\\+?=)\\s*(.*)$`, "gmu");
   for (const match of body.matchAll(pattern)) {
-    words.push(...splitWords(match[1] ?? ""));
+    if (match[1] === "=") {
+      words.length = 0;
+    }
+    words.push(...splitWords(match[2] ?? ""));
   }
   return words;
 }

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -127,8 +127,10 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
   const seeds: FeatureSeed[] = [];
   const { contexts } = await referencedCMakeFiles(root, files);
   const extraSources = await cmakeTargetSources(root, contexts);
-  const exePattern = /add_executable\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
-  const libPattern = /add_library\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
+  const exePattern =
+    /(?:^|[^A-Za-z0-9_])add_executable\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
+  const libPattern =
+    /(?:^|[^A-Za-z0-9_])add_library\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
   for (const { file: cmakeFile, sourceDir: dir, targetScope: scope } of contexts) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     for (const match of body.matchAll(exePattern)) {
@@ -297,7 +299,7 @@ async function cmakeTargetSources(
   contexts: CMakeContext[],
 ): Promise<Map<string, string[]>> {
   const sources = new Map<string, string[]>();
-  const pattern = /target_sources\s*\(\s*([A-Za-z0-9_.+-]+)\s+([^)]*)\)/gimsu;
+  const pattern = /(?:^|[^A-Za-z0-9_])target_sources\s*\(\s*([A-Za-z0-9_.+-]+)\s+([^)]*)\)/gimsu;
   for (const { file: cmakeFile, sourceDir: dir, targetScope: scope } of contexts) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     for (const match of body.matchAll(pattern)) {
@@ -329,7 +331,7 @@ function isCMakeTestExecutableTarget(target: string, sourcePaths: string[]): boo
 
 function cmakeIncludes(body: string): string[] {
   const includes: string[] = [];
-  for (const match of body.matchAll(/include\s*\(([^)]*)\)/gimsu)) {
+  for (const match of body.matchAll(/(?:^|[^A-Za-z0-9_])include\s*\(([^)]*)\)/gimsu)) {
     const path = splitWords(match[1] ?? "")[0];
     if (path !== undefined && !path.startsWith("$")) {
       includes.push(path);
@@ -340,7 +342,7 @@ function cmakeIncludes(body: string): string[] {
 
 function cmakeSubdirectories(body: string): string[] {
   const directories: string[] = [];
-  for (const match of body.matchAll(/add_subdirectory\s*\(([^)]*)\)/gimsu)) {
+  for (const match of body.matchAll(/(?:^|[^A-Za-z0-9_])add_subdirectory\s*\(([^)]*)\)/gimsu)) {
     const path = splitWords(match[1] ?? "")[0];
     if (path !== undefined && !path.startsWith("$")) {
       directories.push(path);

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -521,33 +521,38 @@ function cmakeSubdirectories(body: string): string[] {
 
 function cmakeCommandArgs(body: string, command: string): string[] {
   const args: string[] = [];
-  const lower = body.toLowerCase();
   const needle = command.toLowerCase();
   let depth = 0;
+  let blockDepth = 0;
   for (let index = 0; index < body.length; ) {
     const skipped = cmakeQuotedOrBracketEnd(body, index);
     if (skipped !== null) {
       index = skipped;
       continue;
     }
-    if (
-      depth === 0 &&
-      lower.startsWith(needle, index) &&
-      !isIdentifierChar(body[index - 1] ?? "") &&
-      !isIdentifierChar(body[index + needle.length] ?? "")
-    ) {
-      let open = index + needle.length;
-      while (/\s/u.test(body[open] ?? "")) {
-        open += 1;
-      }
-      if (body[open] === "(") {
-        const close = cmakeCommandClose(body, open);
-        if (close !== null) {
-          args.push(body.slice(open + 1, close));
-          index = close + 1;
-          continue;
+    const parsed = depth === 0 ? cmakeCommandAt(body, index) : null;
+    if (parsed !== null) {
+      if (blockDepth > 0) {
+        if (parsed.name === "function" || parsed.name === "macro") {
+          blockDepth += 1;
+        } else if (parsed.name === "endfunction" || parsed.name === "endmacro") {
+          blockDepth = Math.max(0, blockDepth - 1);
         }
+        index = parsed.close + 1;
+        continue;
       }
+      if (parsed.name === "function" || parsed.name === "macro") {
+        blockDepth = 1;
+        index = parsed.close + 1;
+        continue;
+      }
+      if (parsed.name === needle) {
+        args.push(body.slice(parsed.open + 1, parsed.close));
+        index = parsed.close + 1;
+        continue;
+      }
+      index = parsed.close + 1;
+      continue;
     }
     if (body[index] === "(") {
       depth += 1;
@@ -557,6 +562,32 @@ function cmakeCommandArgs(body: string, command: string): string[] {
     index += 1;
   }
   return args;
+}
+
+type CMakeCommandCall = {
+  name: string;
+  open: number;
+  close: number;
+};
+
+function cmakeCommandAt(body: string, index: number): CMakeCommandCall | null {
+  if (isIdentifierChar(body[index - 1] ?? "")) {
+    return null;
+  }
+  const match = /^[A-Za-z_][A-Za-z0-9_]*/u.exec(body.slice(index));
+  if (match === null) {
+    return null;
+  }
+  const name = match[0].toLowerCase();
+  let open = index + match[0].length;
+  while (/\s/u.test(body[open] ?? "")) {
+    open += 1;
+  }
+  if (body[open] !== "(") {
+    return null;
+  }
+  const close = cmakeCommandClose(body, open);
+  return close === null ? null : { name, open, close };
 }
 
 function cmakeCommandClose(body: string, open: number): number | null {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -165,7 +165,11 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         "CMake target declaration",
         extraSources,
       );
-      const testEntryPath = cmakeTestExecutableEntry(target, sourcePaths);
+      const entryPath = await pickExecutableEntry(root, sourcePaths, target);
+      if (entryPath === null) {
+        continue;
+      }
+      const testEntryPath = cmakeTestExecutableEntry(target, entryPath);
       if (testEntryPath !== null) {
         seeds.push({
           title: `CMake test suite ${target}`,
@@ -188,10 +192,6 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
           tests: sourcePaths.filter(isCOrCppTestPath).map((path) => ({ path, command: null })),
           skipNearbyTests: true,
         });
-        continue;
-      }
-      const entryPath = await pickExecutableEntry(root, sourcePaths, target);
-      if (entryPath === null) {
         continue;
       }
       const tag = languageTag(entryPath);
@@ -478,7 +478,7 @@ function cmakeTargetKey(dir: string, target: string): string {
 }
 
 function resolveCMakeTargetName(target: string, projectName: string): string {
-  return target === "${PROJECT_NAME}" && projectName.length > 0 ? projectName : target;
+  return projectName.length > 0 ? target.replace(/\$\{PROJECT_NAME\}/gu, projectName) : target;
 }
 
 function cmakeTargetContextFiles(
@@ -489,11 +489,7 @@ function cmakeTargetContextFiles(
   return uniqueFileRefs([{ path: cmakeFile, reason }, ...(extraSources?.contextFiles ?? [])]);
 }
 
-function cmakeTestExecutableEntry(target: string, sourcePaths: string[]): string | null {
-  const entryPath = pickEntry(sourcePaths, target) ?? sourcePaths[0];
-  if (entryPath === undefined) {
-    return null;
-  }
+function cmakeTestExecutableEntry(target: string, entryPath: string): string | null {
   return /(?:^|[_-])tests?$/iu.test(target) || isCOrCppTestPath(entryPath) ? entryPath : null;
 }
 

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -15,7 +15,9 @@ import { FeatureSeed } from "./types.js";
 export async function cCppSeeds(root: string): Promise<FeatureSeed[]> {
   const files = (await walk(root, [""])).filter(
     (path) =>
-      !isSampleProjectPath(path) && (isCOrCppSource(path) || isMakefile(path) || isCMake(path)),
+      !isCOrCppDependencyPath(path) &&
+      !isSampleProjectPath(path) &&
+      (isCOrCppSource(path) || isMakefile(path) || isCMake(path)),
   );
   if (files.length === 0) {
     return [];
@@ -88,7 +90,6 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
         trustBoundaries: ["user-input", "filesystem", "process-exec"],
         ownedFiles: targetSourceRefs(sourcePaths),
         contextFiles: [{ path: makefile, reason: "build target declaration" }],
-        testPrefixes: [`${dir}tests`],
       });
     }
     for (const rawTarget of readVariableWords(body, "lib_LTLIBRARIES")) {
@@ -117,7 +118,6 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
         trustBoundaries: packageTrustBoundaries(target),
         ownedFiles: targetSourceRefs(sourcePaths),
         contextFiles: [{ path: makefile, reason: "build target declaration" }],
-        testPrefixes: [`${dir}tests`],
       });
     }
   }
@@ -165,7 +165,6 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         trustBoundaries: ["user-input", "filesystem", "process-exec"],
         ownedFiles: targetSourceRefs(sourcePaths),
         contextFiles: [{ path: cmakeFile, reason: "CMake target declaration" }],
-        testPrefixes: [`${dir}tests`],
       });
     }
     for (const match of body.matchAll(libPattern)) {
@@ -196,7 +195,6 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         trustBoundaries: packageTrustBoundaries(target),
         ownedFiles: targetSourceRefs(sourcePaths),
         contextFiles: [{ path: cmakeFile, reason: "CMake target declaration" }],
-        testPrefixes: [`${dir}tests`],
       });
     }
   }
@@ -416,11 +414,20 @@ async function targetSourcePaths(root: string, dir: string, sources: string[]): 
   for (const source of sources.filter(isCOrCppSource)) {
     const full = isAbsolute(source) ? source : join(root, prefixDir(dir, source));
     const rel = normalize(relative(root, full));
-    if (!shouldSkip(rel) && !isSampleProjectPath(rel) && (await isSafeFile(root, full))) {
+    if (
+      !shouldSkip(rel) &&
+      !isCOrCppDependencyPath(rel) &&
+      !isSampleProjectPath(rel) &&
+      (await isSafeFile(root, full))
+    ) {
       paths.push(rel);
     }
   }
   return paths;
+}
+
+function isCOrCppDependencyPath(path: string): boolean {
+  return /(^|\/)vendor(\/|$)/u.test(path);
 }
 
 function targetSourceRefs(sources: string[]): Array<{ path: string; reason: string }> {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import {
   isSafeFile,
   isCOrCppTestPath,
@@ -63,8 +63,8 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
           continue;
         }
         const sources = readTargetSources(body, target);
-        const entryCandidates = sources.filter(isCOrCppCompilable);
-        const entryPath = (await pickEntry(root, dir, entryCandidates, target)) ?? makefile;
+        const sourcePaths = await targetSourcePaths(root, dir, sources);
+        const entryPath = pickEntry(sourcePaths, target) ?? makefile;
         const tag = languageTag(entryPath);
         seeds.push({
           title: `Autotools binary ${target}`,
@@ -78,7 +78,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
           command: target,
           tags: [tag, "cli"],
           trustBoundaries: ["user-input", "filesystem", "process-exec"],
-          ownedFiles: targetSourceRefs(dir, sources),
+          ownedFiles: targetSourceRefs(sourcePaths),
           contextFiles: [{ path: makefile, reason: "build target declaration" }],
           testPrefixes: [`${dir}tests`],
         });
@@ -91,8 +91,8 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
         }
         const target = rawTarget.replace(/\.la$/u, "");
         const sources = readTargetSources(body, rawTarget.replace(/\./gu, "_"));
-        const entryCandidates = sources.filter(isCOrCppCompilable);
-        const entryPath = (await pickEntry(root, dir, entryCandidates, target)) ?? makefile;
+        const sourcePaths = await targetSourcePaths(root, dir, sources);
+        const entryPath = pickEntry(sourcePaths, target) ?? makefile;
         const tag = languageTag(entryPath);
         seeds.push({
           title: `Autotools library ${target}`,
@@ -106,7 +106,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
           command: null,
           tags: [tag, "library"],
           trustBoundaries: packageTrustBoundaries(target),
-          ownedFiles: targetSourceRefs(dir, sources),
+          ownedFiles: targetSourceRefs(sourcePaths),
           contextFiles: [{ path: makefile, reason: "build target declaration" }],
           testPrefixes: [`${dir}tests`],
         });
@@ -133,8 +133,8 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       if (!isValidTargetName(target)) {
         continue;
       }
-      const sources = splitWords(match[2] ?? "").filter(isCOrCppCompilable);
-      const entryPath = (await pickEntry(root, dir, sources, target)) ?? cmakeFile;
+      const sourcePaths = await targetSourcePaths(root, dir, splitWords(match[2] ?? ""));
+      const entryPath = pickEntry(sourcePaths, target) ?? cmakeFile;
       const tag = languageTag(entryPath);
       seeds.push({
         title: `CMake binary ${target}`,
@@ -148,7 +148,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         command: target,
         tags: [tag, "cli"],
         trustBoundaries: ["user-input", "filesystem", "process-exec"],
-        ownedFiles: targetSourceRefs(dir, sources),
+        ownedFiles: targetSourceRefs(sourcePaths),
         contextFiles: [{ path: cmakeFile, reason: "CMake target declaration" }],
         testPrefixes: [`${dir}tests`],
       });
@@ -158,8 +158,8 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       if (!isValidTargetName(target)) {
         continue;
       }
-      const sources = splitWords(match[2] ?? "").filter(isCOrCppCompilable);
-      const entryPath = (await pickEntry(root, dir, sources, target)) ?? cmakeFile;
+      const sourcePaths = await targetSourcePaths(root, dir, splitWords(match[2] ?? ""));
+      const entryPath = pickEntry(sourcePaths, target) ?? cmakeFile;
       const tag = languageTag(entryPath);
       seeds.push({
         title: `CMake library ${target}`,
@@ -173,7 +173,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         command: null,
         tags: [tag, "library"],
         trustBoundaries: packageTrustBoundaries(target),
-        ownedFiles: targetSourceRefs(dir, sources),
+        ownedFiles: targetSourceRefs(sourcePaths),
         contextFiles: [{ path: cmakeFile, reason: "CMake target declaration" }],
         testPrefixes: [`${dir}tests`],
       });
@@ -245,19 +245,13 @@ function splitWords(value: string): string[] {
   return value.split(/\s+/u).filter((word) => word.length > 0);
 }
 
-async function pickEntry(
-  root: string,
-  dir: string,
-  candidates: string[],
-  targetName: string,
-): Promise<string | null> {
+function pickEntry(candidates: string[], targetName: string): string | null {
   if (candidates.length === 0) {
     return null;
   }
   for (const candidate of candidates) {
-    const full = prefixDir(dir, candidate);
-    if ((await isSafeFile(root, join(root, full))) && full.split("/").at(-1) === targetName) {
-      return full;
+    if (candidate.split("/").at(-1) === targetName) {
+      return candidate;
     }
   }
   const preferred = candidates.find((candidate) => {
@@ -265,16 +259,25 @@ async function pickEntry(
     return base.startsWith(targetName) || base.startsWith("main.");
   });
   if (preferred !== undefined) {
-    return prefixDir(dir, preferred);
+    return preferred;
   }
   const first = candidates[0];
-  return first === undefined ? null : prefixDir(dir, first);
+  return first === undefined ? null : first;
 }
 
-function targetSourceRefs(dir: string, sources: string[]): Array<{ path: string; reason: string }> {
-  return sources
-    .filter(isCOrCppCompilable)
-    .map((source) => ({ path: prefixDir(dir, source), reason: "target source" }));
+async function targetSourcePaths(root: string, dir: string, sources: string[]): Promise<string[]> {
+  const paths: string[] = [];
+  for (const source of sources.filter(isCOrCppCompilable)) {
+    const full = join(root, prefixDir(dir, source));
+    if (await isSafeFile(root, full)) {
+      paths.push(normalize(relative(root, full)));
+    }
+  }
+  return paths;
+}
+
+function targetSourceRefs(sources: string[]): Array<{ path: string; reason: string }> {
+  return sources.map((source) => ({ path: source, reason: "target source" }));
 }
 
 function prefixDir(dir: string, file: string): string {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -60,7 +60,8 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
       stripLineComments(await readFile(join(root, makefile), "utf8").catch(() => ""), "#"),
     );
     const dir = parentDir(makefile);
-    for (const target of readVariableWords(body, "bin_PROGRAMS")) {
+    for (const rawTarget of readVariableWords(body, "bin_PROGRAMS")) {
+      const target = normalizeAutomakeProgramTarget(rawTarget);
       if (!isValidTargetName(target)) {
         continue;
       }
@@ -560,6 +561,10 @@ function uniqueStrings(values: string[]): string[] {
 
 function automakeVariableName(target: string): string {
   return target.replace(/[^A-Za-z0-9@]/gu, "_");
+}
+
+function normalizeAutomakeProgramTarget(target: string): string {
+  return target.replace(/\$[({]EXEEXT[)}]|@EXEEXT@/gu, "");
 }
 
 function prefixDir(dir: string, file: string): string {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -440,13 +440,13 @@ function stripCOrCppSyntax(source: string): string {
       const start = index;
       index = quote.start + 1;
       while (index < source.length) {
-        const char = source[index];
-        if (char === "\\") {
+        const literalChar = source[index];
+        if (literalChar === "\\") {
           index += 2;
           continue;
         }
         index += 1;
-        if (char === quote.char) {
+        if (literalChar === quote.char) {
           break;
         }
       }

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -369,11 +369,26 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
       );
     }
   }
+  const discoveredContexts = preferredCMakeContexts([...contexts.values()]);
   return {
-    contexts: [...contexts.values()].toSorted((left, right) =>
+    contexts: discoveredContexts.toSorted((left, right) =>
       cmakeContextKey(left).localeCompare(cmakeContextKey(right)),
     ),
   };
+}
+
+function preferredCMakeContexts(contexts: CMakeContext[]): CMakeContext[] {
+  const byFile = new Map<string, CMakeContext[]>();
+  for (const context of contexts) {
+    byFile.set(context.file, [...(byFile.get(context.file) ?? []), context]);
+  }
+  return contexts.filter((context) => {
+    const fileContexts = byFile.get(context.file) ?? [];
+    if (fileContexts.length < 2 || context.cmakeSourceDir !== context.sourceDir) {
+      return true;
+    }
+    return !fileContexts.some((other) => other.cmakeSourceDir !== context.cmakeSourceDir);
+  });
 }
 
 function queueCMakeFile(

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -470,7 +470,7 @@ async function targetSourcePaths(root: string, dir: string, sources: string[]): 
 }
 
 function isCOrCppDependencyPath(path: string): boolean {
-  return /(^|\/)vendor(\/|$)/u.test(path);
+  return /(^|\/)(vendor|CMakeFiles|cmake-build-[^/]+)(\/|$)/u.test(path);
 }
 
 function targetSourceRefs(sources: string[]): Array<{ path: string; reason: string }> {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -128,6 +128,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
   const { contexts } = await referencedCMakeFiles(root, files);
   const extraSources = await cmakeTargetSources(root, contexts);
   for (const { file: cmakeFile, sourceDir: dir, targetScope: scope } of contexts) {
+    const listDir = parentDir(cmakeFile);
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     for (const args of cmakeCommandArgs(body, "add_executable")) {
       const [target = "", ...sources] = splitWords(args);
@@ -135,7 +136,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         continue;
       }
       const sourcePaths = uniqueStrings([
-        ...(await targetSourcePaths(root, dir, sources)),
+        ...(await targetSourcePaths(root, dir, sources, listDir)),
         ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
@@ -192,7 +193,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         continue;
       }
       const sourcePaths = uniqueStrings([
-        ...(await targetSourcePaths(root, dir, sources)),
+        ...(await targetSourcePaths(root, dir, sources, listDir)),
         ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
@@ -244,10 +245,14 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
       continue;
     }
     const { file: cmakeFile, sourceDir: dir, targetScope: scope } = context;
+    const listDir = parentDir(cmakeFile);
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     for (const include of cmakeIncludes(body)) {
       const includePath = include.endsWith(".cmake") ? include : `${include}.cmake`;
-      const full = isAbsolute(includePath) ? includePath : join(root, prefixDir(dir, includePath));
+      const full = resolveCMakePath(root, dir, listDir, includePath);
+      if (full === null) {
+        continue;
+      }
       const rel = normalize(relative(root, full));
       if (!cmakeFileSet.has(rel)) {
         continue;
@@ -255,7 +260,11 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
       queueCMakeFile({ file: rel, sourceDir: dir, targetScope: scope }, contexts, pending);
     }
     for (const child of cmakeSubdirectories(body)) {
-      const full = isAbsolute(child) ? child : join(root, prefixDir(dir, child), "CMakeLists.txt");
+      const childFull = resolveCMakePath(root, dir, listDir, child);
+      if (childFull === null) {
+        continue;
+      }
+      const full = join(childFull, "CMakeLists.txt");
       const rel = normalize(relative(root, full));
       if (!cmakeFileSet.has(rel)) {
         continue;
@@ -296,6 +305,7 @@ async function cmakeTargetSources(
 ): Promise<Map<string, string[]>> {
   const sources = new Map<string, string[]>();
   for (const { file: cmakeFile, sourceDir: dir, targetScope: scope } of contexts) {
+    const listDir = parentDir(cmakeFile);
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     for (const args of cmakeCommandArgs(body, "target_sources")) {
       const [target = "", ...sourceTokens] = splitWords(args);
@@ -306,7 +316,10 @@ async function cmakeTargetSources(
       const existing = sources.get(key) ?? [];
       sources.set(
         key,
-        uniqueStrings([...existing, ...(await targetSourcePaths(root, dir, sourceTokens))]),
+        uniqueStrings([
+          ...existing,
+          ...(await targetSourcePaths(root, dir, sourceTokens, listDir)),
+        ]),
       );
     }
   }
@@ -325,7 +338,7 @@ function cmakeIncludes(body: string): string[] {
   const includes: string[] = [];
   for (const args of cmakeCommandArgs(body, "include")) {
     const path = splitWords(args)[0];
-    if (path !== undefined && !path.startsWith("$")) {
+    if (path !== undefined) {
       includes.push(path);
     }
   }
@@ -336,7 +349,7 @@ function cmakeSubdirectories(body: string): string[] {
   const directories: string[] = [];
   for (const args of cmakeCommandArgs(body, "add_subdirectory")) {
     const path = splitWords(args)[0];
-    if (path !== undefined && !path.startsWith("$")) {
+    if (path !== undefined) {
       directories.push(path);
     }
   }
@@ -777,10 +790,18 @@ function pickEntry(candidates: string[], targetName: string): string | null {
   return first === undefined ? null : first;
 }
 
-async function targetSourcePaths(root: string, dir: string, sources: string[]): Promise<string[]> {
+async function targetSourcePaths(
+  root: string,
+  dir: string,
+  sources: string[],
+  listDir = dir,
+): Promise<string[]> {
   const paths: string[] = [];
   for (const source of sources.filter(isCOrCppSource)) {
-    const full = isAbsolute(source) ? source : join(root, prefixDir(dir, source));
+    const full = resolveCMakePath(root, dir, listDir, source);
+    if (full === null) {
+      continue;
+    }
     const rel = normalize(relative(root, full));
     if (
       !shouldSkip(rel) &&
@@ -792,6 +813,34 @@ async function targetSourcePaths(root: string, dir: string, sources: string[]): 
     }
   }
   return paths;
+}
+
+function resolveCMakePath(
+  root: string,
+  sourceDir: string,
+  listDir: string,
+  value: string,
+): string | null {
+  const expanded = expandCMakeDirVariables(root, sourceDir, listDir, value);
+  if (expanded.includes("$")) {
+    return null;
+  }
+  return isAbsolute(expanded) ? expanded : join(root, prefixDir(sourceDir, expanded));
+}
+
+function expandCMakeDirVariables(
+  root: string,
+  sourceDir: string,
+  listDir: string,
+  value: string,
+): string {
+  const sourceRoot = join(root, sourceDir);
+  const listRoot = join(root, listDir);
+  return value
+    .replace(/\$\{CMAKE_CURRENT_SOURCE_DIR\}/gu, sourceRoot)
+    .replace(/\$\{CMAKE_CURRENT_LIST_DIR\}/gu, listRoot)
+    .replace(/\$\{CMAKE_SOURCE_DIR\}/gu, root)
+    .replace(/\$\{PROJECT_SOURCE_DIR\}/gu, root);
 }
 
 function isCOrCppDependencyPath(path: string): boolean {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -470,7 +470,9 @@ function splitWords(value: string): string[] {
   return value
     .split(/\s+/u)
     .filter((word) => word.length > 0)
-    .map(unquoteWord);
+    .map(unquoteWord)
+    .flatMap((word) => word.split(";"))
+    .filter((word) => word.length > 0);
 }
 
 function unquoteWord(value: string): string {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -128,9 +128,9 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
   const seeds: FeatureSeed[] = [];
   const cmakeFiles = files.filter(isCMake);
   const sourceDirs = await cmakeSourceDirs(root, cmakeFiles);
-  const exePattern = /add_executable\s*\(\s*([A-Za-z_][\w-]*)\s+([^)]*)\)/gimsu;
+  const exePattern = /add_executable\s*\(\s*([A-Za-z0-9_.+-]+)\s+([^)]*)\)/gimsu;
   const libPattern =
-    /add_library\s*\(\s*([A-Za-z_][\w-]*)(?:\s+(?:SHARED|STATIC|MODULE|OBJECT|INTERFACE))?\s+([^)]*)\)/gimsu;
+    /add_library\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+(?:SHARED|STATIC|MODULE|OBJECT|INTERFACE))?\s+([^)]*)\)/gimsu;
   for (const cmakeFile of cmakeFiles) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -6,6 +6,7 @@ import {
   isSampleProjectPath,
   normalize,
   packageTrustBoundaries,
+  shouldSkip,
   stripLineComments,
   walk,
 } from "./shared.js";
@@ -66,9 +67,15 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
         if (!isValidTargetName(target)) {
           continue;
         }
-        const sources = readTargetSources(body, automakeVariableName(target));
+        const sources = await automakeTargetSources(root, dir, body, target);
         const sourcePaths = await targetSourcePaths(root, dir, sources);
-        const entryPath = (await pickExecutableEntry(root, sourcePaths, target)) ?? makefile;
+        if (sourcePaths.length === 0) {
+          continue;
+        }
+        const entryPath = await pickExecutableEntry(root, sourcePaths, target);
+        if (entryPath === null) {
+          continue;
+        }
         const tag = languageTag(entryPath);
         seeds.push({
           title: `Autotools binary ${target}`,
@@ -96,6 +103,9 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
         const target = rawTarget.replace(/\.la$/u, "");
         const sources = readTargetSources(body, automakeVariableName(rawTarget));
         const sourcePaths = await targetSourcePaths(root, dir, sources);
+        if (sourcePaths.length === 0) {
+          continue;
+        }
         const entryPath = pickEntry(sourcePaths, target) ?? makefile;
         const tag = languageTag(entryPath);
         seeds.push({
@@ -138,7 +148,13 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         continue;
       }
       const sourcePaths = await targetSourcePaths(root, dir, splitWords(match[2] ?? ""));
-      const entryPath = (await pickExecutableEntry(root, sourcePaths, target)) ?? cmakeFile;
+      if (sourcePaths.length === 0) {
+        continue;
+      }
+      const entryPath = await pickExecutableEntry(root, sourcePaths, target);
+      if (entryPath === null) {
+        continue;
+      }
       const tag = languageTag(entryPath);
       seeds.push({
         title: `CMake binary ${target}`,
@@ -163,6 +179,9 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         continue;
       }
       const sourcePaths = await targetSourcePaths(root, dir, splitWords(match[2] ?? ""));
+      if (sourcePaths.length === 0) {
+        continue;
+      }
       const entryPath = pickEntry(sourcePaths, target) ?? cmakeFile;
       const tag = languageTag(entryPath);
       seeds.push({
@@ -245,8 +264,44 @@ function readTargetSources(body: string, target: string): string[] {
   return splitWords(raw);
 }
 
+async function automakeTargetSources(
+  root: string,
+  dir: string,
+  body: string,
+  target: string,
+): Promise<string[]> {
+  const sources = readTargetSources(body, automakeVariableName(target));
+  if (sources.length > 0) {
+    return sources;
+  }
+  return defaultAutomakeSources(root, dir, target);
+}
+
+async function defaultAutomakeSources(
+  root: string,
+  dir: string,
+  target: string,
+): Promise<string[]> {
+  const defaultSources = [`${target}.c`];
+  const existing: string[] = [];
+  for (const source of defaultSources) {
+    if (await isSafeFile(root, join(root, prefixDir(dir, source)))) {
+      existing.push(source);
+    }
+  }
+  return existing;
+}
+
 function splitWords(value: string): string[] {
-  return value.split(/\s+/u).filter((word) => word.length > 0);
+  return value
+    .split(/\s+/u)
+    .filter((word) => word.length > 0)
+    .map(unquoteWord);
+}
+
+function unquoteWord(value: string): string {
+  const quote = value[0];
+  return (quote === '"' || quote === "'") && value.endsWith(quote) ? value.slice(1, -1) : value;
 }
 
 async function pickExecutableEntry(
@@ -254,41 +309,48 @@ async function pickExecutableEntry(
   candidates: string[],
   targetName: string,
 ): Promise<string | null> {
-  for (const candidate of candidates) {
+  const compilableCandidates = candidates.filter(isCOrCppCompilable);
+  if (compilableCandidates.length === 0) {
+    return null;
+  }
+  for (const candidate of compilableCandidates) {
     const source = await readFile(join(root, candidate), "utf8").catch(() => "");
     if (source.length <= 2_000_000 && definesMain(source)) {
       return candidate;
     }
   }
-  return pickEntry(candidates, targetName);
+  return pickEntry(compilableCandidates, targetName);
 }
 
 function pickEntry(candidates: string[], targetName: string): string | null {
-  if (candidates.length === 0) {
+  const entryCandidates = candidates.filter(isCOrCppCompilable);
+  const candidatesToPick = entryCandidates.length > 0 ? entryCandidates : candidates;
+  if (candidatesToPick.length === 0) {
     return null;
   }
-  for (const candidate of candidates) {
+  for (const candidate of candidatesToPick) {
     if (candidate.split("/").at(-1) === targetName) {
       return candidate;
     }
   }
-  const preferred = candidates.find((candidate) => {
+  const preferred = candidatesToPick.find((candidate) => {
     const base = candidate.split("/").at(-1) ?? candidate;
     return base.startsWith(targetName) || base.startsWith("main.");
   });
   if (preferred !== undefined) {
     return preferred;
   }
-  const first = candidates[0];
+  const first = candidatesToPick[0];
   return first === undefined ? null : first;
 }
 
 async function targetSourcePaths(root: string, dir: string, sources: string[]): Promise<string[]> {
   const paths: string[] = [];
-  for (const source of sources.filter(isCOrCppCompilable)) {
+  for (const source of sources.filter(isCOrCppSource)) {
     const full = join(root, prefixDir(dir, source));
-    if (await isSafeFile(root, full)) {
-      paths.push(normalize(relative(root, full)));
+    const rel = normalize(relative(root, full));
+    if (!shouldSkip(rel) && (await isSafeFile(root, full))) {
+      paths.push(rel);
     }
   }
   return paths;
@@ -333,12 +395,37 @@ function dedupeByEntry(seeds: FeatureSeed[]): FeatureSeed[] {
   const seen = new Set<string>();
   const output: FeatureSeed[] = [];
   for (const seed of seeds) {
-    const key = `${seed.entryPath}:${seed.kind}`;
+    const key = `${seed.entryPath}:${seed.kind}:${seed.command ?? seed.symbol ?? seed.title}`;
     if (seen.has(key)) {
       continue;
     }
     seen.add(key);
     output.push(seed);
   }
-  return output;
+  return disambiguateFeatureIdCollisions(output);
+}
+
+function disambiguateFeatureIdCollisions(seeds: FeatureSeed[]): FeatureSeed[] {
+  const counts = new Map<string, number>();
+  for (const seed of seeds) {
+    const key = featureIdCollisionKey(seed);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return seeds.map((seed) => {
+    if ((counts.get(featureIdCollisionKey(seed)) ?? 0) < 2) {
+      return seed;
+    }
+    if (seed.kind !== "library" || seed.symbol !== null) {
+      return seed;
+    }
+    return { ...seed, symbol: disambiguatorFromTitle(seed.title) };
+  });
+}
+
+function featureIdCollisionKey(seed: FeatureSeed): string {
+  return `${seed.kind}:${seed.source}:${seed.entryPath}:${seed.command ?? seed.route ?? seed.symbol ?? ""}`;
+}
+
+function disambiguatorFromTitle(title: string): string {
+  return title.split(" ").at(-1) ?? title;
 }

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -387,7 +387,7 @@ async function mainFunctionTargets(
 }
 
 function definesMain(source: string): boolean {
-  const stripped = stripCOrCppComments(stripCOrCppLiterals(source));
+  const stripped = stripCOrCppSyntax(source);
   if (!stripped.includes("main")) {
     return false;
   }
@@ -401,7 +401,7 @@ function definesMain(source: string): boolean {
   return false;
 }
 
-function stripCOrCppComments(source: string): string {
+function stripCOrCppSyntax(source: string): string {
   let stripped = "";
   for (let index = 0; index < source.length; ) {
     const char = source[index];
@@ -429,15 +429,6 @@ function stripCOrCppComments(source: string): string {
       }
       continue;
     }
-    stripped += char;
-    index += 1;
-  }
-  return stripped;
-}
-
-function stripCOrCppLiterals(source: string): string {
-  let stripped = "";
-  for (let index = 0; index < source.length; ) {
     const raw = rawStringLiteralEnd(source, index);
     if (raw !== null) {
       stripped += blankLiteral(source.slice(index, raw));

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -33,11 +33,11 @@ export async function cCppSeeds(root: string): Promise<FeatureSeed[]> {
 }
 
 function isCOrCppSource(path: string): boolean {
-  return /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/u.test(path);
+  return /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/iu.test(path);
 }
 
 function isCOrCppCompilable(path: string): boolean {
-  return /\.(?:c|cc|cpp|cxx)$/u.test(path);
+  return /\.(?:c|cc|cpp|cxx)$/iu.test(path);
 }
 
 function isMakefile(path: string): boolean {
@@ -49,7 +49,7 @@ function isCMake(path: string): boolean {
 }
 
 function languageTag(path: string): "c" | "cpp" {
-  return /\.(?:cc|cpp|cxx|hh|hpp|hxx)$/u.test(path) ? "cpp" : "c";
+  return /\.(?:C|H)$/u.test(path) || /\.(?:cc|cpp|cxx|hh|hpp|hxx)$/iu.test(path) ? "cpp" : "c";
 }
 
 async function autotoolsTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
@@ -416,7 +416,7 @@ async function targetSourcePaths(root: string, dir: string, sources: string[]): 
   for (const source of sources.filter(isCOrCppSource)) {
     const full = isAbsolute(source) ? source : join(root, prefixDir(dir, source));
     const rel = normalize(relative(root, full));
-    if (!shouldSkip(rel) && (await isSafeFile(root, full))) {
+    if (!shouldSkip(rel) && !isSampleProjectPath(rel) && (await isSafeFile(root, full))) {
       paths.push(rel);
     }
   }

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -143,6 +143,30 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       if (sourcePaths.length === 0) {
         continue;
       }
+      if (isCMakeTestExecutableTarget(target, sourcePaths)) {
+        const entryPath = pickEntry(sourcePaths, target) ?? sourcePaths[0];
+        if (entryPath === undefined) {
+          continue;
+        }
+        seeds.push({
+          title: `CMake test suite ${target}`,
+          summary: `CMake test executable ${target} declared in ${cmakeFile}.`,
+          kind: "test-suite",
+          source: "cmake-test",
+          confidence: "high",
+          entryPath,
+          symbol: null,
+          route: null,
+          command: null,
+          tags: [languageTag(entryPath), "test"],
+          trustBoundaries: [],
+          ownedFiles: targetSourceRefs(sourcePaths),
+          contextFiles: [{ path: cmakeFile, reason: "CMake test target declaration" }],
+          tests: sourcePaths.filter(isCOrCppTestPath).map((path) => ({ path, command: null })),
+          skipNearbyTests: true,
+        });
+        continue;
+      }
       const entryPath = await pickExecutableEntry(root, sourcePaths, target);
       if (entryPath === null) {
         continue;
@@ -297,6 +321,10 @@ async function cmakeTargetSources(
 
 function cmakeTargetKey(dir: string, target: string): string {
   return `${dir}\0${target}`;
+}
+
+function isCMakeTestExecutableTarget(target: string, sourcePaths: string[]): boolean {
+  return /(?:^|[_-])tests?$/iu.test(target) || sourcePaths.some(isCOrCppTestPath);
 }
 
 function cmakeIncludes(body: string): string[] {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -126,7 +126,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
 
 async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
-  const cmakeFiles = files.filter(isCMake);
+  const cmakeFiles = await referencedCMakeFiles(root, files);
   const sourceDirs = await cmakeSourceDirs(root, cmakeFiles);
   const extraSources = await cmakeTargetSources(root, cmakeFiles, sourceDirs);
   const exePattern = /add_executable\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
@@ -199,6 +199,31 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
     }
   }
   return seeds;
+}
+
+async function referencedCMakeFiles(root: string, files: string[]): Promise<string[]> {
+  const cmakeFileSet = new Set(files.filter(isCMake));
+  const referenced = new Set(files.filter((file) => file.endsWith("CMakeLists.txt")));
+  const pending = [...referenced];
+  while (pending.length > 0) {
+    const cmakeFile = pending.shift();
+    if (cmakeFile === undefined) {
+      continue;
+    }
+    const dir = parentDir(cmakeFile);
+    const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
+    for (const include of cmakeIncludes(body)) {
+      const includePath = include.endsWith(".cmake") ? include : `${include}.cmake`;
+      const full = isAbsolute(includePath) ? includePath : join(root, prefixDir(dir, includePath));
+      const rel = normalize(relative(root, full));
+      if (!cmakeFileSet.has(rel) || referenced.has(rel)) {
+        continue;
+      }
+      referenced.add(rel);
+      pending.push(rel);
+    }
+  }
+  return [...referenced].toSorted();
 }
 
 async function cmakeTargetSources(
@@ -298,13 +323,31 @@ async function mainFunctionTargets(
 
 function definesMain(source: string): boolean {
   const stripped = stripBlockComments(stripLineComments(source, "//"));
-  return /(?:^|[;{}\n])\s*(?:extern\s+"C"\s*)?(?:[\w:<>~*&\s]+\s+)+main\s*\([^;{}]*\)\s*(?:noexcept\s*)?(?:->\s*[\w:<>~*&\s]+)?\s*\{/u.test(
-    stripped,
-  );
+  const pattern =
+    /(?:^|[;\n])\s*(?:extern\s+"C"\s*)?(?:[\w:<>~*&\s]+\s+)+main\s*\([^;{}]*\)\s*(?:noexcept\s*)?(?:->\s*[\w:<>~*&\s]+)?\s*\{/gmu;
+  for (const match of stripped.matchAll(pattern)) {
+    if (braceDepthBefore(stripped, match.index) === 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function stripBlockComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//gu, " ");
+}
+
+function braceDepthBefore(source: string, end: number): number {
+  let depth = 0;
+  for (let index = 0; index < end; index += 1) {
+    const char = source[index];
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth = Math.max(0, depth - 1);
+    }
+  }
+  return depth;
 }
 
 function collapseBackslashContinuations(source: string): string {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -127,16 +127,30 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
   const seeds: FeatureSeed[] = [];
   const { contexts } = await referencedCMakeFiles(root, files);
   const extraSources = await cmakeTargetSources(root, contexts);
-  for (const { file: cmakeFile, sourceDir: dir, targetScope: scope } of contexts) {
+  for (const {
+    file: cmakeFile,
+    sourceDir: dir,
+    targetScope: scope,
+    cmakeSourceDir,
+    projectSourceDir,
+  } of contexts) {
     const listDir = parentDir(cmakeFile);
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
+    const effectiveProjectSourceDir = cmakeDeclaresProject(body) ? dir : projectSourceDir;
     for (const args of cmakeCommandArgs(body, "add_executable")) {
       const [target = "", ...sources] = splitWords(args);
       if (!isValidTargetName(target)) {
         continue;
       }
       const sourcePaths = uniqueStrings([
-        ...(await targetSourcePaths(root, dir, sources, listDir, scope)),
+        ...(await targetSourcePaths(
+          root,
+          dir,
+          sources,
+          listDir,
+          cmakeSourceDir,
+          effectiveProjectSourceDir,
+        )),
         ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
@@ -193,7 +207,14 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         continue;
       }
       const sourcePaths = uniqueStrings([
-        ...(await targetSourcePaths(root, dir, sources, listDir, scope)),
+        ...(await targetSourcePaths(
+          root,
+          dir,
+          sources,
+          listDir,
+          cmakeSourceDir,
+          effectiveProjectSourceDir,
+        )),
         ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
@@ -229,6 +250,8 @@ type CMakeContext = {
   file: string;
   sourceDir: string;
   targetScope: string;
+  cmakeSourceDir: string;
+  projectSourceDir: string;
 };
 
 async function referencedCMakeFiles(root: string, files: string[]): Promise<CMakeDiscovery> {
@@ -237,19 +260,43 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
   const pending: CMakeContext[] = [];
   for (const cmakeList of files.filter((file) => file.endsWith("CMakeLists.txt"))) {
     const dir = parentDir(cmakeList);
-    queueCMakeFile({ file: cmakeList, sourceDir: dir, targetScope: dir }, contexts, pending);
+    queueCMakeFile(
+      {
+        file: cmakeList,
+        sourceDir: dir,
+        targetScope: dir,
+        cmakeSourceDir: dir,
+        projectSourceDir: dir,
+      },
+      contexts,
+      pending,
+    );
   }
   while (pending.length > 0) {
     const context = pending.shift();
     if (context === undefined) {
       continue;
     }
-    const { file: cmakeFile, sourceDir: dir, targetScope: scope } = context;
+    const {
+      file: cmakeFile,
+      sourceDir: dir,
+      targetScope: scope,
+      cmakeSourceDir,
+      projectSourceDir,
+    } = context;
     const listDir = parentDir(cmakeFile);
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
+    const effectiveProjectSourceDir = cmakeDeclaresProject(body) ? dir : projectSourceDir;
     for (const include of cmakeIncludes(body)) {
       const includePath = include.endsWith(".cmake") ? include : `${include}.cmake`;
-      const full = resolveCMakePath(root, dir, listDir, scope, includePath);
+      const full = resolveCMakePath(
+        root,
+        dir,
+        listDir,
+        cmakeSourceDir,
+        effectiveProjectSourceDir,
+        includePath,
+      );
       if (full === null) {
         continue;
       }
@@ -257,10 +304,27 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
       if (!cmakeFileSet.has(rel)) {
         continue;
       }
-      queueCMakeFile({ file: rel, sourceDir: dir, targetScope: scope }, contexts, pending);
+      queueCMakeFile(
+        {
+          file: rel,
+          sourceDir: dir,
+          targetScope: scope,
+          cmakeSourceDir,
+          projectSourceDir: effectiveProjectSourceDir,
+        },
+        contexts,
+        pending,
+      );
     }
     for (const child of cmakeSubdirectories(body)) {
-      const childFull = resolveCMakePath(root, dir, listDir, scope, child);
+      const childFull = resolveCMakePath(
+        root,
+        dir,
+        listDir,
+        cmakeSourceDir,
+        effectiveProjectSourceDir,
+        child,
+      );
       if (childFull === null) {
         continue;
       }
@@ -270,7 +334,13 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
         continue;
       }
       queueCMakeFile(
-        { file: rel, sourceDir: parentDir(rel), targetScope: scope },
+        {
+          file: rel,
+          sourceDir: parentDir(rel),
+          targetScope: scope,
+          cmakeSourceDir,
+          projectSourceDir: effectiveProjectSourceDir,
+        },
         contexts,
         pending,
       );
@@ -296,7 +366,13 @@ function queueCMakeFile(
 }
 
 function cmakeContextKey(context: CMakeContext): string {
-  return `${context.file}\0${context.sourceDir}\0${context.targetScope}`;
+  return [
+    context.file,
+    context.sourceDir,
+    context.targetScope,
+    context.cmakeSourceDir,
+    context.projectSourceDir,
+  ].join("\0");
 }
 
 async function cmakeTargetSources(
@@ -304,9 +380,16 @@ async function cmakeTargetSources(
   contexts: CMakeContext[],
 ): Promise<Map<string, string[]>> {
   const sources = new Map<string, string[]>();
-  for (const { file: cmakeFile, sourceDir: dir, targetScope: scope } of contexts) {
+  for (const {
+    file: cmakeFile,
+    sourceDir: dir,
+    targetScope: scope,
+    cmakeSourceDir,
+    projectSourceDir,
+  } of contexts) {
     const listDir = parentDir(cmakeFile);
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
+    const effectiveProjectSourceDir = cmakeDeclaresProject(body) ? dir : projectSourceDir;
     for (const args of cmakeCommandArgs(body, "target_sources")) {
       const [target = "", ...sourceTokens] = splitWords(args);
       if (!isValidTargetName(target)) {
@@ -318,12 +401,23 @@ async function cmakeTargetSources(
         key,
         uniqueStrings([
           ...existing,
-          ...(await targetSourcePaths(root, dir, sourceTokens, listDir, scope)),
+          ...(await targetSourcePaths(
+            root,
+            dir,
+            sourceTokens,
+            listDir,
+            cmakeSourceDir,
+            effectiveProjectSourceDir,
+          )),
         ]),
       );
     }
   }
   return sources;
+}
+
+function cmakeDeclaresProject(body: string): boolean {
+  return cmakeCommandArgs(body, "project").length > 0;
 }
 
 function cmakeTargetKey(dir: string, target: string): string {
@@ -798,11 +892,12 @@ async function targetSourcePaths(
   dir: string,
   sources: string[],
   listDir = dir,
-  projectDir = dir,
+  cmakeSourceDir = dir,
+  projectSourceDir = dir,
 ): Promise<string[]> {
   const paths: string[] = [];
   for (const source of sources.filter(isCOrCppSource)) {
-    const full = resolveCMakePath(root, dir, listDir, projectDir, source);
+    const full = resolveCMakePath(root, dir, listDir, cmakeSourceDir, projectSourceDir, source);
     if (full === null) {
       continue;
     }
@@ -823,10 +918,18 @@ function resolveCMakePath(
   root: string,
   sourceDir: string,
   listDir: string,
-  projectDir: string,
+  cmakeSourceDir: string,
+  projectSourceDir: string,
   value: string,
 ): string | null {
-  const expanded = expandCMakeDirVariables(root, sourceDir, listDir, projectDir, value);
+  const expanded = expandCMakeDirVariables(
+    root,
+    sourceDir,
+    listDir,
+    cmakeSourceDir,
+    projectSourceDir,
+    value,
+  );
   if (expanded.includes("$")) {
     return null;
   }
@@ -837,16 +940,18 @@ function expandCMakeDirVariables(
   root: string,
   sourceDir: string,
   listDir: string,
-  projectDir: string,
+  cmakeSourceDir: string,
+  projectSourceDir: string,
   value: string,
 ): string {
   const sourceRoot = join(root, sourceDir);
   const listRoot = join(root, listDir);
-  const projectRoot = join(root, projectDir);
+  const cmakeRoot = join(root, cmakeSourceDir);
+  const projectRoot = join(root, projectSourceDir);
   return value
     .replace(/\$\{CMAKE_CURRENT_SOURCE_DIR\}/gu, sourceRoot)
     .replace(/\$\{CMAKE_CURRENT_LIST_DIR\}/gu, listRoot)
-    .replace(/\$\{CMAKE_SOURCE_DIR\}/gu, projectRoot)
+    .replace(/\$\{CMAKE_SOURCE_DIR\}/gu, cmakeRoot)
     .replace(/\$\{PROJECT_SOURCE_DIR\}/gu, projectRoot);
 }
 

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -54,7 +54,7 @@ function languageTag(path: string): "c" | "cpp" {
 
 async function autotoolsTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
-  const makefiles = files.filter((file) => file.endsWith("Makefile.am"));
+  const makefiles = files.filter(isMakefile);
   for (const makefile of makefiles) {
     const body = collapseBackslashContinuations(
       stripLineComments(await readFile(join(root, makefile), "utf8").catch(() => ""), "#"),
@@ -315,7 +315,7 @@ async function mainFunctionTargets(
 }
 
 function definesMain(source: string): boolean {
-  const stripped = stripCOrCppLiterals(stripBlockComments(stripLineComments(source, "//")));
+  const stripped = stripLineComments(stripBlockComments(stripCOrCppLiterals(source)), "//");
   const pattern =
     /(?:^|[;\n])\s*(?:extern\s+"C"\s*)?(?:[\w:<>~*&\s]+\s+)+main\s*\([^;{}]*\)\s*(?:noexcept\s*)?(?:->\s*[\w:<>~*&\s]+)?\s*\{/gmu;
   for (const match of stripped.matchAll(pattern)) {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -310,7 +310,7 @@ async function mainFunctionTargets(
 }
 
 function definesMain(source: string): boolean {
-  const stripped = stripBlockComments(stripLineComments(source, "//"));
+  const stripped = stripCOrCppLiterals(stripBlockComments(stripLineComments(source, "//")));
   const pattern =
     /(?:^|[;\n])\s*(?:extern\s+"C"\s*)?(?:[\w:<>~*&\s]+\s+)+main\s*\([^;{}]*\)\s*(?:noexcept\s*)?(?:->\s*[\w:<>~*&\s]+)?\s*\{/gmu;
   for (const match of stripped.matchAll(pattern)) {
@@ -323,6 +323,84 @@ function definesMain(source: string): boolean {
 
 function stripBlockComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//gu, " ");
+}
+
+function stripCOrCppLiterals(source: string): string {
+  let stripped = "";
+  for (let index = 0; index < source.length; ) {
+    const raw = rawStringLiteralEnd(source, index);
+    if (raw !== null) {
+      stripped += blankLiteral(source.slice(index, raw));
+      index = raw;
+      continue;
+    }
+    const quote = stringOrCharQuote(source, index);
+    if (quote !== null) {
+      const start = index;
+      index = quote.start + 1;
+      while (index < source.length) {
+        const char = source[index];
+        if (char === "\\") {
+          index += 2;
+          continue;
+        }
+        index += 1;
+        if (char === quote.char) {
+          break;
+        }
+      }
+      stripped += blankLiteral(source.slice(start, index));
+      continue;
+    }
+    stripped += source[index];
+    index += 1;
+  }
+  return stripped;
+}
+
+function rawStringLiteralEnd(source: string, index: number): number | null {
+  if (isIdentifierChar(source[index - 1] ?? "")) {
+    return null;
+  }
+  const match = /^(?:u8|u|U|L)?R"([^\s()\\]{0,16})\(/u.exec(source.slice(index));
+  if (match === null) {
+    return null;
+  }
+  const delimiter = match[1] ?? "";
+  const terminator = `)${delimiter}"`;
+  const contentStart = index + match[0].length;
+  const end = source.indexOf(terminator, contentStart);
+  return end === -1 ? source.length : end + terminator.length;
+}
+
+type LiteralQuote = {
+  char: '"' | "'";
+  start: number;
+};
+
+function stringOrCharQuote(source: string, index: number): LiteralQuote | null {
+  if (isIdentifierChar(source[index - 1] ?? "")) {
+    return null;
+  }
+  const prefixes = ["u8", "u", "U", "L"] as const;
+  for (const prefix of prefixes) {
+    if (source.startsWith(prefix, index)) {
+      const char = source[index + prefix.length];
+      if (char === '"' || char === "'") {
+        return { char, start: index + prefix.length };
+      }
+    }
+  }
+  const char = source[index];
+  return char === '"' || char === "'" ? { char, start: index } : null;
+}
+
+function isIdentifierChar(char: string): boolean {
+  return /[A-Za-z0-9_]/u.test(char);
+}
+
+function blankLiteral(literal: string): string {
+  return literal.replace(/[^\n]/gu, " ");
 }
 
 function braceDepthBefore(source: string, end: number): number {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -128,9 +128,9 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
   const seeds: FeatureSeed[] = [];
   const cmakeFiles = files.filter(isCMake);
   const sourceDirs = await cmakeSourceDirs(root, cmakeFiles);
-  const exePattern = /add_executable\s*\(\s*([A-Za-z0-9_.+-]+)\s+([^)]*)\)/gimsu;
-  const libPattern =
-    /add_library\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+(?:SHARED|STATIC|MODULE|OBJECT|INTERFACE))?\s+([^)]*)\)/gimsu;
+  const extraSources = await cmakeTargetSources(root, cmakeFiles, sourceDirs);
+  const exePattern = /add_executable\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
+  const libPattern = /add_library\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
   for (const cmakeFile of cmakeFiles) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);
@@ -139,7 +139,10 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       if (!isValidTargetName(target)) {
         continue;
       }
-      const sourcePaths = await targetSourcePaths(root, dir, splitWords(match[2] ?? ""));
+      const sourcePaths = uniqueStrings([
+        ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
+        ...(extraSources.get(target) ?? []),
+      ]);
       if (sourcePaths.length === 0) {
         continue;
       }
@@ -170,7 +173,10 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       if (!isValidTargetName(target)) {
         continue;
       }
-      const sourcePaths = await targetSourcePaths(root, dir, splitWords(match[2] ?? ""));
+      const sourcePaths = uniqueStrings([
+        ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
+        ...(extraSources.get(target) ?? []),
+      ]);
       if (sourcePaths.length === 0) {
         continue;
       }
@@ -195,6 +201,34 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
     }
   }
   return seeds;
+}
+
+async function cmakeTargetSources(
+  root: string,
+  cmakeFiles: string[],
+  sourceDirs: Map<string, string>,
+): Promise<Map<string, string[]>> {
+  const sources = new Map<string, string[]>();
+  const pattern = /target_sources\s*\(\s*([A-Za-z0-9_.+-]+)\s+([^)]*)\)/gimsu;
+  for (const cmakeFile of cmakeFiles) {
+    const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
+    const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);
+    for (const match of body.matchAll(pattern)) {
+      const target = match[1] ?? "";
+      if (!isValidTargetName(target)) {
+        continue;
+      }
+      const existing = sources.get(target) ?? [];
+      sources.set(
+        target,
+        uniqueStrings([
+          ...existing,
+          ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
+        ]),
+      );
+    }
+  }
+  return sources;
 }
 
 async function cmakeSourceDirs(root: string, cmakeFiles: string[]): Promise<Map<string, string>> {
@@ -391,6 +425,10 @@ async function targetSourcePaths(root: string, dir: string, sources: string[]): 
 
 function targetSourceRefs(sources: string[]): Array<{ path: string; reason: string }> {
   return sources.map((source) => ({ path: source, reason: "target source" }));
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
 }
 
 function automakeVariableName(target: string): string {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -127,19 +127,15 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
   const seeds: FeatureSeed[] = [];
   const { contexts } = await referencedCMakeFiles(root, files);
   const extraSources = await cmakeTargetSources(root, contexts);
-  const exePattern =
-    /(?:^|[^A-Za-z0-9_])add_executable\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
-  const libPattern =
-    /(?:^|[^A-Za-z0-9_])add_library\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
   for (const { file: cmakeFile, sourceDir: dir, targetScope: scope } of contexts) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
-    for (const match of body.matchAll(exePattern)) {
-      const target = match[1] ?? "";
+    for (const args of cmakeCommandArgs(body, "add_executable")) {
+      const [target = "", ...sources] = splitWords(args);
       if (!isValidTargetName(target)) {
         continue;
       }
       const sourcePaths = uniqueStrings([
-        ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
+        ...(await targetSourcePaths(root, dir, sources)),
         ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
@@ -190,13 +186,13 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         contextFiles: [{ path: cmakeFile, reason: "CMake target declaration" }],
       });
     }
-    for (const match of body.matchAll(libPattern)) {
-      const target = match[1] ?? "";
+    for (const args of cmakeCommandArgs(body, "add_library")) {
+      const [target = "", ...sources] = splitWords(args);
       if (!isValidTargetName(target)) {
         continue;
       }
       const sourcePaths = uniqueStrings([
-        ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
+        ...(await targetSourcePaths(root, dir, sources)),
         ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
@@ -299,11 +295,10 @@ async function cmakeTargetSources(
   contexts: CMakeContext[],
 ): Promise<Map<string, string[]>> {
   const sources = new Map<string, string[]>();
-  const pattern = /(?:^|[^A-Za-z0-9_])target_sources\s*\(\s*([A-Za-z0-9_.+-]+)\s+([^)]*)\)/gimsu;
   for (const { file: cmakeFile, sourceDir: dir, targetScope: scope } of contexts) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
-    for (const match of body.matchAll(pattern)) {
-      const target = match[1] ?? "";
+    for (const args of cmakeCommandArgs(body, "target_sources")) {
+      const [target = "", ...sourceTokens] = splitWords(args);
       if (!isValidTargetName(target)) {
         continue;
       }
@@ -311,10 +306,7 @@ async function cmakeTargetSources(
       const existing = sources.get(key) ?? [];
       sources.set(
         key,
-        uniqueStrings([
-          ...existing,
-          ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
-        ]),
+        uniqueStrings([...existing, ...(await targetSourcePaths(root, dir, sourceTokens))]),
       );
     }
   }
@@ -331,8 +323,8 @@ function isCMakeTestExecutableTarget(target: string, sourcePaths: string[]): boo
 
 function cmakeIncludes(body: string): string[] {
   const includes: string[] = [];
-  for (const match of body.matchAll(/(?:^|[^A-Za-z0-9_])include\s*\(([^)]*)\)/gimsu)) {
-    const path = splitWords(match[1] ?? "")[0];
+  for (const args of cmakeCommandArgs(body, "include")) {
+    const path = splitWords(args)[0];
     if (path !== undefined && !path.startsWith("$")) {
       includes.push(path);
     }
@@ -342,13 +334,99 @@ function cmakeIncludes(body: string): string[] {
 
 function cmakeSubdirectories(body: string): string[] {
   const directories: string[] = [];
-  for (const match of body.matchAll(/(?:^|[^A-Za-z0-9_])add_subdirectory\s*\(([^)]*)\)/gimsu)) {
-    const path = splitWords(match[1] ?? "")[0];
+  for (const args of cmakeCommandArgs(body, "add_subdirectory")) {
+    const path = splitWords(args)[0];
     if (path !== undefined && !path.startsWith("$")) {
       directories.push(path);
     }
   }
   return directories;
+}
+
+function cmakeCommandArgs(body: string, command: string): string[] {
+  const args: string[] = [];
+  const lower = body.toLowerCase();
+  const needle = command.toLowerCase();
+  for (let index = 0; index < body.length; ) {
+    const skipped = cmakeQuotedOrBracketEnd(body, index);
+    if (skipped !== null) {
+      index = skipped;
+      continue;
+    }
+    if (
+      lower.startsWith(needle, index) &&
+      !isIdentifierChar(body[index - 1] ?? "") &&
+      !isIdentifierChar(body[index + needle.length] ?? "")
+    ) {
+      let open = index + needle.length;
+      while (/\s/u.test(body[open] ?? "")) {
+        open += 1;
+      }
+      if (body[open] === "(") {
+        const close = cmakeCommandClose(body, open);
+        if (close !== null) {
+          args.push(body.slice(open + 1, close));
+          index = close + 1;
+          continue;
+        }
+      }
+    }
+    index += 1;
+  }
+  return args;
+}
+
+function cmakeCommandClose(body: string, open: number): number | null {
+  let depth = 1;
+  for (let index = open + 1; index < body.length; ) {
+    const skipped = cmakeQuotedOrBracketEnd(body, index);
+    if (skipped !== null) {
+      index = skipped;
+      continue;
+    }
+    if (body[index] === "(") {
+      depth += 1;
+    } else if (body[index] === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+    index += 1;
+  }
+  return null;
+}
+
+function cmakeQuotedOrBracketEnd(body: string, index: number): number | null {
+  if (body[index] === '"') {
+    return cmakeQuotedEnd(body, index);
+  }
+  return cmakeBracketEnd(body, index);
+}
+
+function cmakeQuotedEnd(body: string, index: number): number {
+  for (let cursor = index + 1; cursor < body.length; cursor += 1) {
+    if (body[cursor] === "\\") {
+      cursor += 1;
+      continue;
+    }
+    if (body[cursor] === '"') {
+      return cursor + 1;
+    }
+  }
+  return body.length;
+}
+
+function cmakeBracketEnd(body: string, index: number): number | null {
+  const match = /^\[(=*)\[/u.exec(body.slice(index));
+  if (match === null) {
+    return null;
+  }
+  const delimiter = match[1] ?? "";
+  const terminator = `]${delimiter}]`;
+  const contentStart = index + match[0].length;
+  const end = body.indexOf(terminator, contentStart);
+  return end === -1 ? body.length : end + terminator.length;
 }
 
 async function mainFunctionTargets(
@@ -572,18 +650,54 @@ async function defaultAutomakeSources(
   return existing;
 }
 
+type CMakeWord = {
+  value: string;
+  quoted: boolean;
+};
+
 function splitWords(value: string): string[] {
-  return value
-    .split(/\s+/u)
-    .filter((word) => word.length > 0)
-    .map(unquoteWord)
-    .flatMap((word) => word.split(";"))
+  return cmakeWords(value)
+    .flatMap((word) => (word.quoted ? [word.value] : word.value.split(";")))
     .filter((word) => word.length > 0);
 }
 
-function unquoteWord(value: string): string {
-  const quote = value[0];
-  return (quote === '"' || quote === "'") && value.endsWith(quote) ? value.slice(1, -1) : value;
+function cmakeWords(value: string): CMakeWord[] {
+  const words: CMakeWord[] = [];
+  for (let index = 0; index < value.length; ) {
+    while (/\s/u.test(value[index] ?? "")) {
+      index += 1;
+    }
+    if (index >= value.length) {
+      break;
+    }
+    if (value[index] === '"') {
+      const end = cmakeQuotedEnd(value, index);
+      words.push({ value: unescapeCMakeQuoted(value.slice(index + 1, end - 1)), quoted: true });
+      index = end;
+      continue;
+    }
+    const bracketEnd = cmakeBracketEnd(value, index);
+    if (bracketEnd !== null) {
+      const opener = /^\[(=*)\[/u.exec(value.slice(index))?.[0] ?? "[[";
+      const terminatorLength = opener.length;
+      words.push({
+        value: value.slice(index + opener.length, bracketEnd - terminatorLength),
+        quoted: true,
+      });
+      index = bracketEnd;
+      continue;
+    }
+    const start = index;
+    while (index < value.length && !/\s/u.test(value[index] ?? "")) {
+      index += 1;
+    }
+    words.push({ value: value.slice(start, index), quoted: false });
+  }
+  return words;
+}
+
+function unescapeCMakeQuoted(value: string): string {
+  return value.replace(/\\(.)/gsu, "$1");
 }
 
 async function pickExecutableEntry(

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -125,14 +125,15 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
 
 async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
-  const sourceDirs = await referencedCMakeSourceDirs(root, files);
+  const { sourceDirs, targetScopes } = await referencedCMakeFiles(root, files);
   const cmakeFiles = [...sourceDirs.keys()];
-  const extraSources = await cmakeTargetSources(root, cmakeFiles, sourceDirs);
+  const extraSources = await cmakeTargetSources(root, cmakeFiles, sourceDirs, targetScopes);
   const exePattern = /add_executable\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
   const libPattern = /add_library\s*\(\s*([A-Za-z0-9_.+-]+)(?:\s+([^)]*))?\)/gimsu;
   for (const cmakeFile of cmakeFiles) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);
+    const scope = targetScopes.get(cmakeFile) ?? dir;
     for (const match of body.matchAll(exePattern)) {
       const target = match[1] ?? "";
       if (!isValidTargetName(target)) {
@@ -140,7 +141,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       }
       const sourcePaths = uniqueStrings([
         ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
-        ...(extraSources.get(cmakeTargetKey(dir, target)) ?? []),
+        ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
         continue;
@@ -173,7 +174,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       }
       const sourcePaths = uniqueStrings([
         ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
-        ...(extraSources.get(cmakeTargetKey(dir, target)) ?? []),
+        ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
         continue;
@@ -200,15 +201,20 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
   return seeds;
 }
 
-async function referencedCMakeSourceDirs(
-  root: string,
-  files: string[],
-): Promise<Map<string, string>> {
+type CMakeDiscovery = {
+  sourceDirs: Map<string, string>;
+  targetScopes: Map<string, string>;
+};
+
+async function referencedCMakeFiles(root: string, files: string[]): Promise<CMakeDiscovery> {
   const cmakeFileSet = new Set(files.filter(isCMake));
   const sourceDirs = new Map<string, string>();
+  const targetScopes = new Map<string, string>();
   const pending: string[] = [];
   for (const cmakeList of files.filter((file) => file.endsWith("CMakeLists.txt"))) {
-    sourceDirs.set(cmakeList, parentDir(cmakeList));
+    const dir = parentDir(cmakeList);
+    sourceDirs.set(cmakeList, dir);
+    targetScopes.set(cmakeList, dir);
     pending.push(cmakeList);
   }
   while (pending.length > 0) {
@@ -217,39 +223,69 @@ async function referencedCMakeSourceDirs(
       continue;
     }
     const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);
+    const scope = targetScopes.get(cmakeFile) ?? dir;
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     for (const include of cmakeIncludes(body)) {
       const includePath = include.endsWith(".cmake") ? include : `${include}.cmake`;
       const full = isAbsolute(includePath) ? includePath : join(root, prefixDir(dir, includePath));
       const rel = normalize(relative(root, full));
-      if (!cmakeFileSet.has(rel) || sourceDirs.has(rel)) {
+      if (!cmakeFileSet.has(rel)) {
         continue;
       }
-      sourceDirs.set(rel, dir);
-      pending.push(rel);
+      queueCMakeFile(rel, dir, scope, sourceDirs, targetScopes, pending);
+    }
+    for (const child of cmakeSubdirectories(body)) {
+      const full = isAbsolute(child) ? child : join(root, prefixDir(dir, child), "CMakeLists.txt");
+      const rel = normalize(relative(root, full));
+      if (!cmakeFileSet.has(rel)) {
+        continue;
+      }
+      queueCMakeFile(rel, parentDir(rel), scope, sourceDirs, targetScopes, pending);
     }
   }
-  return new Map(
-    [...sourceDirs.entries()].toSorted(([left], [right]) => left.localeCompare(right)),
-  );
+  return {
+    sourceDirs: new Map(
+      [...sourceDirs.entries()].toSorted(([left], [right]) => left.localeCompare(right)),
+    ),
+    targetScopes,
+  };
+}
+
+function queueCMakeFile(
+  file: string,
+  sourceDir: string,
+  targetScope: string,
+  sourceDirs: Map<string, string>,
+  targetScopes: Map<string, string>,
+  pending: string[],
+): void {
+  const knownSourceDir = sourceDirs.get(file);
+  const knownScope = targetScopes.get(file);
+  sourceDirs.set(file, knownSourceDir ?? sourceDir);
+  if (knownScope !== targetScope) {
+    targetScopes.set(file, targetScope);
+    pending.push(file);
+  }
 }
 
 async function cmakeTargetSources(
   root: string,
   cmakeFiles: string[],
   sourceDirs: Map<string, string>,
+  targetScopes: Map<string, string>,
 ): Promise<Map<string, string[]>> {
   const sources = new Map<string, string[]>();
   const pattern = /target_sources\s*\(\s*([A-Za-z0-9_.+-]+)\s+([^)]*)\)/gimsu;
   for (const cmakeFile of cmakeFiles) {
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     const dir = sourceDirs.get(cmakeFile) ?? parentDir(cmakeFile);
+    const scope = targetScopes.get(cmakeFile) ?? dir;
     for (const match of body.matchAll(pattern)) {
       const target = match[1] ?? "";
       if (!isValidTargetName(target)) {
         continue;
       }
-      const key = cmakeTargetKey(dir, target);
+      const key = cmakeTargetKey(scope, target);
       const existing = sources.get(key) ?? [];
       sources.set(
         key,
@@ -276,6 +312,17 @@ function cmakeIncludes(body: string): string[] {
     }
   }
   return includes;
+}
+
+function cmakeSubdirectories(body: string): string[] {
+  const directories: string[] = [];
+  for (const match of body.matchAll(/add_subdirectory\s*\(([^)]*)\)/gimsu)) {
+    const path = splitWords(match[1] ?? "")[0];
+    if (path !== undefined && !path.startsWith("$")) {
+      directories.push(path);
+    }
+  }
+  return directories;
 }
 
 async function mainFunctionTargets(

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -66,7 +66,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
         continue;
       }
       const sources = await automakeTargetSources(root, dir, body, target);
-      const sourcePaths = await targetSourcePaths(root, dir, sources);
+      const sourcePaths = await targetSourcePaths(root, dir, expandAutomakeSources(root, sources));
       if (sourcePaths.length === 0) {
         continue;
       }
@@ -97,7 +97,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
       }
       const target = rawTarget.replace(/\.la$/u, "");
       const sources = readTargetSources(body, automakeVariableName(rawTarget));
-      const sourcePaths = await targetSourcePaths(root, dir, sources);
+      const sourcePaths = await targetSourcePaths(root, dir, expandAutomakeSources(root, sources));
       if (sourcePaths.length === 0) {
         continue;
       }
@@ -1120,6 +1120,22 @@ function automakeVariableName(target: string): string {
 
 function normalizeAutomakeProgramTarget(target: string): string {
   return target.replace(/\$[({]EXEEXT[)}]|@EXEEXT@/gu, "");
+}
+
+function expandAutomakeSources(root: string, sources: string[]): string[] {
+  return sources.map((source) => expandAutomakeSource(root, source));
+}
+
+function expandAutomakeSource(root: string, source: string): string {
+  const normalized = normalize(source);
+  const srcdir = /^(?:\$\((?:srcdir)\)|\$\{srcdir\}|@srcdir@)(?:\/(.*)|$)/u.exec(normalized);
+  if (srcdir !== null) {
+    return srcdir[1] ?? "";
+  }
+  const topSrcdir = /^(?:\$\((?:top_srcdir)\)|\$\{top_srcdir\}|@top_srcdir@)(?:\/(.*)|$)/u.exec(
+    normalized,
+  );
+  return topSrcdir === null ? source : join(root, topSrcdir[1] ?? "");
 }
 
 function prefixDir(dir: string, file: string): string {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -388,8 +388,11 @@ async function mainFunctionTargets(
 
 function definesMain(source: string): boolean {
   const stripped = stripCOrCppComments(stripCOrCppLiterals(source));
+  if (!stripped.includes("main")) {
+    return false;
+  }
   const pattern =
-    /(?:^|[;\n])\s*(?:extern\s+"C"\s*)?(?:[\w:<>~*&\s]+\s+)+main\s*\([^;{}]*\)\s*(?:noexcept\s*)?(?:->\s*[\w:<>~*&\s]+)?\s*\{/gmu;
+    /(?:^|[;\n])\s*(?:extern\s+"C"\s*)?(?:[\w:<>~*&]+[ \t\r\n]+)+main\s*\([^;{}]*\)\s*(?:noexcept\s*)?(?:->\s*[\w:<>~*&]+(?:[ \t\r\n]+[\w:<>~*&]+)*)?\s*\{/gmu;
   for (const match of stripped.matchAll(pattern)) {
     if (braceDepthBefore(stripped, match.index) === 0) {
       return true;

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -10,7 +10,7 @@ import {
   stripLineComments,
   walk,
 } from "./shared.js";
-import { FeatureSeed } from "./types.js";
+import { FeatureSeed, SeedFileRef } from "./types.js";
 
 export async function cCppSeeds(root: string): Promise<FeatureSeed[]> {
   const files = (await walk(root, [""], shouldSkipCOrCppPath)).filter(
@@ -126,22 +126,26 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
 async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
   const { contexts } = await referencedCMakeFiles(root, files);
-  const extraSources = await cmakeTargetSources(root, contexts);
+  const extraSourceSets = await cmakeTargetSources(root, contexts);
   for (const {
     file: cmakeFile,
     sourceDir: dir,
     targetScope: scope,
     cmakeSourceDir,
     projectSourceDir,
+    projectName,
   } of contexts) {
     const listDir = parentDir(cmakeFile);
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     const effectiveProjectSourceDir = cmakeDeclaresProject(body) ? dir : projectSourceDir;
+    const effectiveProjectName = cmakeProjectName(body) ?? projectName;
     for (const args of cmakeCommandArgs(body, "add_executable")) {
-      const [target = "", ...sources] = splitWords(args);
+      const [rawTarget = "", ...sources] = splitWords(args);
+      const target = resolveCMakeTargetName(rawTarget, effectiveProjectName);
       if (!isValidTargetName(target)) {
         continue;
       }
+      const extraSources = extraSourceSets.get(cmakeTargetKey(scope, target));
       const sourcePaths = uniqueStrings([
         ...(await targetSourcePaths(
           root,
@@ -151,11 +155,16 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
           cmakeSourceDir,
           effectiveProjectSourceDir,
         )),
-        ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
+        ...(extraSources?.paths ?? []),
       ]);
       if (sourcePaths.length === 0) {
         continue;
       }
+      const contextFiles = cmakeTargetContextFiles(
+        cmakeFile,
+        "CMake target declaration",
+        extraSources,
+      );
       const testEntryPath = cmakeTestExecutableEntry(target, sourcePaths);
       if (testEntryPath !== null) {
         seeds.push({
@@ -171,7 +180,11 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
           tags: [languageTag(testEntryPath), "test"],
           trustBoundaries: [],
           ownedFiles: targetSourceRefs(sourcePaths),
-          contextFiles: [{ path: cmakeFile, reason: "CMake test target declaration" }],
+          contextFiles: cmakeTargetContextFiles(
+            cmakeFile,
+            "CMake test target declaration",
+            extraSources,
+          ),
           tests: sourcePaths.filter(isCOrCppTestPath).map((path) => ({ path, command: null })),
           skipNearbyTests: true,
         });
@@ -195,14 +208,16 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         tags: [tag, "cli"],
         trustBoundaries: ["user-input", "filesystem", "process-exec"],
         ownedFiles: targetSourceRefs(sourcePaths),
-        contextFiles: [{ path: cmakeFile, reason: "CMake target declaration" }],
+        contextFiles,
       });
     }
     for (const args of cmakeCommandArgs(body, "add_library")) {
-      const [target = "", ...sources] = splitWords(args);
+      const [rawTarget = "", ...sources] = splitWords(args);
+      const target = resolveCMakeTargetName(rawTarget, effectiveProjectName);
       if (!isValidTargetName(target)) {
         continue;
       }
+      const extraSources = extraSourceSets.get(cmakeTargetKey(scope, target));
       const sourcePaths = uniqueStrings([
         ...(await targetSourcePaths(
           root,
@@ -212,7 +227,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
           cmakeSourceDir,
           effectiveProjectSourceDir,
         )),
-        ...(extraSources.get(cmakeTargetKey(scope, target)) ?? []),
+        ...(extraSources?.paths ?? []),
       ]);
       if (sourcePaths.length === 0) {
         continue;
@@ -232,7 +247,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         tags: [tag, "library"],
         trustBoundaries: packageTrustBoundaries(target),
         ownedFiles: targetSourceRefs(sourcePaths),
-        contextFiles: [{ path: cmakeFile, reason: "CMake target declaration" }],
+        contextFiles: cmakeTargetContextFiles(cmakeFile, "CMake target declaration", extraSources),
       });
     }
   }
@@ -249,6 +264,12 @@ type CMakeContext = {
   targetScope: string;
   cmakeSourceDir: string;
   projectSourceDir: string;
+  projectName: string;
+};
+
+type CMakeTargetSources = {
+  paths: string[];
+  contextFiles: SeedFileRef[];
 };
 
 async function referencedCMakeFiles(root: string, files: string[]): Promise<CMakeDiscovery> {
@@ -264,6 +285,7 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
         targetScope: dir,
         cmakeSourceDir: dir,
         projectSourceDir: dir,
+        projectName: "",
       },
       contexts,
       pending,
@@ -280,10 +302,12 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
       targetScope: scope,
       cmakeSourceDir,
       projectSourceDir,
+      projectName,
     } = context;
     const listDir = parentDir(cmakeFile);
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     const effectiveProjectSourceDir = cmakeDeclaresProject(body) ? dir : projectSourceDir;
+    const effectiveProjectName = cmakeProjectName(body) ?? projectName;
     for (const include of cmakeIncludes(body)) {
       const includePath = include.endsWith(".cmake") ? include : `${include}.cmake`;
       const full = resolveCMakePath(
@@ -308,6 +332,7 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
           targetScope: scope,
           cmakeSourceDir,
           projectSourceDir: effectiveProjectSourceDir,
+          projectName: effectiveProjectName,
         },
         contexts,
         pending,
@@ -337,6 +362,7 @@ async function referencedCMakeFiles(root: string, files: string[]): Promise<CMak
           targetScope: scope,
           cmakeSourceDir,
           projectSourceDir: effectiveProjectSourceDir,
+          projectName: effectiveProjectName,
         },
         contexts,
         pending,
@@ -369,45 +395,50 @@ function cmakeContextKey(context: CMakeContext): string {
     context.targetScope,
     context.cmakeSourceDir,
     context.projectSourceDir,
+    context.projectName,
   ].join("\0");
 }
 
 async function cmakeTargetSources(
   root: string,
   contexts: CMakeContext[],
-): Promise<Map<string, string[]>> {
-  const sources = new Map<string, string[]>();
+): Promise<Map<string, CMakeTargetSources>> {
+  const sources = new Map<string, CMakeTargetSources>();
   for (const {
     file: cmakeFile,
     sourceDir: dir,
     targetScope: scope,
     cmakeSourceDir,
     projectSourceDir,
+    projectName,
   } of contexts) {
     const listDir = parentDir(cmakeFile);
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     const effectiveProjectSourceDir = cmakeDeclaresProject(body) ? dir : projectSourceDir;
+    const effectiveProjectName = cmakeProjectName(body) ?? projectName;
     for (const args of cmakeCommandArgs(body, "target_sources")) {
-      const [target = "", ...sourceTokens] = splitWords(args);
+      const [rawTarget = "", ...sourceTokens] = splitWords(args);
+      const target = resolveCMakeTargetName(rawTarget, effectiveProjectName);
       if (!isValidTargetName(target)) {
         continue;
       }
       const key = cmakeTargetKey(scope, target);
-      const existing = sources.get(key) ?? [];
-      sources.set(
-        key,
-        uniqueStrings([
-          ...existing,
-          ...(await targetSourcePaths(
-            root,
-            dir,
-            sourceTokens,
-            listDir,
-            cmakeSourceDir,
-            effectiveProjectSourceDir,
-          )),
-        ]),
+      const existing = sources.get(key);
+      const paths = await targetSourcePaths(
+        root,
+        dir,
+        sourceTokens,
+        listDir,
+        cmakeSourceDir,
+        effectiveProjectSourceDir,
       );
+      sources.set(key, {
+        paths: uniqueStrings([...(existing?.paths ?? []), ...paths]),
+        contextFiles: uniqueFileRefs([
+          ...(existing?.contextFiles ?? []),
+          { path: cmakeFile, reason: "CMake target source declaration" },
+        ]),
+      });
     }
   }
   return sources;
@@ -417,8 +448,30 @@ function cmakeDeclaresProject(body: string): boolean {
   return cmakeCommandArgs(body, "project").length > 0;
 }
 
+function cmakeProjectName(body: string): string | null {
+  for (const args of cmakeCommandArgs(body, "project")) {
+    const [name = ""] = splitWords(args);
+    if (isValidTargetName(name)) {
+      return name;
+    }
+  }
+  return null;
+}
+
 function cmakeTargetKey(dir: string, target: string): string {
   return `${dir}\0${target}`;
+}
+
+function resolveCMakeTargetName(target: string, projectName: string): string {
+  return target === "${PROJECT_NAME}" && projectName.length > 0 ? projectName : target;
+}
+
+function cmakeTargetContextFiles(
+  cmakeFile: string,
+  reason: string,
+  extraSources: CMakeTargetSources | undefined,
+): SeedFileRef[] {
+  return uniqueFileRefs([{ path: cmakeFile, reason }, ...(extraSources?.contextFiles ?? [])]);
 }
 
 function cmakeTestExecutableEntry(target: string, sourcePaths: string[]): string | null {
@@ -1004,6 +1057,19 @@ function targetSourceRefs(sources: string[]): Array<{ path: string; reason: stri
 
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values)];
+}
+
+function uniqueFileRefs(values: SeedFileRef[]): SeedFileRef[] {
+  const seen = new Set<string>();
+  const output: SeedFileRef[] = [];
+  for (const value of values) {
+    if (seen.has(value.path)) {
+      continue;
+    }
+    seen.add(value.path);
+    output.push(value);
+  }
+  return output;
 }
 
 function automakeVariableName(target: string): string {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -156,22 +156,19 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       if (sourcePaths.length === 0) {
         continue;
       }
-      if (isCMakeTestExecutableTarget(target, sourcePaths)) {
-        const entryPath = pickEntry(sourcePaths, target) ?? sourcePaths[0];
-        if (entryPath === undefined) {
-          continue;
-        }
+      const testEntryPath = cmakeTestExecutableEntry(target, sourcePaths);
+      if (testEntryPath !== null) {
         seeds.push({
           title: `CMake test suite ${target}`,
           summary: `CMake test executable ${target} declared in ${cmakeFile}.`,
           kind: "test-suite",
           source: "cmake-test",
           confidence: "high",
-          entryPath,
+          entryPath: testEntryPath,
           symbol: null,
           route: null,
           command: null,
-          tags: [languageTag(entryPath), "test"],
+          tags: [languageTag(testEntryPath), "test"],
           trustBoundaries: [],
           ownedFiles: targetSourceRefs(sourcePaths),
           contextFiles: [{ path: cmakeFile, reason: "CMake test target declaration" }],
@@ -424,8 +421,12 @@ function cmakeTargetKey(dir: string, target: string): string {
   return `${dir}\0${target}`;
 }
 
-function isCMakeTestExecutableTarget(target: string, sourcePaths: string[]): boolean {
-  return /(?:^|[_-])tests?$/iu.test(target) || sourcePaths.some(isCOrCppTestPath);
+function cmakeTestExecutableEntry(target: string, sourcePaths: string[]): string | null {
+  const entryPath = pickEntry(sourcePaths, target) ?? sourcePaths[0];
+  if (entryPath === undefined) {
+    return null;
+  }
+  return /(?:^|[_-])tests?$/iu.test(target) || isCOrCppTestPath(entryPath) ? entryPath : null;
 }
 
 function cmakeIncludes(body: string): string[] {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { isAbsolute, join, relative } from "node:path";
 import {
   isSafeFile,
   isCOrCppTestPath,
@@ -133,14 +133,11 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
 async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
   const cmakeFiles = files.filter(isCMake);
-  const exePattern = /add_executable\s*\(\s*([A-Za-z_][\w-]*)\s+([^)]*)\)/gmsu;
+  const exePattern = /add_executable\s*\(\s*([A-Za-z_][\w-]*)\s+([^)]*)\)/gimsu;
   const libPattern =
-    /add_library\s*\(\s*([A-Za-z_][\w-]*)(?:\s+(?:SHARED|STATIC|MODULE|OBJECT|INTERFACE))?\s+([^)]*)\)/gmsu;
+    /add_library\s*\(\s*([A-Za-z_][\w-]*)(?:\s+(?:SHARED|STATIC|MODULE|OBJECT|INTERFACE))?\s+([^)]*)\)/gimsu;
   for (const cmakeFile of cmakeFiles) {
-    const body = stripLineComments(
-      await readFile(join(root, cmakeFile), "utf8").catch(() => ""),
-      "#",
-    );
+    const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     const dir = parentDir(cmakeFile);
     for (const match of body.matchAll(exePattern)) {
       const target = match[1] ?? "";
@@ -264,6 +261,10 @@ function readTargetSources(body: string, target: string): string[] {
   return splitWords(raw);
 }
 
+function stripCMakeComments(source: string): string {
+  return stripLineComments(source.replace(/#\[(=*)\[[\s\S]*?\]\1\]/gu, " "), "#");
+}
+
 async function automakeTargetSources(
   root: string,
   dir: string,
@@ -347,7 +348,7 @@ function pickEntry(candidates: string[], targetName: string): string | null {
 async function targetSourcePaths(root: string, dir: string, sources: string[]): Promise<string[]> {
   const paths: string[] = [];
   for (const source of sources.filter(isCOrCppSource)) {
-    const full = join(root, prefixDir(dir, source));
+    const full = isAbsolute(source) ? source : join(root, prefixDir(dir, source));
     const rel = normalize(relative(root, full));
     if (!shouldSkip(rel) && (await isSafeFile(root, full))) {
       paths.push(rel);
@@ -367,10 +368,7 @@ function automakeVariableName(target: string): string {
 function prefixDir(dir: string, file: string): string {
   const normalizedFile = normalize(file).replace(/^\.\//u, "");
   if (dir.length === 0) {
-    return normalizedFile.replace(/^\/+/u, "");
-  }
-  if (normalizedFile.startsWith("/")) {
-    return `${dir}${normalizedFile.replace(/^\/+/u, "")}`;
+    return normalizedFile;
   }
   return `${dir}${normalizedFile}`;
 }

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -387,7 +387,7 @@ async function mainFunctionTargets(
 }
 
 function definesMain(source: string): boolean {
-  const stripped = stripLineComments(stripBlockComments(stripCOrCppLiterals(source)), "//");
+  const stripped = stripCOrCppComments(stripCOrCppLiterals(source));
   const pattern =
     /(?:^|[;\n])\s*(?:extern\s+"C"\s*)?(?:[\w:<>~*&\s]+\s+)+main\s*\([^;{}]*\)\s*(?:noexcept\s*)?(?:->\s*[\w:<>~*&\s]+)?\s*\{/gmu;
   for (const match of stripped.matchAll(pattern)) {
@@ -398,8 +398,38 @@ function definesMain(source: string): boolean {
   return false;
 }
 
-function stripBlockComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//gu, " ");
+function stripCOrCppComments(source: string): string {
+  let stripped = "";
+  for (let index = 0; index < source.length; ) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (char === "/" && next === "/") {
+      stripped += "  ";
+      index += 2;
+      while (index < source.length && source[index] !== "\n") {
+        stripped += " ";
+        index += 1;
+      }
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      stripped += "  ";
+      index += 2;
+      while (index < source.length) {
+        if (source[index] === "*" && source[index + 1] === "/") {
+          stripped += "  ";
+          index += 2;
+          break;
+        }
+        stripped += source[index] === "\n" ? "\n" : " ";
+        index += 1;
+      }
+      continue;
+    }
+    stripped += char;
+    index += 1;
+  }
+  return stripped;
 }
 
 function stripCOrCppLiterals(source: string): string {
@@ -669,7 +699,7 @@ function dedupeByEntry(seeds: FeatureSeed[]): FeatureSeed[] {
   const seen = new Set<string>();
   const output: FeatureSeed[] = [];
   for (const seed of seeds) {
-    const key = `${seed.entryPath}:${seed.kind}:${seed.command ?? seed.symbol ?? seed.title}`;
+    const key = `${seed.source}:${seed.entryPath}:${seed.kind}:${seed.command ?? seed.symbol ?? seed.title}`;
     if (seen.has(key)) {
       continue;
     }

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -455,6 +455,7 @@ function cmakeCommandArgs(body: string, command: string): string[] {
   const args: string[] = [];
   const lower = body.toLowerCase();
   const needle = command.toLowerCase();
+  let depth = 0;
   for (let index = 0; index < body.length; ) {
     const skipped = cmakeQuotedOrBracketEnd(body, index);
     if (skipped !== null) {
@@ -462,6 +463,7 @@ function cmakeCommandArgs(body: string, command: string): string[] {
       continue;
     }
     if (
+      depth === 0 &&
       lower.startsWith(needle, index) &&
       !isIdentifierChar(body[index - 1] ?? "") &&
       !isIdentifierChar(body[index + needle.length] ?? "")
@@ -478,6 +480,11 @@ function cmakeCommandArgs(body: string, command: string): string[] {
           continue;
         }
       }
+    }
+    if (body[index] === "(") {
+      depth += 1;
+    } else if (body[index] === ")") {
+      depth = Math.max(0, depth - 1);
     }
     index += 1;
   }

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -139,7 +139,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       }
       const sourcePaths = uniqueStrings([
         ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
-        ...(extraSources.get(target) ?? []),
+        ...(extraSources.get(cmakeTargetKey(dir, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
         continue;
@@ -172,7 +172,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       }
       const sourcePaths = uniqueStrings([
         ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
-        ...(extraSources.get(target) ?? []),
+        ...(extraSources.get(cmakeTargetKey(dir, target)) ?? []),
       ]);
       if (sourcePaths.length === 0) {
         continue;
@@ -248,9 +248,10 @@ async function cmakeTargetSources(
       if (!isValidTargetName(target)) {
         continue;
       }
-      const existing = sources.get(target) ?? [];
+      const key = cmakeTargetKey(dir, target);
+      const existing = sources.get(key) ?? [];
       sources.set(
-        target,
+        key,
         uniqueStrings([
           ...existing,
           ...(await targetSourcePaths(root, dir, splitWords(match[2] ?? ""))),
@@ -259,6 +260,10 @@ async function cmakeTargetSources(
     }
   }
   return sources;
+}
+
+function cmakeTargetKey(dir: string, target: string): string {
+  return `${dir}\0${target}`;
 }
 
 function cmakeIncludes(body: string): string[] {

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -1,0 +1,319 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  isSafeFile,
+  isCOrCppTestPath,
+  normalize,
+  packageTrustBoundaries,
+  stripLineComments,
+  walk,
+} from "./shared.js";
+import { FeatureSeed } from "./types.js";
+
+export async function cCppSeeds(root: string): Promise<FeatureSeed[]> {
+  const files = (await walk(root, [""])).filter(
+    (path) => isCOrCppSource(path) || isMakefile(path) || isCMake(path),
+  );
+  if (files.length === 0) {
+    return [];
+  }
+  const seeds: FeatureSeed[] = [];
+  seeds.push(...(await autotoolsTargets(root, files)));
+  seeds.push(...(await cmakeTargets(root, files)));
+  const alreadySeeded = new Set(
+    seeds.filter((seed) => seed.kind === "cli-command").map((seed) => seed.entryPath),
+  );
+  seeds.push(...(await mainFunctionTargets(root, files, alreadySeeded)));
+  return dedupeByEntry(seeds);
+}
+
+function isCOrCppSource(path: string): boolean {
+  return /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/u.test(path);
+}
+
+function isCOrCppCompilable(path: string): boolean {
+  return /\.(?:c|cc|cpp|cxx)$/u.test(path);
+}
+
+function isMakefile(path: string): boolean {
+  return path.endsWith("Makefile.am") || path.endsWith("Makefile.in");
+}
+
+function isCMake(path: string): boolean {
+  return path.endsWith("CMakeLists.txt") || path.endsWith(".cmake");
+}
+
+function languageTag(path: string): "c" | "cpp" {
+  return /\.(?:cc|cpp|cxx|hh|hpp|hxx)$/u.test(path) ? "cpp" : "c";
+}
+
+async function autotoolsTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
+  const seeds: FeatureSeed[] = [];
+  const makefiles = files.filter((file) => file.endsWith("Makefile.am"));
+  const binPattern = /^\s*bin_PROGRAMS\s*=\s*(.+)$/gmu;
+  const libPattern = /^\s*lib_LTLIBRARIES\s*=\s*(.+)$/gmu;
+  for (const makefile of makefiles) {
+    const body = collapseBackslashContinuations(
+      await readFile(join(root, makefile), "utf8").catch(() => ""),
+    );
+    const dir = parentDir(makefile);
+    for (const match of body.matchAll(binPattern)) {
+      for (const target of splitWords(match[1] ?? "")) {
+        if (!isValidTargetName(target)) {
+          continue;
+        }
+        const sources = readTargetSources(body, target);
+        const entryCandidates = sources.filter(isCOrCppCompilable);
+        const entryPath = (await pickEntry(root, dir, entryCandidates, target)) ?? makefile;
+        const tag = languageTag(entryPath);
+        seeds.push({
+          title: `Autotools binary ${target}`,
+          summary: `Autotools bin_PROGRAMS target declared in ${makefile}.`,
+          kind: "cli-command",
+          source: "autotools-bin",
+          confidence: "high",
+          entryPath,
+          symbol: "main",
+          route: null,
+          command: target,
+          tags: [tag, "cli"],
+          trustBoundaries: ["user-input", "filesystem", "process-exec"],
+          ownedFiles: targetSourceRefs(dir, sources),
+          contextFiles: [{ path: makefile, reason: "build target declaration" }],
+          testPrefixes: [`${dir}tests`],
+        });
+      }
+    }
+    for (const match of body.matchAll(libPattern)) {
+      for (const rawTarget of splitWords(match[1] ?? "")) {
+        if (!isValidTargetName(rawTarget)) {
+          continue;
+        }
+        const target = rawTarget.replace(/\.la$/u, "");
+        const sources = readTargetSources(body, rawTarget.replace(/\./gu, "_"));
+        const entryCandidates = sources.filter(isCOrCppCompilable);
+        const entryPath = (await pickEntry(root, dir, entryCandidates, target)) ?? makefile;
+        const tag = languageTag(entryPath);
+        seeds.push({
+          title: `Autotools library ${target}`,
+          summary: `Autotools lib_LTLIBRARIES target declared in ${makefile}.`,
+          kind: "library",
+          source: "autotools-lib",
+          confidence: "high",
+          entryPath,
+          symbol: null,
+          route: null,
+          command: null,
+          tags: [tag, "library"],
+          trustBoundaries: packageTrustBoundaries(target),
+          ownedFiles: targetSourceRefs(dir, sources),
+          contextFiles: [{ path: makefile, reason: "build target declaration" }],
+          testPrefixes: [`${dir}tests`],
+        });
+      }
+    }
+  }
+  return seeds;
+}
+
+async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
+  const seeds: FeatureSeed[] = [];
+  const cmakeFiles = files.filter(isCMake);
+  const exePattern = /add_executable\s*\(\s*([A-Za-z_][\w-]*)\s+([^)]*)\)/gmsu;
+  const libPattern =
+    /add_library\s*\(\s*([A-Za-z_][\w-]*)(?:\s+(?:SHARED|STATIC|MODULE|OBJECT|INTERFACE))?\s+([^)]*)\)/gmsu;
+  for (const cmakeFile of cmakeFiles) {
+    const body = stripLineComments(
+      await readFile(join(root, cmakeFile), "utf8").catch(() => ""),
+      "#",
+    );
+    const dir = parentDir(cmakeFile);
+    for (const match of body.matchAll(exePattern)) {
+      const target = match[1] ?? "";
+      if (!isValidTargetName(target)) {
+        continue;
+      }
+      const sources = splitWords(match[2] ?? "").filter(isCOrCppCompilable);
+      const entryPath = (await pickEntry(root, dir, sources, target)) ?? cmakeFile;
+      const tag = languageTag(entryPath);
+      seeds.push({
+        title: `CMake binary ${target}`,
+        summary: `CMake add_executable(${target}) declared in ${cmakeFile}.`,
+        kind: "cli-command",
+        source: "cmake-bin",
+        confidence: "high",
+        entryPath,
+        symbol: "main",
+        route: null,
+        command: target,
+        tags: [tag, "cli"],
+        trustBoundaries: ["user-input", "filesystem", "process-exec"],
+        ownedFiles: targetSourceRefs(dir, sources),
+        contextFiles: [{ path: cmakeFile, reason: "CMake target declaration" }],
+        testPrefixes: [`${dir}tests`],
+      });
+    }
+    for (const match of body.matchAll(libPattern)) {
+      const target = match[1] ?? "";
+      if (!isValidTargetName(target)) {
+        continue;
+      }
+      const sources = splitWords(match[2] ?? "").filter(isCOrCppCompilable);
+      const entryPath = (await pickEntry(root, dir, sources, target)) ?? cmakeFile;
+      const tag = languageTag(entryPath);
+      seeds.push({
+        title: `CMake library ${target}`,
+        summary: `CMake add_library(${target}) declared in ${cmakeFile}.`,
+        kind: "library",
+        source: "cmake-lib",
+        confidence: "high",
+        entryPath,
+        symbol: null,
+        route: null,
+        command: null,
+        tags: [tag, "library"],
+        trustBoundaries: packageTrustBoundaries(target),
+        ownedFiles: targetSourceRefs(dir, sources),
+        contextFiles: [{ path: cmakeFile, reason: "CMake target declaration" }],
+        testPrefixes: [`${dir}tests`],
+      });
+    }
+  }
+  return seeds;
+}
+
+async function mainFunctionTargets(
+  root: string,
+  files: string[],
+  alreadySeeded: Set<string>,
+): Promise<FeatureSeed[]> {
+  const seeds: FeatureSeed[] = [];
+  for (const file of files.filter(isCOrCppCompilable)) {
+    if (alreadySeeded.has(file) || isCOrCppTestPath(file)) {
+      continue;
+    }
+    const source = await readFile(join(root, file), "utf8").catch(() => "");
+    if (source.length > 2_000_000 || !definesMain(source)) {
+      continue;
+    }
+    const tag = languageTag(file);
+    const command =
+      file
+        .split("/")
+        .at(-1)
+        ?.replace(/\.[^.]+$/u, "") ?? "main";
+    seeds.push({
+      title: `${tag === "cpp" ? "C++" : "C"} binary ${command}`,
+      summary: `C/C++ source file with a top-level main() at ${file}.`,
+      kind: "cli-command",
+      source: "c-main",
+      confidence: "medium",
+      entryPath: file,
+      symbol: "main",
+      route: null,
+      command,
+      tags: [tag, "cli"],
+      trustBoundaries: ["user-input", "filesystem", "process-exec"],
+    });
+  }
+  return seeds;
+}
+
+function definesMain(source: string): boolean {
+  const stripped = stripBlockComments(stripLineComments(source, "//"));
+  return /(?:^|[;{}\n])\s*(?:extern\s+"C"\s*)?(?:[\w:<>~*&\s]+\s+)+main\s*\([^;{}]*\)\s*(?:noexcept\s*)?(?:->\s*[\w:<>~*&\s]+)?\s*\{/u.test(
+    stripped,
+  );
+}
+
+function stripBlockComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//gu, " ");
+}
+
+function collapseBackslashContinuations(source: string): string {
+  return source.replace(/\\\r?\n/gu, " ");
+}
+
+function readTargetSources(body: string, target: string): string[] {
+  const escaped = target.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const pattern = new RegExp(`^\\s*${escaped}_SOURCES\\s*=\\s*(.+)$`, "mu");
+  const raw = pattern.exec(body)?.[1] ?? "";
+  return splitWords(raw);
+}
+
+function splitWords(value: string): string[] {
+  return value.split(/\s+/u).filter((word) => word.length > 0);
+}
+
+async function pickEntry(
+  root: string,
+  dir: string,
+  candidates: string[],
+  targetName: string,
+): Promise<string | null> {
+  if (candidates.length === 0) {
+    return null;
+  }
+  for (const candidate of candidates) {
+    const full = prefixDir(dir, candidate);
+    if ((await isSafeFile(root, join(root, full))) && full.split("/").at(-1) === targetName) {
+      return full;
+    }
+  }
+  const preferred = candidates.find((candidate) => {
+    const base = candidate.split("/").at(-1) ?? candidate;
+    return base.startsWith(targetName) || base.startsWith("main.");
+  });
+  if (preferred !== undefined) {
+    return prefixDir(dir, preferred);
+  }
+  const first = candidates[0];
+  return first === undefined ? null : prefixDir(dir, first);
+}
+
+function targetSourceRefs(dir: string, sources: string[]): Array<{ path: string; reason: string }> {
+  return sources
+    .filter(isCOrCppCompilable)
+    .map((source) => ({ path: prefixDir(dir, source), reason: "target source" }));
+}
+
+function prefixDir(dir: string, file: string): string {
+  const normalizedFile = normalize(file).replace(/^\.\//u, "");
+  if (dir.length === 0) {
+    return normalizedFile.replace(/^\/+/u, "");
+  }
+  if (normalizedFile.startsWith("/")) {
+    return `${dir}${normalizedFile.replace(/^\/+/u, "")}`;
+  }
+  return `${dir}${normalizedFile}`;
+}
+
+function parentDir(path: string): string {
+  const index = path.lastIndexOf("/");
+  return index === -1 ? "" : path.slice(0, index + 1);
+}
+
+function isValidTargetName(value: string): boolean {
+  return (
+    value.length > 0 &&
+    !value.startsWith("$") &&
+    !value.startsWith("\\") &&
+    !value.includes("(") &&
+    !value.includes("=") &&
+    !value.includes("#")
+  );
+}
+
+function dedupeByEntry(seeds: FeatureSeed[]): FeatureSeed[] {
+  const seen = new Set<string>();
+  const output: FeatureSeed[] = [];
+  for (const seed of seeds) {
+    const key = `${seed.entryPath}:${seed.kind}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    output.push(seed);
+  }
+  return output;
+}

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -257,8 +257,8 @@ export function isCOrCppTestPath(path: string): boolean {
   return (
     /(^|\/)(test|tests|__tests__)\//u.test(path) ||
     /^test[_-]/u.test(base) ||
-    /[_-]test\./u.test(base) ||
-    /Test\./u.test(base)
+    /[_-]tests?\./u.test(base) ||
+    /Tests?\./u.test(base)
   );
 }
 

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -14,6 +14,7 @@ export async function nearbyTests(
   entryPath: string,
   testCommand: string | null,
   seedTestPrefixes: string[],
+  seedTestNames: string[] = [],
 ): Promise<TestRef[]> {
   const dir = dirname(entryPath);
   const base = entryPath.replace(/\.[^.]+$/u, "");
@@ -41,6 +42,7 @@ export async function nearbyTests(
       .at(-1)
       ?.replace(/\.[^.]+$/u, "") ?? "";
   const swiftTestPrefixes = seedTestPrefixes.length > 0 ? [] : swiftTestPrefixesForEntry(entryPath);
+  const cOrCppTestNames = seedTestNames.map(testNameToken).filter((name) => name.length > 0);
   const tests = all
     .filter((path) => path !== entryPath)
     .filter(
@@ -61,6 +63,7 @@ export async function nearbyTests(
           rustTestPrefixes.some((prefix) => pathMatchesPrefix(path, prefix))) ||
         (isCOrCppPath(path) &&
           seedTestPrefixes.some((prefix) => pathMatchesPrefix(path, prefix))) ||
+        (isCOrCppPath(path) && cOrCppTestNames.some((name) => pathMatchesTestName(path, name))) ||
         (path.endsWith(".swift") &&
           seedTestPrefixes.some((prefix) => pathMatchesPrefix(path, prefix))) ||
         (path.endsWith(".swift") &&
@@ -241,6 +244,24 @@ export function stripSwiftComments(source: string): string {
 export function pathMatchesPrefix(path: string, prefix: string): boolean {
   const normalized = normalize(prefix).replace(/\/$/u, "");
   return normalized === "" || path === normalized || path.startsWith(`${normalized}/`);
+}
+
+function pathMatchesTestName(path: string, name: string): boolean {
+  const normalized = testNameToken(path.replace(/\.[^.]+$/u, ""));
+  return (
+    normalized === name ||
+    normalized.startsWith(`${name}_`) ||
+    normalized.endsWith(`_${name}`) ||
+    normalized.includes(`_${name}_`)
+  );
+}
+
+function testNameToken(name: string): string {
+  return name
+    .replace(/\.[^.]+$/u, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "_")
+    .replace(/^_+|_+$/gu, "");
 }
 
 export async function detectNodePackageManager(root: string): Promise<string> {

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -249,16 +249,16 @@ function isJsTestPath(path: string): boolean {
 }
 
 export function isCOrCppPath(path: string): boolean {
-  return /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/u.test(path);
+  return /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/iu.test(path);
 }
 
 export function isCOrCppTestPath(path: string): boolean {
   const base = path.split("/").at(-1) ?? path;
   return (
     /(^|\/)(test|tests|__tests__)\//u.test(path) ||
-    /^test[_-]/u.test(base) ||
-    /[_-]tests?\./u.test(base) ||
-    /Tests?\./u.test(base)
+    /^test[_-]/iu.test(base) ||
+    /[_-]tests?\./iu.test(base) ||
+    /Tests?\./iu.test(base)
   );
 }
 

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -41,6 +41,7 @@ export async function nearbyTests(
       .split("/")
       .at(-1)
       ?.replace(/\.[^.]+$/u, "") ?? "";
+  const stemTestName = testNameToken(stem);
   const swiftTestPrefixes = seedTestPrefixes.length > 0 ? [] : swiftTestPrefixesForEntry(entryPath);
   const cOrCppTestNames = seedTestNames.map(testNameToken).filter((name) => name.length > 0);
   const tests = all
@@ -58,7 +59,11 @@ export async function nearbyTests(
     .filter(
       (path) =>
         path.startsWith(base) ||
-        path.includes(stem) ||
+        (!isCOrCppEntry && path.includes(stem)) ||
+        (isCOrCppEntry &&
+          stemTestName !== "main" &&
+          stemTestName.length > 0 &&
+          pathMatchesTestName(path, stemTestName)) ||
         (path.endsWith(".rs") &&
           rustTestPrefixes.some((prefix) => pathMatchesPrefix(path, prefix))) ||
         (isCOrCppPath(path) &&

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -36,11 +36,13 @@ export async function nearbyTests(
   const swiftTestPrefixes = seedTestPrefixes.length > 0 ? [] : swiftTestPrefixesForEntry(entryPath);
   const isRustEntry = entryPath.endsWith(".rs");
   const isSwiftEntry = entryPath.endsWith(".swift");
+  const isCOrCppEntry = isCOrCppPath(entryPath);
   const tests = all
     .filter((path) => path !== entryPath)
     .filter(
       (path) =>
         (isRustEntry && path.endsWith(".rs") && isTestPath(path)) ||
+        (isCOrCppEntry && isCOrCppPath(path) && isCOrCppTestPath(path)) ||
         (isSwiftEntry &&
           path.endsWith(".swift") &&
           (isTestPath(path) ||
@@ -53,6 +55,8 @@ export async function nearbyTests(
         path.includes(stem) ||
         (path.endsWith(".rs") &&
           rustTestPrefixes.some((prefix) => pathMatchesPrefix(path, prefix))) ||
+        (isCOrCppPath(path) &&
+          seedTestPrefixes.some((prefix) => pathMatchesPrefix(path, prefix))) ||
         (path.endsWith(".swift") &&
           seedTestPrefixes.some((prefix) => pathMatchesPrefix(path, prefix))) ||
         (path.endsWith(".swift") &&
@@ -242,6 +246,20 @@ function isTestPath(path: string): boolean {
 
 function isJsTestPath(path: string): boolean {
   return /\.(test|spec)\.(ts|tsx|js|jsx)$/u.test(path);
+}
+
+export function isCOrCppPath(path: string): boolean {
+  return /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/u.test(path);
+}
+
+export function isCOrCppTestPath(path: string): boolean {
+  const base = path.split("/").at(-1) ?? path;
+  return (
+    /(^|\/)(test|tests|__tests__)\//u.test(path) ||
+    /^test[_-]/u.test(base) ||
+    /[_-]test\./u.test(base) ||
+    /Test\./u.test(base)
+  );
 }
 
 function swiftTestPrefixesForEntry(entryPath: string): string[] {

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -176,7 +176,7 @@ export function shouldSkip(path: string): boolean {
     return false;
   }
   return (
-    /(^|\/)(node_modules|dist|build|coverage|\.build|\.git|\.clawpatch|\.worktrees|\.venv|venv|vendor|Pods|Carthage|SourcePackages|DerivedData|__pycache__)(\/|$)/u.test(
+    /(^|\/)(node_modules|dist|build|coverage|\.build|\.git|\.clawpatch|\.worktrees|\.venv|venv|Pods|Carthage|SourcePackages|DerivedData|__pycache__)(\/|$)/u.test(
       path,
     ) ||
     path === "target" ||

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -66,7 +66,11 @@ export async function nearbyTests(
   return tests.map((path) => ({ path, command: testCommand }));
 }
 
-export async function walk(root: string, prefixes: string[]): Promise<string[]> {
+export async function walk(
+  root: string,
+  prefixes: string[],
+  skipPath: (path: string) => boolean = shouldSkip,
+): Promise<string[]> {
   const files: string[] = [];
   const seen = new Set<string>();
   const seenRoots = new Set<string>();
@@ -89,7 +93,7 @@ export async function walk(root: string, prefixes: string[]): Promise<string[]> 
     }
     const rel = normalize(relative(realRoot, canonicalStart));
     if (info.isFile()) {
-      if (!seen.has(rel) && !shouldSkip(rel)) {
+      if (!seen.has(rel) && !skipPath(rel)) {
         seen.add(rel);
         files.push(rel);
       }
@@ -99,7 +103,7 @@ export async function walk(root: string, prefixes: string[]): Promise<string[]> 
       continue;
     }
     seenRoots.add(canonicalStart);
-    await walkDir(realRoot, canonicalStart, files, seen);
+    await walkDir(realRoot, canonicalStart, files, seen, skipPath);
   }
   return files.toSorted();
 }
@@ -109,6 +113,7 @@ async function walkDir(
   dir: string,
   files: string[],
   seen: Set<string>,
+  skipPath: (path: string) => boolean,
 ): Promise<void> {
   const dirInfo = await lstat(dir);
   if (dirInfo.isSymbolicLink()) {
@@ -119,14 +124,14 @@ async function walkDir(
     return;
   }
   const relDir = normalize(relative(root, dir));
-  if (shouldSkip(relDir)) {
+  if (skipPath(relDir)) {
     return;
   }
   const entries = await readdir(dir);
   for (const entry of entries) {
     const full = join(dir, entry);
     const rel = normalize(relative(root, full));
-    if (seen.has(rel) || shouldSkip(rel)) {
+    if (seen.has(rel) || skipPath(rel)) {
       continue;
     }
     seen.add(rel);
@@ -135,7 +140,7 @@ async function walkDir(
       continue;
     }
     if (info.isDirectory()) {
-      await walkDir(root, full, files, seen);
+      await walkDir(root, full, files, seen, skipPath);
     } else if (info.isFile()) {
       files.push(rel);
     }

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -260,7 +260,7 @@ export function isCOrCppPath(path: string): boolean {
 export function isCOrCppTestPath(path: string): boolean {
   const base = path.split("/").at(-1) ?? path;
   return (
-    /(^|\/)(test|tests|__tests__)\//u.test(path) ||
+    /(^|\/)(test|tests|__tests__)\//iu.test(path) ||
     /^test[_-]/iu.test(base) ||
     /(?:^|[_-])tests?\./iu.test(base) ||
     /Tests?\.[^.]+$/u.test(base)

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -257,8 +257,8 @@ export function isCOrCppTestPath(path: string): boolean {
   return (
     /(^|\/)(test|tests|__tests__)\//u.test(path) ||
     /^test[_-]/iu.test(base) ||
-    /[_-]tests?\./iu.test(base) ||
-    /Tests?\./iu.test(base)
+    /(?:^|[_-])tests?\./iu.test(base) ||
+    /Tests?\.[^.]+$/u.test(base)
   );
 }
 

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -47,7 +47,7 @@ export async function nearbyTests(
           path.endsWith(".swift") &&
           (isTestPath(path) ||
             seedTestPrefixes.some((prefix) => pathMatchesPrefix(path, prefix)))) ||
-        (!isRustEntry && !isSwiftEntry && isJsTestPath(path)),
+        (!isRustEntry && !isSwiftEntry && !isCOrCppEntry && isJsTestPath(path)),
     )
     .filter(
       (path) =>

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -176,7 +176,7 @@ export function shouldSkip(path: string): boolean {
     return false;
   }
   return (
-    /(^|\/)(node_modules|dist|build|coverage|\.build|\.git|\.clawpatch|\.worktrees)(\/|$)/u.test(
+    /(^|\/)(node_modules|dist|build|coverage|\.build|\.git|\.clawpatch|\.worktrees|\.venv|venv|vendor|Pods|Carthage|SourcePackages|DerivedData|__pycache__)(\/|$)/u.test(
       path,
     ) ||
     path === "target" ||

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -18,25 +18,29 @@ export async function nearbyTests(
   const dir = dirname(entryPath);
   const base = entryPath.replace(/\.[^.]+$/u, "");
   const rustTestPrefixes = rustTestPrefixesForEntry(entryPath);
-  const all = await walk(root, [
-    dir === "." ? "" : dir,
-    "test",
-    "Tests",
-    "tests",
-    "__tests__",
-    "src",
-    ...rustTestPrefixes,
-    ...seedTestPrefixes,
-  ]);
+  const isRustEntry = entryPath.endsWith(".rs");
+  const isSwiftEntry = entryPath.endsWith(".swift");
+  const isCOrCppEntry = isCOrCppPath(entryPath);
+  const all = await walk(
+    root,
+    [
+      dir === "." ? "" : dir,
+      "test",
+      "Tests",
+      "tests",
+      "__tests__",
+      "src",
+      ...rustTestPrefixes,
+      ...seedTestPrefixes,
+    ],
+    isCOrCppEntry ? shouldSkipCOrCppNearbyPath : shouldSkip,
+  );
   const stem =
     entryPath
       .split("/")
       .at(-1)
       ?.replace(/\.[^.]+$/u, "") ?? "";
   const swiftTestPrefixes = seedTestPrefixes.length > 0 ? [] : swiftTestPrefixesForEntry(entryPath);
-  const isRustEntry = entryPath.endsWith(".rs");
-  const isSwiftEntry = entryPath.endsWith(".swift");
-  const isCOrCppEntry = isCOrCppPath(entryPath);
   const tests = all
     .filter((path) => path !== entryPath)
     .filter(
@@ -265,6 +269,14 @@ export function isCOrCppTestPath(path: string): boolean {
     /(?:^|[_-])tests?\./iu.test(base) ||
     /Tests?\.[^.]+$/u.test(base)
   );
+}
+
+function shouldSkipCOrCppNearbyPath(path: string): boolean {
+  return shouldSkip(path) || isCOrCppDependencyPath(path) || isSampleProjectPath(path);
+}
+
+function isCOrCppDependencyPath(path: string): boolean {
+  return /(^|\/)(vendor|CMakeFiles|cmake-build-[^/]+)(\/|$)/u.test(path);
 }
 
 function swiftTestPrefixesForEntry(entryPath: string): string[] {


### PR DESCRIPTION
## Summary

- Add a deterministic C/C++ mapper for standalone `main()` files, CMake `add_executable` / `add_library` targets, and autotools `bin_PROGRAMS` / `lib_LTLIBRARIES` targets.
- Detect `c` / `cpp` languages plus `cmake` / `autotools` project signals.
- Attach nearby C/C++ tests without mapping test files with their own `main()` as CLI features.
- Document the new mapper and call out that project-specific C dialects such as php-src extension metadata stay out of scope.

## Verification

- `corepack pnpm typecheck`
- `corepack pnpm lint`
- `corepack pnpm format:check`
- `corepack pnpm test`
- `corepack pnpm build`
- Built CLI runtime probe from `/tmp`: `init` + `map` on a CMake C/C++ fixture produced `CMake binary myapp` and `CMake library core`, attached `tests/main_test.cpp`, and did not emit `C++ binary main_test`.
