### PR TITLE
Add Turborepo task graph support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added security ownership, CodeQL, Dependabot, dependency review, and a private disclosure policy for repository automation and package integrity, plus fixed the first CodeQL mapper sanitizer finding.
+- Added Turborepo task metadata mapping for workspace-aware feature validation commands.
 - Added JVM semantic role mapping from Java annotations, imports, inheritance, interfaces, and method signatures.
 - Added Ruby and Rails feature mapping while excluding legacy Rails secrets from reviewable config.
 - Fixed Ruby/Rails project detection so `gems.rb` uses Bundler commands and Rails JavaScript roots avoid duplicate Node feature queues.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ validation commands and records a patch attempt under `.clawpatch/`.
   workspace patterns
 - Nx project metadata from `project.json`, including project-scoped validation
   targets
+- Turborepo task metadata for workspace-aware validation commands and feature
+  context
 - Next.js `app/` and `pages/` routes, including routes inside monorepo apps
 - Go package slices from `go list ./...`, including command packages
 - Go package tests and same-repo imports as review context

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -30,6 +30,7 @@ Supported deterministic mappers today:
 - selected root and workspace package scripts
 - Node/TypeScript workspace packages from `package.json` workspaces, `pnpm-workspace.yaml`, and common package folders
 - Nx project metadata from `project.json`, including project names, source roots, project types, and target names
+- Turborepo `turbo.json` metadata for workspace-aware validation commands and feature context
 - bounded Node/TypeScript source groups under `src/`, `lib/`, `app/`, `pages/`, and `scripts/`
 - Next.js `app/` and `pages/` routes at the repo root or inside discovered monorepo projects
 - Go `cmd/*/main.go`
@@ -72,6 +73,11 @@ clawpatch next --project web
 When an Nx project target is available, nearby tests use the project-scoped
 command, such as `yarn nx test web`, instead of a repository-wide test command.
 
+When Turborepo metadata is available, mapped workspace features use filtered
+Turbo validation commands such as `pnpm turbo run test --filter web`. Clawpatch
+does not execute Turbo during mapping and leaves task dependency expansion to
+Turbo when validation commands run.
+
 Native app mappers use the same bounded grouping model. SwiftPM packages can be
 discovered below the repo root, Apple projects are grouped by Swift source area,
 and Gradle modules are grouped from `src/main`, `src/test`, and `src/androidTest`.
@@ -100,5 +106,4 @@ Known gaps:
 - no Express/Fastify/Hono route mapper yet
 - no Django route mapper yet
 - no import graph expansion beyond nearby tests yet
