### PR TITLE
feat(mapper): improve Python packaging support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added JVM semantic role mapping from Java annotations, imports, inheritance, interfaces, and method signatures.
 - Added Ruby and Rails feature mapping while excluding legacy Rails secrets from reviewable config.
 - Fixed Ruby/Rails project detection so `gems.rb` uses Bundler commands and Rails JavaScript roots avoid duplicate Node feature queues.
+- Improved Python mapping for `setup.cfg`/`setup.py` project metadata and console scripts, plus `black --check .` format defaults.
 - Added selected package script mapping for Node workspace packages.
 - Detected Java/Kotlin language and default Gradle build/test commands for root Gradle projects.
 - Added FastAPI route feature mapping and kept root/web Python project detection in sync.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ validation commands and records a patch attempt under `.clawpatch/`.
 - Rust `src/main.rs`, `src/bin/*.rs`, `src/lib.rs`, `crates/*`, and
   `tests/*.rs`
 - Python project metadata, console scripts, bounded source groups, pytest suites,
-  and Flask routes
+  and Flask/FastAPI routes
 - SwiftPM `Sources/*` targets and `Tests/*` suites
 - common project config files
 

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -63,12 +63,15 @@ Java files in Gradle modules also get role-oriented review slices when code
 evidence identifies web entrypoints, services, persistence boundaries, external
 clients, configuration, framework components, or extension boundaries.
 
-Python mapping covers `pyproject.toml` metadata, `[project.scripts]` and
-`[tool.poetry.scripts]` console scripts, root app files, source groups under
-common Python source roots including `web/`, pytest files, Flask `@*.route(...)`
-handlers, and FastAPI `@*.get(...)` / `@*.api_route(...)` handlers. Flask and
-FastAPI route methods are read from list, tuple, or set literals. FastAPI paths
-can be positional strings or literal `path=` keywords.
+Python mapping covers `pyproject.toml`, `setup.cfg`, `setup.py`, and
+`requirements.txt` metadata; `[project.scripts]`, `[tool.poetry.scripts]`,
+`setup.cfg` `console_scripts`, and `setup.py` console script entry points; root
+app files; source groups under common Python source roots including `web/`;
+pytest files; Flask `@*.route(...)` handlers; and FastAPI `@*.get(...)` /
+`@*.api_route(...)` handlers. Flask and FastAPI route methods are read from list,
+tuple, or set literals. FastAPI paths can be positional strings or literal
+`path=` keywords. Default Python command detection covers pytest, ruff, mypy,
+pyright, and black.
 
 Ruby mapping covers project metadata, executables, source groups, RSpec and
 Minitest suites, and Rails app structure. Rails legacy `config/secrets.yml` is

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,7 @@ This discovers reviewable features:
 - Next.js routes
 - Go packages and commands
 - Java/Kotlin Gradle modules
