### PR TITLE
fix(mapper): tighten Ruby Rails detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added JVM semantic role mapping from Java annotations, imports, inheritance, interfaces, and method signatures.
 - Added Ruby and Rails feature mapping while excluding legacy Rails secrets from reviewable config.
+- Fixed Ruby/Rails project detection so `gems.rb` uses Bundler commands and Rails JavaScript roots avoid duplicate Node feature queues.
 - Added selected package script mapping for Node workspace packages.
 - Detected Java/Kotlin language and default Gradle build/test commands for root Gradle projects.
 - Added FastAPI route feature mapping and kept root/web Python project detection in sync.

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -245,7 +245,7 @@ async function detectPackageManagers(root: string): Promise<string[]> {
     found.push((await pathExists(join(root, "requirements.txt"))) ? "pip" : "python");
   }
   if ((await isRubyProject(root)) && !found.some((name) => rubyPackageManagers.has(name))) {
-    found.push((await pathExists(join(root, "Gemfile"))) ? "bundler" : "ruby");
+    found.push((await hasBundlerConfig(root)) ? "bundler" : "ruby");
   }
   return found;
 }
@@ -345,7 +345,7 @@ function pythonRunCommand(runner: string | null, command: string): string {
 
 async function rubyDefaultCommands(root: string): Promise<ProjectCommands> {
   const source = await rubyDependencySource(root);
-  const hasBundle = await pathExists(join(root, "Gemfile"));
+  const hasBundle = await hasBundlerConfig(root);
   const hasRspec = /\brspec\b/iu.test(source) || (await containsRubySpecFile(root, 5));
   const hasMinitest = /\bminitest\b/iu.test(source) || (await containsRubyTestFile(root, 5));
   const hasRubocop =
@@ -359,6 +359,10 @@ async function rubyDefaultCommands(root: string): Promise<ProjectCommands> {
     format: null,
     test: hasRspec ? `${run}rspec` : hasMinitest ? `${run}rake test` : null,
   };
+}
+
+async function hasBundlerConfig(root: string): Promise<boolean> {
+  return (await pathExists(join(root, "Gemfile"))) || (await pathExists(join(root, "gems.rb")));
 }
 
 async function rubyDependencySource(root: string): Promise<string> {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -252,6 +252,26 @@ describe("mapFeatures", () => {
     ).not.toContain("vendor/bundle/ignored.rb");
   });
 
+  it("treats gems.rb projects as Bundler-backed", async () => {
+    const root = await fixtureRoot("clawpatch-map-gems-rb-");
+    await writeFixture(
+      root,
+      "gems.rb",
+      "source 'https://rubygems.org'\ngem 'rspec'\ngem 'rubocop'\n",
+    );
+    await writeFixture(root, "lib/fixture.rb", "module Fixture\nend\n");
+    await writeFixture(root, "spec/fixture_spec.rb", "RSpec.describe Fixture\n");
+
+    const project = await detectProject(root);
+
+    expect(project.detected.languages).toContain("ruby");
+    expect(project.detected.packageManagers).toContain("bundler");
+    expect(project.detected.commands).toMatchObject({
+      lint: "bundle exec rubocop",
+      test: "bundle exec rspec",
+    });
+  });
+
   it("maps Gemfile-only Jekyll sites without mistaking dependencies for project names", async () => {
     const root = await fixtureRoot("clawpatch-map-jekyll-");
     await writeFixture(
@@ -335,6 +355,11 @@ describe("mapFeatures", () => {
     await writeFixture(root, "app/views/widgets/index.json.jbuilder", "json.widgets []\n");
     await writeFixture(root, "app/assets/javascripts/widgets.coffee", "console.log 'widgets'\n");
     await writeFixture(root, "app/assets/stylesheets/widgets.scss", ".widgets { color: black; }\n");
+    await writeFixture(
+      root,
+      "app/javascript/controllers/widgets_controller.js",
+      "export function connect() {}\n",
+    );
     await writeFixture(root, "src/client.ts", "export function client() {}\n");
     await writeFixture(root, "lib/client.ts", "export function libClient() {}\n");
     await writeFixture(root, "pages/home.tsx", "export function Home() { return null; }\n");
@@ -362,6 +387,7 @@ describe("mapFeatures", () => {
     expect(titles).not.toContain("Ruby CLI command rails");
     expect(titles).not.toContain("Node source app");
     expect(titles).not.toContain("Node source app/assets");
+    expect(titles).toContain("Node source app/javascript");
     expect(titles).toContain("Node source src");
     expect(titles).toContain("Node source lib");
     expect(titles).toContain("Node source pages");
@@ -374,6 +400,13 @@ describe("mapFeatures", () => {
     );
     expect(railsConfig?.ownedFiles.map((ref) => ref.path)).toContain("config/routes.rb");
     expect(railsConfig?.ownedFiles.map((ref) => ref.path)).not.toContain("config/secrets.yml");
+    expect(
+      result.features.filter((feature) =>
+        feature.ownedFiles.some(
+          (ref) => ref.path === "app/javascript/controllers/widgets_controller.js",
+        ),
+      ),
+    ).toHaveLength(1);
     expect(referencedFiles).not.toContain("config/secrets.yml");
   });
 

--- a/src/mappers/node.ts
+++ b/src/mappers/node.ts
@@ -497,9 +497,10 @@ async function packageContextFiles(root: string, info: PackageInfo): Promise<See
 
 async function packageSourceRoots(root: string, info: PackageInfo): Promise<string[]> {
   if (await isRailsPackage(root, info.root)) {
+    const railsSourceDirectories = sourceDirectories.filter((dir) => dir !== "app");
     return [
       ...new Set(
-        [...sourceDirectories, "app/javascript", "app/packs", "app/frontend"].map((dir) =>
+        [...railsSourceDirectories, "app/javascript", "app/packs", "app/frontend"].map((dir) =>
           packageRelativePath(info.root, dir),
         ),
       ),


### PR DESCRIPTION
## Summary
- treat `gems.rb` projects as Bundler-backed for package manager detection and default commands
- avoid duplicate Rails JavaScript Node source queues by excluding the broad Rails `app` root
- add regression coverage and changelog entry

## Tests
- pnpm test src/mapper.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test

Note: local `pnpm format:check` reports the existing macOS `oxfmt` broad-format mismatch across unrelated files; touched-file whitespace was checked with `git diff --check`.