-- no Turborepo task metadata mapper yet
 - no agent enrichment yet

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1190,6 +1190,11 @@ describe("mapFeatures", () => {
     await writeFixture(root, "pnpm-lock.yaml", "");
     await writeFixture(
       root,
+      "apps/web/project.json",
+      JSON.stringify({ name: "web-app", targets: { test: {} } }, null, 2),
+    );
+    await writeFixture(
+      root,
       "turbo.json",
       JSON.stringify(
         {
@@ -1197,7 +1202,7 @@ describe("mapFeatures", () => {
           globalEnv: ["NODE_ENV"],
           tasks: {
             build: { dependsOn: ["^build"], outputs: ["dist/**", ".next/**"] },
-            test: { dependsOn: ["^test"], outputs: ["coverage/**"] },
+            "@scope/web#test": { dependsOn: ["^test"], outputs: ["coverage/**"] },
             lint: {},
             dev: { cache: false, persistent: true },
             "@scope/ext#build": {
@@ -1216,7 +1221,7 @@ describe("mapFeatures", () => {
       "apps/web/package.json",
       JSON.stringify(
         {
-          name: "web",
+          name: "@scope/web",
           scripts: { build: "next build", test: "vitest run", lint: "biome check ." },
           dependencies: { next: "1.0.0" },
         },
@@ -1242,7 +1247,7 @@ describe("mapFeatures", () => {
     const projects = await discoverNodeProjects(root);
     const graph = await turboTaskGraph(root, projects);
     const webTest = graph.commands.find(
-      (command) => command.projectName === "web" && command.task === "test",
+      (command) => command.projectRoot === "apps/web" && command.task === "test",
     );
     const extBuild = graph.commands.find(
       (command) => command.projectName === "@scope/ext" && command.task === "build",
@@ -1251,7 +1256,8 @@ describe("mapFeatures", () => {
     expect(graph.runner).toBe("turbo");
     expect(graph.globalDependencies).toEqual(["package.json", "pnpm-lock.yaml"]);
     expect(graph.globalEnv).toEqual(["NODE_ENV"]);
-    expect(webTest?.command).toBe("pnpm turbo run test --filter web");
+    expect(webTest?.projectName).toBe("web-app");
+    expect(webTest?.command).toBe("pnpm turbo run test --filter @scope/web");
     expect(webTest?.metadata.dependsOn).toEqual(["^test"]);
     expect(extBuild?.command).toBe("pnpm turbo run build --filter @scope/ext");
     expect(extBuild?.metadata.dependsOn).toEqual(["@scope/contracts#build"]);

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1326,6 +1326,52 @@ describe("mapFeatures", () => {
     ]);
   });
 
+  it("keeps package-local validation for fallback packages outside the workspace graph", async () => {
+    const root = await fixtureRoot("clawpatch-turbo-non-workspace-package-");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify(
+        {
+          name: "workspace-root",
+          packageManager: "pnpm@10.0.0",
+          workspaces: ["packages/*"],
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(root, "pnpm-lock.yaml", "");
+    await writeFixture(root, "turbo.json", JSON.stringify({ tasks: { test: {} } }, null, 2));
+    await writeFixture(
+      root,
+      "apps/web/package.json",
+      JSON.stringify(
+        {
+          name: "web",
+          scripts: { test: "vitest run" },
+          dependencies: { next: "1.0.0" },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(
+      root,
+      "apps/web/app/page.tsx",
+      "export default function Page() { return null; }\n",
+    );
+    await writeFixture(root, "apps/web/app/page.test.tsx", "test('page', () => {});\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const route = result.features.find((feature) => feature.title === "web route /");
+
+    expect(route?.tests).toEqual([
+      { path: "apps/web/app/page.test.tsx", command: "pnpm --dir apps/web test" },
+    ]);
+  });
+
   it("maps turbo config and skips versioned virtualenv directories", async () => {
     const root = await fixtureRoot("clawpatch-turbo-config-venv-");
     await writeFixture(root, "package.json", JSON.stringify({ name: "root" }, null, 2));

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { detectProject } from "./detect.js";
 import { mapFeatures } from "./mapper.js";
+import { discoverNodeProjects } from "./mappers/projects.js";
+import { turboTaskGraph } from "./mappers/turbo.js";
 import { fixtureRoot, writeFixture } from "./test-helpers.js";
 
 describe("mapFeatures", () => {
@@ -267,6 +269,43 @@ describe("mapFeatures", () => {
         "project-type:application",
       ]),
     );
+  });
+
+  it("uses package-local commands when no task graph adapter is present", async () => {
+    const root = await fixtureRoot("clawpatch-task-graph-fallback-");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify({ name: "workspace-root", workspaces: ["apps/*"] }, null, 2),
+    );
+    await writeFixture(root, "pnpm-lock.yaml", "");
+    await writeFixture(
+      root,
+      "apps/web/package.json",
+      JSON.stringify(
+        {
+          name: "web",
+          scripts: { test: "vitest run", build: "next build" },
+          dependencies: { next: "1.0.0" },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(
+      root,
+      "apps/web/app/page.tsx",
+      "export default function Page() { return null; }\n",
+    );
+    await writeFixture(root, "apps/web/app/page.test.tsx", "test('page', () => {});\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const route = result.features.find((feature) => feature.title === "web route /");
+
+    expect(route?.tests).toEqual([
+      { path: "apps/web/app/page.test.tsx", command: "pnpm --dir apps/web test" },
+    ]);
   });
 
   it("does not map src app-shaped routes without a Next project signal", async () => {
@@ -753,6 +792,179 @@ describe("mapFeatures", () => {
     ).toEqual([
       { path: "packages/core/src/index.test.ts", command: "pnpm --dir packages/core test" },
     ]);
+  });
+
+  it("parses Turbo task metadata for workspace validation commands", async () => {
+    const root = await fixtureRoot("clawpatch-turbo-task-graph-");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify(
+        {
+          name: "workspace-root",
+          packageManager: "pnpm@10.0.0",
+          workspaces: ["apps/*", "packages/*"],
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(root, "pnpm-lock.yaml", "");
+    await writeFixture(
+      root,
+      "turbo.json",
+      JSON.stringify(
+        {
+          globalDependencies: ["package.json", "pnpm-lock.yaml"],
+          globalEnv: ["NODE_ENV"],
+          tasks: {
+            build: { dependsOn: ["^build"], outputs: ["dist/**", ".next/**"] },
+            test: { dependsOn: ["^test"], outputs: ["coverage/**"] },
+            lint: {},
+            dev: { cache: false, persistent: true },
+            "@scope/ext#build": {
+              dependsOn: ["@scope/contracts#build"],
+              outputs: ["dist/**"],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(
+      root,
+      "apps/web/package.json",
+      JSON.stringify(
+        {
+          name: "web",
+          scripts: { build: "next build", test: "vitest run", lint: "biome check ." },
+          dependencies: { next: "1.0.0" },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(
+      root,
+      "packages/contracts/package.json",
+      JSON.stringify(
+        { name: "@scope/contracts", scripts: { build: "tsc -p tsconfig.json" } },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(
+      root,
+      "apps/ext/package.json",
+      JSON.stringify({ name: "@scope/ext", scripts: { build: "vite build" } }, null, 2),
+    );
+
+    const projects = await discoverNodeProjects(root);
+    const graph = await turboTaskGraph(root, projects);
+    const webTest = graph.commands.find(
+      (command) => command.projectName === "web" && command.task === "test",
+    );
+    const extBuild = graph.commands.find(
+      (command) => command.projectName === "@scope/ext" && command.task === "build",
+    );
+
+    expect(graph.runner).toBe("turbo");
+    expect(graph.globalDependencies).toEqual(["package.json", "pnpm-lock.yaml"]);
+    expect(graph.globalEnv).toEqual(["NODE_ENV"]);
+    expect(webTest?.command).toBe("pnpm turbo run test --filter web");
+    expect(webTest?.metadata.dependsOn).toEqual(["^test"]);
+    expect(extBuild?.command).toBe("pnpm turbo run build --filter @scope/ext");
+    expect(extBuild?.metadata.dependsOn).toEqual(["@scope/contracts#build"]);
+    expect(graph.commands.some((command) => command.task === "dev")).toBe(false);
+    expect(
+      graph.commands.some(
+        (command) => command.projectName === "@scope/contracts" && command.task === "test",
+      ),
+    ).toBe(false);
+  });
+
+  it("uses Turbo task commands for mapped workspace feature validation", async () => {
+    const root = await fixtureRoot("clawpatch-turbo-feature-validation-");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify(
+        {
+          name: "workspace-root",
+          packageManager: "pnpm@10.0.0",
+          workspaces: ["apps/*"],
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(root, "pnpm-lock.yaml", "");
+    await writeFixture(
+      root,
+      "turbo.json",
+      JSON.stringify({ tasks: { test: { dependsOn: ["^test"] } } }, null, 2),
+    );
+    await writeFixture(
+      root,
+      "apps/web/package.json",
+      JSON.stringify(
+        {
+          name: "web",
+          scripts: { test: "vitest run" },
+          dependencies: { next: "1.0.0" },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(
+      root,
+      "apps/web/app/page.tsx",
+      "export default function Page() { return null; }\n",
+    );
+    await writeFixture(root, "apps/web/app/page.test.tsx", "test('page', () => {});\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const route = result.features.find((feature) => feature.title === "web route /");
+    const webSource = result.features.find(
+      (feature) => feature.title === "Node source apps/web/app",
+    );
+
+    expect(route?.tests).toEqual([
+      { path: "apps/web/app/page.test.tsx", command: "pnpm turbo run test --filter web" },
+    ]);
+    expect(webSource?.tests).toEqual([
+      { path: "apps/web/app/page.test.tsx", command: "pnpm turbo run test --filter web" },
+    ]);
+  });
+
+  it("maps turbo config and skips versioned virtualenv directories", async () => {
+    const root = await fixtureRoot("clawpatch-turbo-config-venv-");
+    await writeFixture(root, "package.json", JSON.stringify({ name: "root" }, null, 2));
+    await writeFixture(root, "turbo.json", JSON.stringify({ tasks: { test: {} } }, null, 2));
+    await writeFixture(root, "apps/sandbox/pyproject.toml", "[project]\nname = 'sandbox'\n");
+    await writeFixture(
+      root,
+      "apps/sandbox/src/main.py",
+      "from fastapi import FastAPI\napp = FastAPI()\n",
+    );
+    await writeFixture(
+      root,
+      "apps/sandbox/.venv-311/lib/python/site-packages/bad.py",
+      "raise RuntimeError()\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const ownedPaths = result.features.flatMap((feature) =>
+      feature.ownedFiles.map((file) => file.path),
+    );
+
+    expect(titles).toContain("Project config turbo.json");
+    expect(ownedPaths.some((path) => path.includes(".venv-311"))).toBe(false);
   });
 
   it("maps nested SwiftPM, Apple, and Android Gradle app surfaces", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -408,6 +408,55 @@ describe("mapFeatures", () => {
       { path: "apps/web/src/pages/HomePage.test.tsx", command: "pnpm nx test web" },
     ]);
   });
+
+  it("uses Turbo task commands for React route tests", async () => {
+    const root = await fixtureRoot("clawpatch-map-react-turbo-test-command-");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify({ name: "workspace-root", workspaces: ["apps/*"] }, null, 2),
+    );
+    await writeFixture(root, "pnpm-workspace.yaml", "packages:\n  - apps/*\n");
+    await writeFixture(root, "pnpm-lock.yaml", "");
+    await writeFixture(root, "turbo.json", JSON.stringify({ tasks: { test: {} } }, null, 2));
+    await writeFixture(
+      root,
+      "apps/web/package.json",
+      JSON.stringify(
+        {
+          name: "web",
+          scripts: { test: "vitest run" },
+          dependencies: { react: "1.0.0", "react-router-dom": "1.0.0" },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(
+      root,
+      "apps/web/src/App.tsx",
+      [
+        "import { Route, Routes } from 'react-router-dom';",
+        "import HomePage from './pages/HomePage';",
+        'export function App() { return <Routes><Route path="/home" element={<HomePage />} /></Routes>; }',
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "apps/web/src/pages/HomePage.tsx",
+      "export default function HomePage() { return null; }\n",
+    );
+    await writeFixture(root, "apps/web/src/pages/HomePage.test.tsx", "test('home', () => {});\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const route = result.features.find((feature) => feature.title === "React route /home");
+
+    expect(route?.tests).toEqual([
+      { path: "apps/web/src/pages/HomePage.test.tsx", command: "pnpm turbo run test --filter web" },
+    ]);
+  });
+
   it("does not map src app-shaped routes without a Next project signal", async () => {
     const root = await fixtureRoot("clawpatch-map-src-non-next-");
     await writeFixture(root, "package.json", JSON.stringify({ name: "plain-app" }, null, 2));
@@ -1132,6 +1181,7 @@ describe("mapFeatures", () => {
           name: "workspace-root",
           packageManager: "pnpm@10.0.0",
           workspaces: ["apps/*", "packages/*"],
+          scripts: { test: "vitest run root.test.ts" },
         },
         null,
         2,
@@ -1160,6 +1210,7 @@ describe("mapFeatures", () => {
         2,
       ),
     );
+    await writeFixture(root, "apps/web/package-lock.json", "{}\n");
     await writeFixture(
       root,
       "apps/web/package.json",
@@ -1210,6 +1261,7 @@ describe("mapFeatures", () => {
         (command) => command.projectName === "@scope/contracts" && command.task === "test",
       ),
     ).toBe(false);
+    expect(graph.commands.some((command) => command.projectRoot === ".")).toBe(false);
   });
 
   it("uses Turbo task commands for mapped workspace feature validation", async () => {

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -12,6 +12,7 @@ import { rubySeeds } from "./mappers/ruby.js";
 import { rustSeeds } from "./mappers/rust.js";
 import { nearbyTests } from "./mappers/shared.js";
 import { swiftSeeds } from "./mappers/swift.js";
+import { turboTaskGraph } from "./mappers/turbo.js";
 import { FeatureMapper, FeatureSeed, MapperContext } from "./mappers/types.js";
 import { FeatureRecord, ProjectRecord } from "./types.js";
 
@@ -155,8 +156,10 @@ function uniqueTests(tests: Array<{ path: string; command: string | null }>): Ar
 }
 
 async function collectSeeds(root: string): Promise<FeatureSeed[]> {
+  const projects = await discoverNodeProjects(root);
   const context: MapperContext = {
-    projects: await discoverNodeProjects(root),
+    projects,
+    taskGraph: await turboTaskGraph(root, projects),
   };
   const groups = await Promise.all(featureMappers.map((mapper) => mapper.map(root, context)));
   return dedupeSeeds(groups.flat());

--- a/src/mappers/config.ts
+++ b/src/mappers/config.ts
@@ -6,6 +6,7 @@ export async function configSeeds(root: string): Promise<FeatureSeed[]> {
   const candidates = [
     "package.json",
     "tsconfig.json",
+    "turbo.json",
     "oxlint.json",
     "vitest.config.ts",
     "go.mod",

--- a/src/mappers/next.ts
+++ b/src/mappers/next.ts
@@ -9,16 +9,21 @@ import {
 } from "./projects.js";
 import { walk } from "./shared.js";
 import type { NodeProjectInfo } from "./projects.js";
+import type { WorkspaceTaskGraph } from "./task-graph.js";
 import { FeatureSeed, MapperContext } from "./types.js";
 
 export async function nextSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
   const seedGroups = await Promise.all(
-    context.projects.map(async (project) => projectNextSeeds(root, project)),
+    context.projects.map(async (project) => projectNextSeeds(root, project, context.taskGraph)),
   );
   return seedGroups.flat();
 }
 
-async function projectNextSeeds(root: string, project: NodeProjectInfo): Promise<FeatureSeed[]> {
+async function projectNextSeeds(
+  root: string,
+  project: NodeProjectInfo,
+  taskGraph: WorkspaceTaskGraph,
+): Promise<FeatureSeed[]> {
   const prefixes = await nextPrefixes(root, project);
   if (prefixes.length === 0) {
     return [];
@@ -32,7 +37,7 @@ async function projectNextSeeds(root: string, project: NodeProjectInfo): Promise
     const kind = nextRouteKind(projectRelativePath);
     return kind === null ? [] : [{ file, projectRelativePath, kind }];
   });
-  const testCommand = projectTargetCommand(project, "test");
+  const testCommand = projectTargetCommand(project, "test", taskGraph);
   const contextFiles = await projectContextFiles(root, project);
 
   return routeFiles.map(({ file, projectRelativePath, kind }) => {

--- a/src/mappers/node.ts
+++ b/src/mappers/node.ts
@@ -16,6 +16,7 @@ import {
   projectTargetCommand,
 } from "./projects.js";
 import type { NodePackageJson, NodeProjectInfo } from "./projects.js";
+import type { WorkspaceTaskGraph } from "./task-graph.js";
 import { FeatureSeed, MapperContext, SeedFileRef, SeedTestRef } from "./types.js";
 
 type PackageInfo = NodeProjectInfo & {
@@ -38,8 +39,8 @@ export async function nodeSeeds(root: string, context: MapperContext): Promise<F
   const seeds: FeatureSeed[] = [];
 
   for (const info of packages) {
-    seeds.push(...(await packageSeeds(root, info)));
-    seeds.push(...(await sourceGroupSeeds(root, info)));
+    seeds.push(...(await packageSeeds(root, info, context.taskGraph)));
+    seeds.push(...(await sourceGroupSeeds(root, info, context.taskGraph)));
   }
 
   return seeds;
@@ -49,14 +50,18 @@ function hasNodePackage(project: NodeProjectInfo): project is PackageInfo {
   return project.packageJsonPath !== null && project.packageJson !== null;
 }
 
-async function packageSeeds(root: string, info: PackageInfo): Promise<FeatureSeed[]> {
+async function packageSeeds(
+  root: string,
+  info: PackageInfo,
+  taskGraph: WorkspaceTaskGraph,
+): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
   const packageName = projectDisplayName(info);
   const packageTags = ["node", "package", ...projectTags(info)];
   if (info.root !== ".") {
     packageTags.push("workspace");
   }
-  const testCommand = projectTargetCommand(info, "test");
+  const testCommand = projectTargetCommand(info, "test", taskGraph);
 
   const manifestSeed: FeatureSeed = {
     title: `Node package ${packageName}`,
@@ -128,9 +133,13 @@ async function packageSeeds(root: string, info: PackageInfo): Promise<FeatureSee
   return seeds;
 }
 
-async function sourceGroupSeeds(root: string, info: PackageInfo): Promise<FeatureSeed[]> {
+async function sourceGroupSeeds(
+  root: string,
+  info: PackageInfo,
+  taskGraph: WorkspaceTaskGraph,
+): Promise<FeatureSeed[]> {
   const packageName = projectDisplayName(info);
-  const testCommand = projectTargetCommand(info, "test");
+  const testCommand = projectTargetCommand(info, "test", taskGraph);
   const testFiles = await packageTestFiles(root, info);
   const seeds: FeatureSeed[] = [];
 

--- a/src/mappers/projects.ts
+++ b/src/mappers/projects.ts
@@ -22,6 +22,7 @@ export type NodeProjectTarget = {
 export type NodeProjectInfo = {
   root: string;
   name: string;
+  workspaceMember: boolean;
   packageJsonPath: string | null;
   packageJson: NodePackageJson | null;
   projectJsonPath: string | null;
@@ -41,6 +42,7 @@ export async function discoverNodeProjects(root: string): Promise<NodeProjectInf
   const rootPackage = await readPackageJson(root);
   const rootPackageManager = await detectNodePackageManager(root);
   const byRoot = new Map<string, NodeProjectInfo>();
+  const declaredPackageRoots = await discoverDeclaredPackageRoots(root, rootPackage);
 
   for (const packageRoot of await discoverPackageRoots(root, rootPackage)) {
     const packageJsonPath = packageRelativePath(packageRoot, "package.json");
@@ -51,6 +53,7 @@ export async function discoverNodeProjects(root: string): Promise<NodeProjectInf
     byRoot.set(packageRoot, {
       root: packageRoot,
       name: packageDisplayName(packageRoot, packageJsonPath, packageJson),
+      workspaceMember: packageRoot === "." || declaredPackageRoots.has(packageRoot),
       packageJsonPath,
       packageJson,
       projectJsonPath: null,
@@ -81,6 +84,7 @@ export async function discoverNodeProjects(root: string): Promise<NodeProjectInf
         previousName: previous?.name,
         nxName: nxProject.name,
       }),
+      workspaceMember: projectRoot === "." || declaredPackageRoots.has(projectRoot),
       packageJsonPath: packageJson === null ? null : packageJsonPath,
       packageJson,
       projectJsonPath,
@@ -93,6 +97,15 @@ export async function discoverNodeProjects(root: string): Promise<NodeProjectInf
   }
 
   return [...byRoot.values()].toSorted((left, right) => left.root.localeCompare(right.root));
+}
+
+async function discoverDeclaredPackageRoots(
+  root: string,
+  rootPackage: NodePackageJson | null,
+): Promise<Set<string>> {
+  const patterns = await declaredWorkspacePatterns(root, rootPackage);
+  const roots = await packageRootsForPatterns(root, patterns);
+  return new Set(roots);
 }
 
 async function nodePackageManagerForPackage(
@@ -242,35 +255,17 @@ async function discoverPackageRoots(
   if (rootPackage !== null) {
     packageRoots.add(".");
   }
-  const patterns = await workspacePatterns(root, rootPackage);
-  const excludes = patterns
-    .filter((pattern) => pattern.startsWith("!"))
-    .flatMap((pattern) => {
-      const normalized = normalizeWorkspacePattern(pattern.slice(1));
-      return normalized === null ? [] : [normalized];
-    });
-  for (const includePattern of patterns.filter((pattern) => !pattern.startsWith("!"))) {
-    for (const packageRoot of await expandWorkspacePattern(root, includePattern)) {
-      packageRoots.add(packageRoot);
-    }
+  for (const packageRoot of await packageRootsForPatterns(
+    root,
+    await workspacePatterns(root, rootPackage),
+  )) {
+    packageRoots.add(packageRoot);
   }
-  return [...packageRoots].filter((path) => !isExcludedWorkspace(path, excludes)).toSorted();
+  return [...packageRoots].toSorted();
 }
 
 async function workspacePatterns(root: string, pkg: NodePackageJson | null): Promise<string[]> {
-  const patterns = new Set<string>();
-  if (pkg !== null) {
-    for (const pattern of packageWorkspacePatterns(pkg)) {
-      patterns.add(pattern);
-    }
-  }
-  if (await pathExists(join(root, "pnpm-workspace.yaml"))) {
-    for (const pattern of parsePnpmWorkspace(
-      await readFile(join(root, "pnpm-workspace.yaml"), "utf8"),
-    )) {
-      patterns.add(pattern);
-    }
-  }
+  const patterns = new Set(await declaredWorkspacePatterns(root, pkg));
   for (const fallback of [
     "frontend",
     "client",
@@ -286,6 +281,42 @@ async function workspacePatterns(root: string, pkg: NodePackageJson | null): Pro
     }
   }
   return [...patterns];
+}
+
+async function declaredWorkspacePatterns(
+  root: string,
+  pkg: NodePackageJson | null,
+): Promise<string[]> {
+  const patterns = new Set<string>();
+  if (pkg !== null) {
+    for (const pattern of packageWorkspacePatterns(pkg)) {
+      patterns.add(pattern);
+    }
+  }
+  if (await pathExists(join(root, "pnpm-workspace.yaml"))) {
+    for (const pattern of parsePnpmWorkspace(
+      await readFile(join(root, "pnpm-workspace.yaml"), "utf8"),
+    )) {
+      patterns.add(pattern);
+    }
+  }
+  return [...patterns];
+}
+
+async function packageRootsForPatterns(root: string, patterns: string[]): Promise<string[]> {
+  const excludes = patterns
+    .filter((pattern) => pattern.startsWith("!"))
+    .flatMap((pattern) => {
+      const normalized = normalizeWorkspacePattern(pattern.slice(1));
+      return normalized === null ? [] : [normalized];
+    });
+  const packageRoots = new Set<string>();
+  for (const includePattern of patterns.filter((pattern) => !pattern.startsWith("!"))) {
+    for (const packageRoot of await expandWorkspacePattern(root, includePattern)) {
+      packageRoots.add(packageRoot);
+    }
+  }
+  return [...packageRoots].filter((path) => !isExcludedWorkspace(path, excludes)).toSorted();
 }
 
 function packageWorkspacePatterns(pkg: NodePackageJson): string[] {

--- a/src/mappers/projects.ts
+++ b/src/mappers/projects.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join } from "node:path";
 import { packageScripts, readPackageJson } from "../detect.js";
 import { pathExists } from "../fs.js";
 import { isSafeDirectory, normalize, pathMatchesPrefix, shouldSkip } from "./shared.js";
+import { taskGraphCommand, type WorkspaceTaskGraph } from "./task-graph.js";
 import type { SeedFileRef } from "./types.js";
 
 export type NodePackageJson = {
@@ -106,7 +107,15 @@ export function projectContextFiles(
   return existingProjectContextFiles(root, project);
 }
 
-export function projectTargetCommand(project: NodeProjectInfo, target: string): string | null {
+export function projectTargetCommand(
+  project: NodeProjectInfo,
+  target: string,
+  graph?: WorkspaceTaskGraph,
+): string | null {
+  const graphCommand = graph === undefined ? null : taskGraphCommand(graph, project, target);
+  if (graphCommand !== null) {
+    return graphCommand;
+  }
   if (project.targets[target] !== undefined) {
     return nxCommand(project.packageManager, target, project.name);
   }

--- a/src/mappers/projects.ts
+++ b/src/mappers/projects.ts
@@ -136,9 +136,9 @@ export function projectContextFiles(
 export function projectTargetCommand(
   project: NodeProjectInfo,
   target: string,
-  graph?: WorkspaceTaskGraph,
+  graph: WorkspaceTaskGraph,
 ): string | null {
-  const graphCommand = graph === undefined ? null : taskGraphCommand(graph, project, target);
+  const graphCommand = taskGraphCommand(graph, project, target);
   if (graphCommand !== null) {
     return graphCommand;
   }

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -967,7 +967,9 @@ function isPythonTestPath(path: string): boolean {
 function pythonShouldSkip(path: string): boolean {
   return (
     shouldSkip(path) ||
-    /(^|\/)(\.venv|venv|__pycache__|\.mypy_cache|\.ruff_cache|\.pytest_cache)(\/|$)/u.test(path)
+    /(^|\/)(\.venv(?:-[^/]+)?|venv|__pycache__|\.mypy_cache|\.ruff_cache|\.pytest_cache)(\/|$)/u.test(
+      path,
+    )
   );
 }
 

--- a/src/mappers/react.ts
+++ b/src/mappers/react.ts
@@ -16,6 +16,7 @@ import {
 import { projectTargetCommand } from "./projects.js";
 import { FeatureSeed, MapperContext, SeedFileRef, SeedTestRef } from "./types.js";
 import type { NodeProjectInfo } from "./projects.js";
+import type { WorkspaceTaskGraph } from "./task-graph.js";
 
 type PackageJson = {
   name?: unknown;
@@ -73,7 +74,7 @@ const contextImportExtensions = new Set([
 
 export async function reactSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
   syncFileCache.clear();
-  const packages = await discoverReactPackages(root, context.projects);
+  const packages = await discoverReactPackages(root, context.projects, context.taskGraph);
   const seeds: FeatureSeed[] = [];
   for (const info of packages) {
     seeds.push(...(await routeSeeds(root, info)));
@@ -193,6 +194,7 @@ async function componentSeeds(
 async function discoverReactPackages(
   root: string,
   projects: NodeProjectInfo[],
+  taskGraph: WorkspaceTaskGraph,
 ): Promise<ReactPackage[]> {
   const packages: ReactPackage[] = [];
   const rootPackageManager = await detectNodePackageManager(root);
@@ -206,7 +208,8 @@ async function discoverReactPackages(
     const packageManager =
       project?.packageManager ??
       (await packageManagerForReactPackage(root, packageRoot, rootPackageManager));
-    const projectTestCommand = project === undefined ? null : projectTargetCommand(project, "test");
+    const projectTestCommand =
+      project === undefined ? null : projectTargetCommand(project, "test", taskGraph);
     packages.push({
       root: packageRoot,
       packageJsonPath,

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -172,7 +172,7 @@ export function shouldSkip(path: string): boolean {
     return false;
   }
   return (
-    /(^|\/)(node_modules|dist|build|coverage|\.build|\.git|\.clawpatch|\.worktrees)(\/|$)/u.test(
+    /(^|\/)(node_modules|dist|build|coverage|\.build|\.git|\.clawpatch|\.worktrees|\.turbo|\.next|\.vercel|\.venv(?:-[^/]+)?|venv|__pycache__)(\/|$)/u.test(
       path,
     ) ||
     path === "target" ||

--- a/src/mappers/task-graph.ts
+++ b/src/mappers/task-graph.ts
@@ -1,0 +1,57 @@
+import type { NodeProjectInfo } from "./projects.js";
+
+export type WorkspaceTaskName = "build" | "test" | "lint" | "typecheck" | "format" | string;
+
+export type WorkspaceTaskMetadata = {
+  dependsOn: string[];
+  outputs: string[];
+  env: string[];
+  cache: boolean | null;
+  persistent: boolean;
+};
+
+export type WorkspaceTaskCommand = {
+  projectRoot: string;
+  projectName: string;
+  task: WorkspaceTaskName;
+  command: string;
+  metadata: WorkspaceTaskMetadata;
+};
+
+export type WorkspaceTaskGraph = {
+  runner: string | null;
+  globalDependencies: string[];
+  globalEnv: string[];
+  commands: WorkspaceTaskCommand[];
+};
+
+export const validationTaskNames = ["test", "build", "lint", "typecheck", "format"] as const;
+
+export function emptyTaskGraph(): WorkspaceTaskGraph {
+  return { runner: null, globalDependencies: [], globalEnv: [], commands: [] };
+}
+
+export function taskGraphCommand(
+  graph: WorkspaceTaskGraph,
+  project: NodeProjectInfo,
+  task: string,
+): string | null {
+  return (
+    graph.commands.find((command) => command.projectRoot === project.root && command.task === task)
+      ?.command ?? null
+  );
+}
+
+export function taskGraphProjectCommands(
+  graph: WorkspaceTaskGraph,
+  project: NodeProjectInfo,
+): Record<string, string> {
+  const commands: Record<string, string> = {};
+  for (const task of validationTaskNames) {
+    const command = taskGraphCommand(graph, project, task);
+    if (command !== null) {
+      commands[task] = command;
+    }
+  }
+  return commands;
+}

--- a/src/mappers/turbo.ts
+++ b/src/mappers/turbo.ts
@@ -51,6 +51,7 @@ export async function turboTaskGraph(
     for (const task of validationTaskNames) {
       if (
         project.root === "." ||
+        !project.workspaceMember ||
         scripts[task] === undefined ||
         !hasTaskEntry(taskEntries, packageName, task)
       ) {

--- a/src/mappers/turbo.ts
+++ b/src/mappers/turbo.ts
@@ -47,15 +47,16 @@ export async function turboTaskGraph(
 
   for (const project of projects) {
     const scripts = packageScripts(project.packageJson);
+    const packageName = turboPackageName(project);
     for (const task of validationTaskNames) {
       if (
         project.root === "." ||
         scripts[task] === undefined ||
-        !hasTaskEntry(taskEntries, project.name, task)
+        !hasTaskEntry(taskEntries, packageName, task)
       ) {
         continue;
       }
-      const metadata = metadataForTask(taskEntries, project.name, task);
+      const metadata = metadataForTask(taskEntries, packageName, task);
       if (metadata.persistent) {
         continue;
       }
@@ -63,7 +64,7 @@ export async function turboTaskGraph(
         projectRoot: project.root,
         projectName: project.name,
         task,
-        command: turboCommand(rootPackageManager, task, project.name, project.root),
+        command: turboCommand(rootPackageManager, task, turboFilter(project, packageName)),
         metadata,
       });
     }
@@ -79,16 +80,22 @@ function taskRecord(value: unknown): Map<string, unknown> {
   return new Map(Object.entries(value));
 }
 
-function hasTaskEntry(entries: Map<string, unknown>, projectName: string, task: string): boolean {
-  return entries.has(`${projectName}#${task}`) || entries.has(task);
+function hasTaskEntry(
+  entries: Map<string, unknown>,
+  packageName: string | null,
+  task: string,
+): boolean {
+  return (packageName !== null && entries.has(`${packageName}#${task}`)) || entries.has(task);
 }
 
 function metadataForTask(
   entries: Map<string, unknown>,
-  projectName: string,
+  packageName: string | null,
   task: string,
 ): WorkspaceTaskMetadata {
-  return taskMetadata(entries.get(`${projectName}#${task}`) ?? entries.get(task));
+  return taskMetadata(
+    (packageName === null ? undefined : entries.get(`${packageName}#${task}`)) ?? entries.get(task),
+  );
 }
 
 function taskMetadata(value: unknown): WorkspaceTaskMetadata {
@@ -117,13 +124,7 @@ function stringArray(value: unknown): string[] {
     : [];
 }
 
-function turboCommand(
-  packageManager: string,
-  task: string,
-  projectName: string,
-  projectRoot: string,
-): string {
-  const filter = projectName.length > 0 ? projectName : projectRoot;
+function turboCommand(packageManager: string, task: string, filter: string): string {
   if (packageManager === "pnpm") {
     return `pnpm turbo run ${task} --filter ${filter}`;
   }
@@ -134,4 +135,19 @@ function turboCommand(
     return `bunx turbo run ${task} --filter ${filter}`;
   }
   return `npx turbo run ${task} --filter ${filter}`;
+}
+
+function turboPackageName(project: NodeProjectInfo): string | null {
+  const packageName = project.packageJson?.name;
+  if (typeof packageName === "string" && packageName.length > 0) {
+    return packageName;
+  }
+  return null;
+}
+
+function turboFilter(project: NodeProjectInfo, packageName: string | null): string {
+  if (packageName !== null) {
+    return packageName;
+  }
+  return `./${project.root}`;
 }

--- a/src/mappers/turbo.ts
+++ b/src/mappers/turbo.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { packageScripts } from "../detect.js";
 import { pathExists } from "../fs.js";
 import type { NodeProjectInfo } from "./projects.js";
+import { detectNodePackageManager } from "./shared.js";
 import {
   emptyTaskGraph,
   validationTaskNames,
@@ -36,6 +37,7 @@ export async function turboTaskGraph(
 
   const parsed = JSON.parse(await readFile(path, "utf8")) as TurboConfig;
   const taskEntries = taskRecord(parsed.tasks ?? parsed.pipeline);
+  const rootPackageManager = await detectNodePackageManager(root);
   const graph: WorkspaceTaskGraph = {
     runner: "turbo",
     globalDependencies: stringArray(parsed.globalDependencies),
@@ -46,7 +48,11 @@ export async function turboTaskGraph(
   for (const project of projects) {
     const scripts = packageScripts(project.packageJson);
     for (const task of validationTaskNames) {
-      if (scripts[task] === undefined || !hasTaskEntry(taskEntries, project.name, task)) {
+      if (
+        project.root === "." ||
+        scripts[task] === undefined ||
+        !hasTaskEntry(taskEntries, project.name, task)
+      ) {
         continue;
       }
       const metadata = metadataForTask(taskEntries, project.name, task);
@@ -57,7 +63,7 @@ export async function turboTaskGraph(
         projectRoot: project.root,
         projectName: project.name,
         task,
-        command: turboCommand(project.packageManager, task, project.name, project.root),
+        command: turboCommand(rootPackageManager, task, project.name, project.root),
         metadata,
       });
     }

--- a/src/mappers/turbo.ts
+++ b/src/mappers/turbo.ts
@@ -1,0 +1,131 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { packageScripts } from "../detect.js";
+import { pathExists } from "../fs.js";
+import type { NodeProjectInfo } from "./projects.js";
+import {
+  emptyTaskGraph,
+  validationTaskNames,
+  type WorkspaceTaskGraph,
+  type WorkspaceTaskMetadata,
+} from "./task-graph.js";
+
+type TurboConfig = {
+  globalDependencies?: unknown;
+  globalEnv?: unknown;
+  tasks?: unknown;
+  pipeline?: unknown;
+};
+
+const emptyTaskMetadata: WorkspaceTaskMetadata = {
+  dependsOn: [],
+  outputs: [],
+  env: [],
+  cache: null,
+  persistent: false,
+};
+
+export async function turboTaskGraph(
+  root: string,
+  projects: NodeProjectInfo[],
+): Promise<WorkspaceTaskGraph> {
+  const path = join(root, "turbo.json");
+  if (!(await pathExists(path))) {
+    return emptyTaskGraph();
+  }
+
+  const parsed = JSON.parse(await readFile(path, "utf8")) as TurboConfig;
+  const taskEntries = taskRecord(parsed.tasks ?? parsed.pipeline);
+  const graph: WorkspaceTaskGraph = {
+    runner: "turbo",
+    globalDependencies: stringArray(parsed.globalDependencies),
+    globalEnv: stringArray(parsed.globalEnv),
+    commands: [],
+  };
+
+  for (const project of projects) {
+    const scripts = packageScripts(project.packageJson);
+    for (const task of validationTaskNames) {
+      if (scripts[task] === undefined || !hasTaskEntry(taskEntries, project.name, task)) {
+        continue;
+      }
+      const metadata = metadataForTask(taskEntries, project.name, task);
+      if (metadata.persistent) {
+        continue;
+      }
+      graph.commands.push({
+        projectRoot: project.root,
+        projectName: project.name,
+        task,
+        command: turboCommand(project.packageManager, task, project.name, project.root),
+        metadata,
+      });
+    }
+  }
+
+  return graph;
+}
+
+function taskRecord(value: unknown): Map<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return new Map();
+  }
+  return new Map(Object.entries(value));
+}
+
+function hasTaskEntry(entries: Map<string, unknown>, projectName: string, task: string): boolean {
+  return entries.has(`${projectName}#${task}`) || entries.has(task);
+}
+
+function metadataForTask(
+  entries: Map<string, unknown>,
+  projectName: string,
+  task: string,
+): WorkspaceTaskMetadata {
+  return taskMetadata(entries.get(`${projectName}#${task}`) ?? entries.get(task));
+}
+
+function taskMetadata(value: unknown): WorkspaceTaskMetadata {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { ...emptyTaskMetadata };
+  }
+  const record = value as {
+    dependsOn?: unknown;
+    outputs?: unknown;
+    env?: unknown;
+    cache?: unknown;
+    persistent?: unknown;
+  };
+  return {
+    dependsOn: stringArray(record.dependsOn),
+    outputs: stringArray(record.outputs),
+    env: stringArray(record.env),
+    cache: typeof record.cache === "boolean" ? record.cache : null,
+    persistent: record.persistent === true,
+  };
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function turboCommand(
+  packageManager: string,
+  task: string,
+  projectName: string,
+  projectRoot: string,
+): string {
+  const filter = projectName.length > 0 ? projectName : projectRoot;
+  if (packageManager === "pnpm") {
+    return `pnpm turbo run ${task} --filter ${filter}`;
+  }
+  if (packageManager === "yarn") {
+    return `yarn turbo run ${task} --filter ${filter}`;
+  }
+  if (packageManager === "bun") {
+    return `bunx turbo run ${task} --filter ${filter}`;
+  }
+  return `npx turbo run ${task} --filter ${filter}`;
+}

--- a/src/mappers/types.ts
+++ b/src/mappers/types.ts
@@ -1,5 +1,6 @@
 import { FeatureRecord, TrustBoundary } from "../types.js";
 import type { NodeProjectInfo } from "./projects.js";
+import type { WorkspaceTaskGraph } from "./task-graph.js";
 
 export type SeedFileRef = {
   path: string;
@@ -38,4 +39,5 @@ export type FeatureMapper = {
 
 export type MapperContext = {
   projects: NodeProjectInfo[];
+  taskGraph: WorkspaceTaskGraph;
 };


### PR DESCRIPTION
## Summary

Adds generic workspace task graph support for Turborepo monorepos.

- Parses `turbo.json` task metadata without executing Turbo
- Adds Turbo-aware validation commands for mapped Node and Next.js workspace features
- Maps `turbo.json` as project config
- Skips common generated monorepo output such as `.turbo`, `.next`, `.venv-*`, and `__pycache__`
- Documents the new mapper behavior

## Validation

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`