### PR TITLE
Add packaged CLI mapping smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,4 @@ jobs:
       - run: pnpm format:check
       - run: pnpm test
       - run: pnpm build
+      - run: pnpm pack:smoke

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint": "oxlint . --config oxlint.json",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "pack:smoke": "node scripts/package-smoke.mjs"
   },
   "dependencies": {
     "zod": "^4.4.3"

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = process.cwd();
+const tmp = mkdtempSync(join(tmpdir(), "clawpatch-pack-smoke-"));
+
+function write(path, contents) {
+  const full = join(tmp, "fixture", path);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, contents, "utf8");
+}
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: options.cwd ?? root,
+    encoding: "utf8",
+    stdio: options.stdio ?? "pipe",
+  });
+}
+
+try {
+  write(
+    "pyproject.toml",
+    [
+      "[project]",
+      'name = "mixed-app"',
+      'dependencies = ["fastapi", "pytest"]',
+      "",
+      "[tool.pytest.ini_options]",
+      'testpaths = ["tests"]',
+      "",
+    ].join("\n"),
+  );
+  write("app/__init__.py", "");
+  write(
+    "app/main.py",
+    [
+      "from fastapi import FastAPI",
+      "",
+      "app = FastAPI()",
+      "",
+      '@app.post("/webhook")',
+      "async def webhook() -> dict[str, str]:",
+      '    return {"status": "ok"}',
+      "",
+    ].join("\n"),
+  );
+  write("tests/test_ingest.py", "def test_ingest() -> None:\n    assert True\n");
+  write("pnpm-workspace.yaml", ["packages:", "  - frontend", ""].join("\n"));
+  write(
+    "frontend/package.json",
+    JSON.stringify(
+      {
+        name: "frontend",
+        scripts: { test: "vitest run" },
+        dependencies: { next: "1.0.0" },
+      },
+      null,
+      2,
+    ),
+  );
+  write("frontend/src/app/dashboard/page.tsx", "export default function Page() { return null; }\n");
+  write("frontend/src/app/dashboard/page.test.tsx", "test('dashboard', () => {});\n");
+
+  const packOutput = JSON.parse(
+    run("npm", ["pack", "--json", "--pack-destination", tmp], { stdio: "pipe" }),
+  );
+  const tarball = join(tmp, packOutput[0].filename);
+  const installRoot = join(tmp, "installed");
+  mkdirSync(installRoot, { recursive: true });
+  run("npm", ["install", "--prefix", installRoot, tarball]);
+
+  const bin = join(
+    installRoot,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "clawpatch.cmd" : "clawpatch",
+  );
+  const fixtureRoot = join(tmp, "fixture");
+  run(bin, ["--root", fixtureRoot, "init", "--force", "--json"]);
+  const mapped = JSON.parse(run(bin, ["--root", fixtureRoot, "map", "--json"]));
+  const features = JSON.parse(
+    run("node", [
+      "-e",
+      [
+        "const { readdirSync, readFileSync } = require('node:fs');",
+        "const { join } = require('node:path');",
+        "const dir = join(process.argv[1], '.clawpatch', 'features');",
+        "console.log(JSON.stringify(readdirSync(dir).map((file) => JSON.parse(readFileSync(join(dir, file), 'utf8')))));",
+      ].join(""),
+      fixtureRoot,
+    ]),
+  );
+  const sources = new Set(features.map((feature) => feature.source));
+  const titles = new Set(features.map((feature) => feature.title));
+
+  if (mapped.features < 4) {
+    throw new Error(
+      `expected packaged CLI to map several fixture features, got ${mapped.features}`,
+    );
+  }
+  if (!sources.has("python-project")) {
+    throw new Error("expected packaged CLI to include Python project mapping");
+  }
+  if (!sources.has("python-fastapi-route")) {
+    throw new Error("expected packaged CLI to include FastAPI route mapping");
+  }
+  if (!titles.has("frontend route /dashboard")) {
+    throw new Error("expected packaged CLI to include nested Next workspace route mapping");
+  }
+
+  console.log(`packaged CLI smoke mapped ${mapped.features} features`);
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,15 +1,20 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
+const moduleRequire = createRequire(import.meta.url);
 const root = process.cwd();
 const tmp = mkdtempSync(join(tmpdir(), "clawpatch-pack-smoke-"));
+const fixtureRoot = join(tmp, "fixture");
+const installRoot = join(tmp, "installed");
+const npmCache = join(tmp, "npm-cache");
 
 function write(path, contents) {
-  const full = join(tmp, "fixture", path);
-  mkdirSync(join(full, ".."), { recursive: true });
+  const full = join(fixtureRoot, path);
+  mkdirSync(dirname(full), { recursive: true });
   writeFileSync(full, contents, "utf8");
 }
 
@@ -17,8 +22,21 @@ function run(command, args, options = {}) {
   return execFileSync(command, args, {
     cwd: options.cwd ?? root,
     encoding: "utf8",
+    env: {
+      ...process.env,
+      NPM_CONFIG_CACHE: npmCache,
+      npm_config_cache: npmCache,
+      npm_config_update_notifier: "false",
+    },
+    shell: needsWindowsShell(command) ? (process.env.ComSpec ?? true) : false,
     stdio: options.stdio ?? "pipe",
   });
+}
+
+function needsWindowsShell(command) {
+  return (
+    process.platform === "win32" && (!command.includes("/") || /\.(?:cmd|bat)$/iu.test(command))
+  );
 }
 
 try {
@@ -66,12 +84,29 @@ try {
   write("frontend/src/app/dashboard/page.test.tsx", "test('dashboard', () => {});\n");
 
   const packOutput = JSON.parse(
-    run("npm", ["pack", "--json", "--pack-destination", tmp], { stdio: "pipe" }),
+    run("npm", ["pack", "--json", "--cache", npmCache, "--pack-destination", tmp], {
+      stdio: "pipe",
+    }),
   );
-  const tarball = join(tmp, packOutput[0].filename);
-  const installRoot = join(tmp, "installed");
+  const tarball = join(tmp, packFilename(packOutput));
+  const zodPackOutput = JSON.parse(
+    run(
+      "npm",
+      [
+        "pack",
+        "--json",
+        "--cache",
+        npmCache,
+        "--pack-destination",
+        tmp,
+        dirname(moduleRequire.resolve("zod/package.json")),
+      ],
+      { stdio: "pipe" },
+    ),
+  );
+  const zodTarball = join(tmp, packFilename(zodPackOutput));
   mkdirSync(installRoot, { recursive: true });
-  run("npm", ["install", "--prefix", installRoot, tarball]);
+  run("npm", ["install", "--cache", npmCache, "--prefix", installRoot, tarball, zodTarball]);
 
   const bin = join(
     installRoot,
@@ -79,7 +114,6 @@ try {
     ".bin",
     process.platform === "win32" ? "clawpatch.cmd" : "clawpatch",
   );
-  const fixtureRoot = join(tmp, "fixture");
   run(bin, ["--root", fixtureRoot, "init", "--force", "--json"]);
   const mapped = JSON.parse(run(bin, ["--root", fixtureRoot, "map", "--json"]));
   const features = JSON.parse(
@@ -115,4 +149,12 @@ try {
   console.log(`packaged CLI smoke mapped ${mapped.features} features`);
 } finally {
   rmSync(tmp, { recursive: true, force: true });
+}
+
+function packFilename(output) {
+  const filename = Array.isArray(output) ? output[0]?.filename : null;
+  if (typeof filename !== "string" || filename.length === 0) {
+    throw new Error("npm pack did not report a tarball filename");
+  }
+  return filename;
 }


### PR DESCRIPTION
## Summary

- add `pnpm pack:smoke` to build, pack, install, and execute the packaged CLI from a temporary npm install prefix
- cover a mixed fixture with Python project metadata, a FastAPI route, and a nested PNPM/Next workspace route
- run the smoke test in CI after `pnpm build`

## Why

The published `clawpatch@0.1.0` tarball can map zero features for mixed Python / nested Next repos because the package artifact lags behind the mapper support present on `main`. The source tree already has the relevant mappers, but CI did not exercise the installed package artifact.

Refs #34.

## Validation

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm pack:smoke`