-- Python packages, console scripts, Flask routes, and pytest suites
+- Python packages, console scripts, Flask/FastAPI routes, and pytest suites
 - JVM semantic role groups
 - Ruby packages, Rails apps, executables, and tests
 - Rust crates and binaries

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -280,6 +280,7 @@ async function pythonDefaultCommands(root: string): Promise<ProjectCommands> {
     info.dependencies.has("pytest") ||
     (await containsPythonTestFile(root, 5));
   const hasRuff = info.tools.has("ruff") || info.dependencies.has("ruff");
+  const hasBlack = info.tools.has("black") || info.dependencies.has("black");
   const hasPyright = info.tools.has("pyright") || info.dependencies.has("pyright");
   const hasMypy = info.tools.has("mypy") || info.dependencies.has("mypy");
   return {
@@ -291,7 +292,11 @@ async function pythonDefaultCommands(root: string): Promise<ProjectCommands> {
           ? pythonRunCommand(runner, "ruff check .")
           : null,
     lint: hasRuff ? pythonRunCommand(runner, "ruff check .") : null,
-    format: hasRuff ? pythonRunCommand(runner, "ruff format --check .") : null,
+    format: hasRuff
+      ? pythonRunCommand(runner, "ruff format --check .")
+      : hasBlack
+        ? pythonRunCommand(runner, "black --check .")
+        : null,
     test: hasPytest ? pythonRunCommand(runner, "pytest") : null,
   };
 }
@@ -410,7 +415,7 @@ async function pythonProjectInfo(root: string): Promise<PythonProjectInfo> {
     if (/^\s*(?:\[tool:pytest\]|\[pytest\])\s*(?:#.*)?$/mu.test(source)) {
       info.hasPytestConfig = true;
     }
-    for (const toolMatch of source.matchAll(/^\s*\[(mypy|pyright|ruff)\]/gmu)) {
+    for (const toolMatch of source.matchAll(/^\s*\[(mypy|pyright|ruff|black)\]/gmu)) {
       if (toolMatch[1] !== undefined) {
         info.tools.add(toolMatch[1]);
       }

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1577,6 +1577,21 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
       },
     });
 
+    const blackRoot = await fixtureRoot("clawpatch-python-black-");
+    await writeFixture(blackRoot, "requirements.txt", "black\n");
+    expect((await detectProject(blackRoot)).detected.commands.format).toBe("black --check .");
+
+    const uvBlackRoot = await fixtureRoot("clawpatch-python-uv-black-");
+    await writeFixture(
+      uvBlackRoot,
+      "pyproject.toml",
+      '[project]\nname = "uv-black"\ndependencies = ["black"]\n',
+    );
+    await writeFixture(uvBlackRoot, "uv.lock", "");
+    expect((await detectProject(uvBlackRoot)).detected.commands.format).toBe(
+      "uv run black --check .",
+    );
+
     const poetryRoot = await fixtureRoot("clawpatch-python-poetry-");
     await writeFixture(
       poetryRoot,
@@ -2153,6 +2168,60 @@ let package = Package(name: "HybridApp", targets: [.target(name: "HybridApp")])
       { path: "setup.cfg", reason: "python project metadata" },
       { path: "requirements.txt", reason: "python project metadata" },
     ]);
+  });
+
+  it("maps setup.cfg Python project names and console scripts", async () => {
+    const root = await fixtureRoot("clawpatch-python-setup-cfg-entry-points-");
+    await writeFixture(
+      root,
+      "setup.cfg",
+      [
+        "[metadata]",
+        "name = legacy-cli",
+        "",
+        "[options.entry_points]",
+        "console_scripts =",
+        "    legacy = legacy.cli:main",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(root, "legacy/cli.py", "def main():\n    pass\n");
+    await writeFixture(root, "tests/test_cli.py", "def test_cli():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const cli = result.features.find((feature) => feature.title === "Python CLI command legacy");
+
+    expect(titles).toContain("Python project legacy-cli");
+    expect(cli?.entrypoints[0]).toMatchObject({ path: "legacy/cli.py", symbol: "main" });
+    expect(cli?.tests).toEqual([{ path: "tests/test_cli.py", command: "pytest" }]);
+  });
+
+  it("maps setup.py Python project names and console scripts", async () => {
+    const root = await fixtureRoot("clawpatch-python-setup-py-entry-points-");
+    await writeFixture(
+      root,
+      "setup.py",
+      [
+        "from setuptools import setup",
+        "",
+        "setup(",
+        "    name='setup-cli',",
+        "    entry_points={'console_scripts': ['setcli=setup_cli.cli:main']},",
+        ")",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(root, "setup_cli/cli.py", "def main():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const cli = result.features.find((feature) => feature.title === "Python CLI command setcli");
+
+    expect(titles).toContain("Python project setup-cli");
+    expect(cli?.entrypoints[0]).toMatchObject({ path: "setup_cli/cli.py", symbol: "main" });
   });
 
   it("keeps Python source group ids stable when a root gains files", async () => {

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -15,6 +15,7 @@ import { FeatureSeed, SeedFileRef, SeedTestRef } from "./types.js";
 type PythonScript = {
   name: string;
   target: string;
+  metadataPath: string;
 };
 
 type FlaskRoute = {
@@ -76,53 +77,53 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
   if (!(await isPythonProject(root))) {
     return [];
   }
-  const pyproject = await readPyproject(root);
+  const metadata = await readPythonProjectMetadata(root);
   const metadataFiles = await pythonMetadataFiles(root);
-  const testCommand = await pythonTestCommand(root, pyproject);
+  const testCommand = await pythonTestCommand(root, metadata);
   const testFiles = await pythonTestFiles(root);
   const seeds: FeatureSeed[] = [];
 
   if (metadataFiles.length > 0) {
     seeds.push({
-      title: `Python project ${pyproject.name ?? basename(root)}`,
+      title: `Python project ${metadata.name ?? basename(root)}`,
       summary: `Python project metadata in ${metadataFiles.join(", ")}.`,
-      kind: packageKind(pyproject.name ?? basename(root)),
+      kind: packageKind(metadata.name ?? basename(root)),
       source: "python-project",
       confidence: "medium",
       entryPath: metadataFiles[0] ?? "pyproject.toml",
-      symbol: pyproject.name,
+      symbol: metadata.name,
       route: null,
       command: null,
       ownedFiles: metadataFiles.map((path) => ({ path, reason: "python project metadata" })),
       contextFiles: await pythonProjectContextFiles(root, metadataFiles),
       tags: ["python", "package"],
-      trustBoundaries: packageTrustBoundaries(pyproject.name ?? basename(root)),
+      trustBoundaries: packageTrustBoundaries(metadata.name ?? basename(root)),
       skipNearbyTests: true,
     });
   }
 
-  for (const script of pyproject.scripts) {
-    const resolved = await resolvePythonScript(root, script.target);
+  for (const script of metadata.scripts) {
+    const resolved = await resolvePythonScript(root, script.target, script.metadataPath);
     const tests =
-      resolved.entryPath === "pyproject.toml"
+      resolved.entryPath === script.metadataPath
         ? []
         : associatedTests([resolved.entryPath], testFiles, testCommand);
     seeds.push({
       title: `Python CLI command ${script.name}`,
       summary:
-        resolved.entryPath === "pyproject.toml"
+        resolved.entryPath === script.metadataPath
           ? `Python console script '${script.name}' targets ${script.target}.`
           : `Python console script '${script.name}' targets ${script.target}, source ${resolved.entryPath}.`,
       kind: "cli-command",
       source: "python-console-script",
-      confidence: resolved.entryPath === "pyproject.toml" ? "medium" : "high",
+      confidence: resolved.entryPath === script.metadataPath ? "medium" : "high",
       entryPath: resolved.entryPath,
       symbol: resolved.symbol,
       route: null,
       command: script.name,
       ownedFiles:
-        resolved.entryPath === "pyproject.toml"
-          ? [{ path: "pyproject.toml", reason: "console script metadata" }]
+        resolved.entryPath === script.metadataPath
+          ? [{ path: script.metadataPath, reason: "console script metadata" }]
           : [{ path: resolved.entryPath, reason: "console script source" }],
       contextFiles: tests.map((test) => ({ path: test.path, reason: "associated test" })),
       tests,
@@ -183,22 +184,32 @@ async function isPythonProject(root: string): Promise<boolean> {
   );
 }
 
-async function readPyproject(root: string): Promise<PyprojectInfo> {
-  if (!(await pathExists(join(root, "pyproject.toml")))) {
-    return { name: null, scripts: [], hasPytest: false };
-  }
-  const source = await readFile(join(root, "pyproject.toml"), "utf8");
-  return {
-    name:
+async function readPythonProjectMetadata(root: string): Promise<PyprojectInfo> {
+  const metadata: PyprojectInfo = { name: null, scripts: [], hasPytest: false };
+  if (await pathExists(join(root, "pyproject.toml"))) {
+    const source = await readFile(join(root, "pyproject.toml"), "utf8");
+    metadata.name =
       tomlStringValue(table(source, "project"), "name") ??
-      tomlStringValue(table(source, "tool.poetry"), "name"),
-    scripts: [
-      ...scriptsFromTable(table(source, "project.scripts")),
-      ...scriptsFromTable(table(source, "tool.poetry.scripts")),
-    ],
-    hasPytest:
-      table(source, "tool.pytest.ini_options").length > 0 || dependencyNames(source).has("pytest"),
-  };
+      tomlStringValue(table(source, "tool.poetry"), "name");
+    metadata.scripts.push(
+      ...scriptsFromTable(table(source, "project.scripts"), "pyproject.toml"),
+      ...scriptsFromTable(table(source, "tool.poetry.scripts"), "pyproject.toml"),
+    );
+    metadata.hasPytest =
+      table(source, "tool.pytest.ini_options").length > 0 || dependencyNames(source).has("pytest");
+  }
+  if (await pathExists(join(root, "setup.cfg"))) {
+    const source = await readFile(join(root, "setup.cfg"), "utf8");
+    metadata.name ??= setupCfgStringValue(source, "metadata", "name");
+    metadata.scripts.push(...setupCfgConsoleScripts(source));
+    metadata.hasPytest ||= /^\s*(?:\[tool:pytest\]|\[pytest\])\s*(?:#.*)?$/mu.test(source);
+  }
+  if (await pathExists(join(root, "setup.py"))) {
+    const source = await readFile(join(root, "setup.py"), "utf8");
+    metadata.name ??= setupPyStringValue(source, "name");
+    metadata.scripts.push(...setupPyConsoleScripts(source));
+  }
+  return metadata;
 }
 
 async function pythonMetadataFiles(root: string): Promise<string[]> {
@@ -346,10 +357,11 @@ async function pythonProjectContextFiles(
 async function resolvePythonScript(
   root: string,
   target: string,
+  metadataPath: string,
 ): Promise<{ entryPath: string; symbol: string | null }> {
   const [moduleName, symbol = null] = target.split(":");
   if (moduleName === undefined || moduleName.length === 0) {
-    return { entryPath: "pyproject.toml", symbol };
+    return { entryPath: metadataPath, symbol };
   }
   const modulePath = `${moduleName.replace(/\./gu, "/")}.py`;
   const packageInitPath = `${moduleName.replace(/\./gu, "/")}/__init__.py`;
@@ -363,7 +375,7 @@ async function resolvePythonScript(
       return { entryPath: candidate, symbol };
     }
   }
-  return { entryPath: "pyproject.toml", symbol };
+  return { entryPath: metadataPath, symbol };
 }
 
 async function fastApiRouteSeeds(
@@ -1043,15 +1055,101 @@ function tomlStringValue(source: string, key: string): string | null {
   return new RegExp(`^\\s*${escapedKey}\\s*=\\s*(["'])([^"']+)\\1`, "mu").exec(source)?.[2] ?? null;
 }
 
-function scriptsFromTable(source: string): PythonScript[] {
+function scriptsFromTable(source: string, metadataPath: string): PythonScript[] {
   const scripts: PythonScript[] = [];
   for (const line of source.split("\n")) {
     const match = /^\s*["']?([^#"'=\s]+)["']?\s*=\s*(["'])([^"']+)\2/u.exec(line);
     if (match?.[1] !== undefined && match[3] !== undefined) {
-      scripts.push({ name: match[1], target: match[3] });
+      scripts.push({ name: match[1], target: match[3], metadataPath });
     }
   }
   return scripts;
+}
+
+function setupCfgStringValue(source: string, sectionName: string, keyName: string): string | null {
+  const section = iniSection(source, sectionName);
+  const escapedKey = keyName.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return (
+    new RegExp(`^\\s*${escapedKey}\\s*=\\s*([^#;\\r\\n]+)`, "imu").exec(section)?.[1]?.trim() ??
+    null
+  );
+}
+
+function setupCfgConsoleScripts(source: string): PythonScript[] {
+  const scripts: PythonScript[] = [];
+  const section = iniSection(source, "options.entry_points");
+  let inConsoleScripts = false;
+  for (const rawLine of section.split("\n")) {
+    const line = rawLine.replace(/\r$/u, "");
+    if (/^\s*(?:#|;|$)/u.test(line)) {
+      continue;
+    }
+    const assignment = /^\s*([A-Za-z0-9_.-]+)\s*=\s*(.*)$/u.exec(line);
+    if (assignment !== null) {
+      if (!/^\s/u.test(line)) {
+        inConsoleScripts = assignment[1] === "console_scripts";
+        const inlineScript = inConsoleScripts ? consoleScriptFromEntry(assignment[2] ?? "") : null;
+        if (inlineScript !== null) {
+          scripts.push({ ...inlineScript, metadataPath: "setup.cfg" });
+        }
+        continue;
+      }
+      if (inConsoleScripts) {
+        scripts.push({
+          name: assignment[1] ?? "",
+          target: (assignment[2] ?? "").trim(),
+          metadataPath: "setup.cfg",
+        });
+      }
+      continue;
+    }
+    const script = inConsoleScripts ? consoleScriptFromEntry(line) : null;
+    if (script !== null) {
+      scripts.push({ ...script, metadataPath: "setup.cfg" });
+    }
+  }
+  return scripts.filter((script) => script.name.length > 0 && script.target.length > 0);
+}
+
+function setupPyStringValue(source: string, keyName: string): string | null {
+  const escapedKey = keyName.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return new RegExp(`\\b${escapedKey}\\s*=\\s*(["'])([^"']+)\\1`, "su").exec(source)?.[2] ?? null;
+}
+
+function setupPyConsoleScripts(source: string): PythonScript[] {
+  const scripts: PythonScript[] = [];
+  for (const block of source.matchAll(/console_scripts["']?\s*[:=]\s*\[([\s\S]*?)\]/gu)) {
+    const entries = block[1] ?? "";
+    for (const match of entries.matchAll(/["']([^"']+)["']/gu)) {
+      const script = consoleScriptFromEntry(match[1] ?? "");
+      if (script !== null) {
+        scripts.push({ ...script, metadataPath: "setup.py" });
+      }
+    }
+  }
+  return scripts;
+}
+
+function consoleScriptFromEntry(source: string): Omit<PythonScript, "metadataPath"> | null {
+  const match =
+    /^\s*([A-Za-z0-9_.-]+)\s*=\s*([A-Za-z_][A-Za-z0-9_.]*(?::[A-Za-z_][A-Za-z0-9_]*)?)\s*$/u.exec(
+      source,
+    );
+  if (match?.[1] === undefined || match[2] === undefined) {
+    return null;
+  }
+  return { name: match[1], target: match[2] };
+}
+
+function iniSection(source: string, sectionName: string): string {
+  const escapedName = sectionName.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const match = new RegExp(`^\\s*\\[${escapedName}\\]\\s*(?:[#;].*)?$`, "imu").exec(source);
+  if (match?.index === undefined) {
+    return "";
+  }
+  const rest = source.slice(match.index + match[0].length);
+  const next = /^\s*\[[^\]]+\]\s*(?:[#;].*)?$/mu.exec(rest);
+  return next?.index === undefined ? rest : rest.slice(0, next.index);
 }
 
 function dependencyNames(source: string): Set<string> {

--- a/website/index.html
+++ b/website/index.html
@@ -1160,8 +1160,9 @@
             </li>
           </ul>
           <p>
-            Clawpatch auto-detects Node.js, TypeScript, Next.js, Python, Flask, Go, Rust/Cargo,
-            SwiftPM, and common build tools. You can customize settings after initialization.
+            Clawpatch auto-detects Node.js, TypeScript, Next.js, Python, Flask, FastAPI, Go,
+            Rust/Cargo, SwiftPM, and common build tools. You can customize settings after
+            initialization.
           </p>
 
           <h2 id="feature-mapping">Feature Mapping</h2>
@@ -1169,7 +1170,9 @@
           <pre><code><span class="hl-cmd">clawpatch</span> map</code></pre>
           <p>Features are semantic units like:</p>
           <ul>
-            <li><strong>Routes</strong> — Next.js app/pages routes and Flask routes</li>
+            <li>
+              <strong>Routes</strong> — Next.js app/pages routes plus Flask and FastAPI routes
+            </li>
             <li>
               <strong>Commands</strong> — npm package bins plus Python, Go, Rust, and SwiftPM
               commands


### PR DESCRIPTION
## Summary
- map `setup.cfg` and `setup.py` project names and console script entry points
- detect `black` as a Python format default, including package-runner prefixes
- update README, docs, website, and changelog for current Python/FastAPI coverage

## Tests
- pnpm test src/mapper.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm test

Closes #12 after merge. Python support is on main and will be included in the next release; this does not publish a release.