### PR TITLE
feat(mapper): support Kotlin semantic role mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Detected Java/Kotlin language and default Gradle build/test commands for root Gradle projects.
 - Added FastAPI route feature mapping and kept root/web Python project detection in sync.
 - Added Laravel/PHP feature mapping for routes, controllers, form requests, Artisan commands, jobs, services, models, migrations, seeders, Composer scripts, and PHP tests, thanks @Jonathanm10.
+- Added Kotlin semantic role mapping for Gradle projects, including Android UI, ViewModel, data, external client, dependency injection, and server-side role slices, thanks @mrmans0n.
 - Added `--since <ref>` on `clawpatch review` and `clawpatch revalidate` to restrict runs to features whose owned or context files changed since the given git ref, thanks @mvanhorn.
 - Added Flask route feature mapping for Python projects, including `web/` source roots, common root entry files, non-list method literals, and Python framework detection.
 - Added Next.js route mapping for `src/app` and `src/pages` layouts, thanks @obatried.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ validation commands and records a patch attempt under `.clawpatch/`.
 - Go package slices from `go list ./...`, including command packages
 - Go package tests and same-repo imports as review context
 - Java/Kotlin Gradle source groups and root Gradle build/test commands
-- JVM semantic roles from Java code evidence such as annotations, imports,
-  interfaces, inheritance, and method signatures
+- JVM semantic roles from Java and Kotlin code evidence such as annotations,
+  imports, interfaces, inheritance, supertypes, and method signatures
+- Kotlin Android semantic roles for UI entrypoints, ViewModels, data
+  boundaries, external clients, and dependency injection, including Metro
 - Ruby project metadata, executables, source groups, RSpec/Minitest suites
 - Rust `src/main.rs`, `src/bin/*.rs`, `src/lib.rs`, `crates/*`, and
   `tests/*.rs`

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -36,7 +36,8 @@ Supported deterministic mappers today:
 - Go `internal/*` packages
 - Python project metadata, console scripts, root app files, bounded source groups,
   pytest suites, and Flask/FastAPI routes
-- JVM semantic role groups from Java annotations, imports, inheritance, interfaces, and method signatures
+- Java and Kotlin JVM semantic role groups, plus Kotlin Android semantic role
+  groups including Hilt, Dagger, Koin, and Metro
 - Ruby project metadata, executables, source groups, RSpec/Minitest suites,
   Rails configs, routes, views, assets, and database files
 - Rust Cargo commands, libraries, workspace crates, and integration tests
@@ -76,9 +77,12 @@ Native app mappers use the same bounded grouping model. SwiftPM packages can be
 discovered below the repo root, Apple projects are grouped by Swift source area,
 and Gradle modules are grouped from `src/main`, `src/test`, and `src/androidTest`.
 Root Gradle projects get default `gradle`/`./gradlew` build and test commands.
-Java files in Gradle modules also get role-oriented review slices when code
-evidence identifies web entrypoints, services, persistence boundaries, external
-clients, configuration, framework components, or extension boundaries.
+Java and Kotlin files in Gradle modules also get role-oriented review slices
+when code evidence identifies web entrypoints, services, persistence boundaries,
+external clients, configuration, framework components, extension boundaries,
+Android UI entrypoints, ViewModels, data boundaries, or dependency injection.
+Kotlin dependency-injection evidence includes Hilt, Dagger, Koin, and Metro
+annotations and imports.
 
 Python mapping covers `pyproject.toml`, `setup.cfg`, `setup.py`, and
 `requirements.txt` metadata; `[project.scripts]`, `[tool.poetry.scripts]`,

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2426,6 +2426,23 @@ describe("mapFeatures", () => {
       "build.gradle.kts",
       'plugins { id("com.android.application") version "1.0" apply false }\n',
     );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/api/RootController.kt",
+      [
+        "package com.example.api",
+        "",
+        "import org.springframework.web.bind.annotation.GetMapping",
+        "import org.springframework.web.bind.annotation.RestController",
+        "",
+        "@RestController",
+        "class RootController {",
+        '  @GetMapping("/root")',
+        '  fun root(): String = "ok"',
+        "}",
+        "",
+      ].join("\n"),
+    );
     await writeFixture(root, "app/build.gradle.kts", 'plugins { id("com.android.application") }\n');
     await writeFixture(
       root,
@@ -2537,10 +2554,20 @@ describe("mapFeatures", () => {
     const di = result.features.find((feature) =>
       feature.title.startsWith("Kotlin Android role dependency injection "),
     );
+    const rootModule = result.features.find((feature) => feature.title === "Gradle module .");
+    const rootWeb = result.features.find(
+      (feature) =>
+        feature.source === "kotlin-server-role-web-entrypoint" &&
+        feature.ownedFiles.some(
+          (file) => file.path === "src/main/kotlin/com/example/api/RootController.kt",
+        ),
+    );
 
     expect(project.detected.languages).toContain("kotlin");
     expect(project.detected.packageManagers).toContain("gradle");
     expect(titles).toContain("Gradle module app");
+    expect(rootModule?.tags).not.toContain("android");
+    expect(rootWeb?.source).toBe("kotlin-server-role-web-entrypoint");
     expect(gradleModule?.tags).toEqual(expect.arrayContaining(["gradle", "kotlin", "android"]));
     expect(ui?.source).toBe("kotlin-android-role-ui-entrypoint");
     expect(ui?.kind).toBe("ui-flow");
@@ -2634,6 +2661,11 @@ describe("mapFeatures", () => {
     );
     await writeFixture(
       root,
+      "src/main/kotlin/com/example/network/PaymentClient.kt",
+      "package com.example.network\ninterface PaymentClient\n",
+    );
+    await writeFixture(
+      root,
       "src/main/kotlin/com/example/config/AppConfig.kt",
       [
         "package com.example.config",
@@ -2691,6 +2723,7 @@ describe("mapFeatures", () => {
       expect.arrayContaining([
         "src/main/kotlin/com/example/client/RemoteClient.kt",
         "src/main/kotlin/com/example/network/FallbackClient.kt",
+        "src/main/kotlin/com/example/network/PaymentClient.kt",
       ]),
     );
   });
@@ -2800,6 +2833,39 @@ describe("mapFeatures", () => {
           feature.source === "kotlin-android-role-ui-entrypoint" &&
           feature.ownedFiles.some(
             (file) => file.path === "app/src/main/kotlin/com/example/alerts/Notifier.kt",
+          ),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not treat Compose runtime state imports as UI roles", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-android-compose-state-");
+    await writeFixture(root, "settings.gradle.kts", 'pluginManagement {}\ninclude(":app")\n');
+    await writeFixture(root, "app/build.gradle.kts", 'plugins { id("com.android.library") }\n');
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/state/CounterState.kt",
+      [
+        "package com.example.state",
+        "",
+        "import androidx.compose.runtime.mutableStateOf",
+        "",
+        "class CounterState {",
+        "  val count = mutableStateOf(0)",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "kotlin-android-role-ui-entrypoint" &&
+          feature.ownedFiles.some(
+            (file) => file.path === "app/src/main/kotlin/com/example/state/CounterState.kt",
           ),
       ),
     ).toBe(false);

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -861,6 +861,426 @@ describe("mapFeatures", () => {
     ]);
   });
 
+  it("maps Kotlin Android semantic roles from framework evidence", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-android-role-map-");
+    await writeFixture(root, "settings.gradle.kts", 'pluginManagement {}\ninclude(":app")\n');
+    await writeFixture(
+      root,
+      "build.gradle.kts",
+      'plugins { id("com.android.application") version "1.0" apply false }\n',
+    );
+    await writeFixture(root, "app/build.gradle.kts", 'plugins { id("com.android.application") }\n');
+    await writeFixture(root, "app/src/main/AndroidManifest.xml", "<manifest />\n");
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/ui/MainActivity.kt",
+      [
+        "package com.example.ui",
+        "",
+        "import androidx.activity.ComponentActivity",
+        "import androidx.compose.runtime.Composable",
+        "import androidx.hilt.navigation.compose.hiltViewModel",
+        "",
+        "class MainActivity : ComponentActivity()",
+        "",
+        "@Composable",
+        "fun HomeScreen() { hiltViewModel<MainViewModel>() }",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/ui/MainViewModel.kt",
+      [
+        "package com.example.ui",
+        "",
+        "import androidx.lifecycle.ViewModel",
+        "",
+        "class MainViewModel : ViewModel()",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/data/AppDatabase.kt",
+      [
+        "package com.example.data",
+        "",
+        "import androidx.room.Database",
+        "import androidx.room.RoomDatabase",
+        "",
+        "@Database(entities = [], version = 1)",
+        "abstract class AppDatabase : RoomDatabase()",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/network/ApiClient.kt",
+      [
+        "package com.example.network",
+        "",
+        "import retrofit2.Retrofit",
+        "",
+        "class ApiClient(private val retrofit: Retrofit)",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/di/AppGraph.kt",
+      [
+        "package com.example.di",
+        "",
+        "import dev.zacsweers.metro.BindingContainer",
+        "import dev.zacsweers.metro.DependencyGraph",
+        "import dev.zacsweers.metro.Provides",
+        "",
+        "@DependencyGraph",
+        "interface AppGraph",
+        "",
+        "@BindingContainer",
+        "object AppBindings {",
+        '  @Provides fun provideName(): String = "app"',
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/domain/UseCase.kt",
+      "package com.example.domain\nclass UseCase\n",
+    );
+    await writeFixture(
+      root,
+      "app/src/test/kotlin/com/example/ui/MainActivityTest.kt",
+      "package com.example.ui\nclass MainActivityTest\n",
+    );
+    await writeFixture(
+      root,
+      "app/build/generated/source/kapt/debug/com/example/Ignored.kt",
+      "package com.example\nclass Ignored\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const ui = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin Android role UI entrypoint "),
+    );
+    const viewModel = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin Android role view model "),
+    );
+    const data = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin Android role data boundary "),
+    );
+    const client = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin Android role external client "),
+    );
+    const di = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin Android role dependency injection "),
+    );
+
+    expect(project.detected.languages).toContain("kotlin");
+    expect(project.detected.packageManagers).toContain("gradle");
+    expect(titles).toContain("Gradle module app");
+    expect(ui?.source).toBe("kotlin-android-role-ui-entrypoint");
+    expect(ui?.kind).toBe("ui-flow");
+    expect(ui?.confidence).toBe("high");
+    expect(ui?.ownedFiles.map((file) => file.path)).toContain(
+      "app/src/main/kotlin/com/example/ui/MainActivity.kt",
+    );
+    expect(ui?.tests).toEqual([
+      { path: "app/src/test/kotlin/com/example/ui/MainActivityTest.kt", command: null },
+    ]);
+    expect(viewModel?.source).toBe("kotlin-android-role-view-model");
+    expect(viewModel?.ownedFiles.map((file) => file.path)).not.toContain(
+      "app/src/main/kotlin/com/example/ui/MainActivity.kt",
+    );
+    expect(data?.trustBoundaries).toEqual(expect.arrayContaining(["database", "serialization"]));
+    expect(client?.trustBoundaries).toEqual(
+      expect.arrayContaining(["network", "external-api", "serialization"]),
+    );
+    expect(di?.source).toBe("kotlin-android-role-dependency-injection");
+    expect(di?.ownedFiles.map((file) => file.path)).toContain(
+      "app/src/main/kotlin/com/example/di/AppGraph.kt",
+    );
+    expect(
+      result.features.flatMap((feature) => feature.ownedFiles.map((file) => file.path)),
+    ).not.toContain("app/build/generated/source/kapt/debug/com/example/Ignored.kt");
+  });
+
+  it("maps server-side Kotlin roles and path fallback evidence", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-server-role-map-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("org.jetbrains.kotlin.jvm") }\n');
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/api/OrderController.kt",
+      [
+        "package com.example.api",
+        "",
+        "import org.springframework.web.bind.annotation.GetMapping",
+        "import org.springframework.web.bind.annotation.RestController",
+        "",
+        "@RestController",
+        "class OrderController {",
+        '  @GetMapping("/orders")',
+        '  fun list(): String = "ok"',
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/app/BillingService.kt",
+      [
+        "package com.example.app",
+        "",
+        "import jakarta.inject.Singleton",
+        "",
+        "@Singleton",
+        "class BillingService",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/db/OrderRepository.kt",
+      [
+        "package com.example.db",
+        "",
+        "import org.springframework.data.repository.CrudRepository",
+        "",
+        "interface OrderRepository : CrudRepository<Order, String>",
+        "class Order",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/client/RemoteClient.kt",
+      [
+        "package com.example.client",
+        "",
+        "import okhttp3.OkHttpClient",
+        "",
+        "class RemoteClient(private val client: OkHttpClient)",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/network/FallbackClient.kt",
+      "package com.example.network\nclass FallbackClient\n",
+    );
+    await writeFixture(
+      root,
+      "src/test/kotlin/com/example/api/OrderControllerTest.kt",
+      "package com.example.api\nclass OrderControllerTest\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const web = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin server role web entrypoint "),
+    );
+    const service = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin server role application service "),
+    );
+    const persistence = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin server role persistence boundary "),
+    );
+    const clientFeatures = result.features.filter((feature) =>
+      feature.title.startsWith("Kotlin server role external client "),
+    );
+
+    expect(web?.source).toBe("kotlin-server-role-web-entrypoint");
+    expect(web?.tests).toEqual([
+      { path: "src/test/kotlin/com/example/api/OrderControllerTest.kt", command: null },
+    ]);
+    expect(service?.source).toBe("kotlin-server-role-application-service");
+    expect(persistence?.source).toBe("kotlin-server-role-persistence-boundary");
+    expect(clientFeatures.some((feature) => feature.confidence === "high")).toBe(true);
+    expect(clientFeatures.some((feature) => feature.confidence === "medium")).toBe(true);
+  });
+
+  it("keeps Kotlin feature IDs stable when confidence changes", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-role-id-stability-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("org.jetbrains.kotlin.jvm") }\n');
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/network/FallbackClient.kt",
+      "package com.example.network\nclass FallbackClient\n",
+    );
+
+    const project = await detectProject(root);
+    const first = await mapFeatures(root, project, []);
+    const fallbackBefore = first.features.find(
+      (feature) =>
+        feature.source === "kotlin-server-role-external-client" &&
+        feature.ownedFiles.some(
+          (file) => file.path === "src/main/kotlin/com/example/network/FallbackClient.kt",
+        ),
+    );
+
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/network/FallbackClient.kt",
+      [
+        "package com.example.network",
+        "",
+        "import okhttp3.OkHttpClient",
+        "",
+        "class FallbackClient(private val client: OkHttpClient)",
+        "",
+      ].join("\n"),
+    );
+
+    const second = await mapFeatures(root, project, first.features);
+    const fallbackAfter = second.features.find(
+      (feature) =>
+        feature.source === "kotlin-server-role-external-client" &&
+        feature.ownedFiles.some(
+          (file) => file.path === "src/main/kotlin/com/example/network/FallbackClient.kt",
+        ),
+    );
+
+    expect(fallbackBefore?.confidence).toBe("medium");
+    expect(fallbackAfter?.confidence).toBe("high");
+    expect(fallbackAfter?.featureId).toBe(fallbackBefore?.featureId);
+  });
+
+  it("does not infer Android roles from non-Android Gradle module paths", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-android-path-leak-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(
+      root,
+      "apps/android/build.gradle.kts",
+      'plugins { id("org.jetbrains.kotlin.jvm") }\n',
+    );
+    await writeFixture(
+      root,
+      "apps/android/src/main/kotlin/com/example/di/Injector.kt",
+      "package com.example.di\nclass Injector\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(
+      result.features.some((feature) => feature.source.startsWith("kotlin-android-role-")),
+    ).toBe(false);
+  });
+
+  it("maps Kotlin role evidence from wildcard imports", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-wildcard-imports-");
+    await writeFixture(root, "settings.gradle.kts", 'pluginManagement {}\ninclude(":app")\n');
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("org.jetbrains.kotlin.jvm") }\n');
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/client/RemoteClient.kt",
+      [
+        "package com.example.client",
+        "",
+        "import retrofit2.*",
+        "",
+        "class RemoteClient(private val retrofit: Retrofit)",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(root, "app/build.gradle.kts", 'plugins { id("com.android.application") }\n');
+    await writeFixture(root, "app/src/main/AndroidManifest.xml", "<manifest />\n");
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/bootstrap/AppModule.kt",
+      [
+        "package com.example.bootstrap",
+        "",
+        "import org.koin.dsl.*",
+        "",
+        'fun appModule() = module { single { "value" } }',
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const client = result.features.find(
+      (feature) =>
+        feature.source === "kotlin-server-role-external-client" &&
+        feature.ownedFiles.some(
+          (file) => file.path === "src/main/kotlin/com/example/client/RemoteClient.kt",
+        ),
+    );
+    const di = result.features.find(
+      (feature) =>
+        feature.source === "kotlin-android-role-dependency-injection" &&
+        feature.ownedFiles.some(
+          (file) => file.path === "app/src/main/kotlin/com/example/bootstrap/AppModule.kt",
+        ),
+    );
+
+    expect(client?.ownedFiles[0]?.reason).toContain("retrofit2.*");
+    expect(di?.ownedFiles[0]?.reason).toContain("org.koin.dsl.*");
+  });
+
+  it("maps server-side Kotlin declaration role evidence", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-declaration-role-map-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("org.jetbrains.kotlin.jvm") }\n');
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/ports/PaymentPort.kt",
+      "package com.example.ports\nfun interface PaymentPort { fun pay() }\n",
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/jobs/JobFactory.kt",
+      [
+        "package com.example.jobs",
+        "",
+        "import org.scheduler.*",
+        "",
+        "open class LocalBase",
+        "",
+        "class JobFactory : LocalBase(), JobFactoryBase<Job>() {",
+        "  fun buildJob(): Job = TODO()",
+        '  fun label(): String = "job"',
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const extension = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin server role extension boundary "),
+    );
+    const framework = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin server role framework component "),
+    );
+
+    expect(extension?.source).toBe("kotlin-server-role-extension-boundary");
+    expect(extension?.confidence).toBe("medium");
+    expect(extension?.ownedFiles.map((file) => file.path)).toContain(
+      "src/main/kotlin/com/example/ports/PaymentPort.kt",
+    );
+    expect(
+      extension?.ownedFiles.find(
+        (file) => file.path === "src/main/kotlin/com/example/ports/PaymentPort.kt",
+      )?.reason,
+    ).toContain("interface declaration PaymentPort");
+    expect(framework?.source).toBe("kotlin-server-role-framework-component");
+    expect(framework?.ownedFiles.map((file) => file.path)).toContain(
+      "src/main/kotlin/com/example/jobs/JobFactory.kt",
+    );
+    expect(framework?.ownedFiles[0]?.reason).toContain("external type org.scheduler.");
+    expect(framework?.ownedFiles[0]?.reason).not.toContain("org.scheduler.LocalBase");
+    expect(framework?.ownedFiles[0]?.reason).not.toContain("org.scheduler.String");
+  });
+
   it("normalizes root Gradle source groups", async () => {
     const root = await fixtureRoot("clawpatch-root-gradle-map-");
     await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2482,6 +2482,11 @@ describe("mapFeatures", () => {
     );
     await writeFixture(
       root,
+      "app/src/main/kotlin/com/example/ui/SettingsActivity.kt",
+      "package com.example.ui\nclass SettingsActivity : androidx.activity.ComponentActivity()\n",
+    );
+    await writeFixture(
+      root,
       "app/src/main/kotlin/com/example/ui/MainViewModel.kt",
       [
         "package com.example.ui",
@@ -2609,6 +2614,9 @@ describe("mapFeatures", () => {
     expect(ui?.ownedFiles.map((file) => file.path)).toContain(
       "app/src/main/kotlin/com/example/ui/ProfileFragment.kt",
     );
+    expect(ui?.ownedFiles.map((file) => file.path)).toContain(
+      "app/src/main/kotlin/com/example/ui/SettingsActivity.kt",
+    );
     expect(ui?.tests).toEqual([
       { path: "app/src/test/kotlin/com/example/ui/MainActivityTest.kt", command: null },
     ]);
@@ -2650,6 +2658,17 @@ describe("mapFeatures", () => {
         '  @GetMapping("/orders")',
         '  fun list(): String = "ok"',
         "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/api/QualifiedController.kt",
+      [
+        "package com.example.api",
+        "",
+        "@org.springframework.web.bind.annotation.RestController",
+        "class QualifiedController",
         "",
       ].join("\n"),
     );
@@ -2759,6 +2778,9 @@ describe("mapFeatures", () => {
     expect(web?.source).toBe("kotlin-server-role-web-entrypoint");
     expect(web?.ownedFiles.map((file) => file.path)).not.toContain(
       "src/main/kotlin/com/example/client/GitHubApi.kt",
+    );
+    expect(web?.ownedFiles.map((file) => file.path)).toContain(
+      "src/main/kotlin/com/example/api/QualifiedController.kt",
     );
     expect(web?.tests).toEqual([
       { path: "src/test/kotlin/com/example/api/OrderControllerTest.kt", command: null },
@@ -3184,6 +3206,16 @@ describe("mapFeatures", () => {
         "",
       ].join("\n"),
     );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/jobs/QualifiedHandler.kt",
+      [
+        "package com.example.jobs",
+        "",
+        "class QualifiedHandler : org.framework.FrameworkBase()",
+        "",
+      ].join("\n"),
+    );
 
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
@@ -3201,6 +3233,9 @@ describe("mapFeatures", () => {
     );
     expect(framework?.ownedFiles.map((file) => file.path)).toContain(
       "src/main/kotlin/com/example/jobs/InternalHandler.kt",
+    );
+    expect(framework?.ownedFiles.map((file) => file.path)).toContain(
+      "src/main/kotlin/com/example/jobs/QualifiedHandler.kt",
     );
   });
 

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2896,6 +2896,40 @@ describe("mapFeatures", () => {
     ).not.toContain("android");
   });
 
+  it("detects legacy Android Gradle plugin application syntax", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-android-legacy-gradle-map-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(root, "build.gradle", 'apply plugin: "com.android.library"\n');
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/ui/MainActivity.kt",
+      [
+        "package com.example.ui",
+        "",
+        "import androidx.activity.ComponentActivity",
+        "",
+        "class MainActivity : ComponentActivity()",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(result.features.find((feature) => feature.title === "Gradle module .")?.tags).toContain(
+      "android",
+    );
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "kotlin-android-role-ui-entrypoint" &&
+          feature.ownedFiles.some(
+            (file) => file.path === "src/main/kotlin/com/example/ui/MainActivity.kt",
+          ),
+      ),
+    ).toBe(true);
+  });
+
   it("does not treat non-entrypoint Android framework imports as UI roles", async () => {
     const root = await fixtureRoot("clawpatch-kotlin-android-non-ui-import-");
     await writeFixture(root, "settings.gradle.kts", 'pluginManagement {}\ninclude(":app")\n');
@@ -3050,6 +3084,11 @@ describe("mapFeatures", () => {
       root,
       "src/main/kotlin/com/example/ports/PaymentPort.kt",
       "package com.example.ports\nfun interface PaymentPort { fun pay() }\n",
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/domain/Job.kt",
+      "package com.example.domain\nclass Job\n",
     );
     await writeFixture(
       root,

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3017,6 +3017,72 @@ describe("mapFeatures", () => {
     ).toBe(false);
   });
 
+  it("filters mixed Java/Kotlin module types from Kotlin framework roles", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-java-local-type-map-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("org.jetbrains.kotlin.jvm") }\n');
+    await writeFixture(
+      root,
+      "src/main/java/com/example/framework/BaseHandler.java",
+      "package com.example.framework; public class BaseHandler {}\n",
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/api/Handler.kt",
+      [
+        "package com.example.api",
+        "",
+        "import com.example.framework.BaseHandler",
+        "",
+        "class Handler : BaseHandler()",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "kotlin-server-role-framework-component" &&
+          feature.ownedFiles.some(
+            (file) => file.path === "src/main/kotlin/com/example/api/Handler.kt",
+          ),
+      ),
+    ).toBe(false);
+  });
+
+  it("maps Kotlin supertypes with constructor arguments", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-supertype-args-map-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("org.jetbrains.kotlin.jvm") }\n');
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/jobs/Handler.kt",
+      [
+        "package com.example.jobs",
+        "",
+        "import org.framework.FrameworkBase",
+        "",
+        "class Handler : FrameworkBase(dep, config)",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const framework = result.features.find(
+      (feature) =>
+        feature.source === "kotlin-server-role-framework-component" &&
+        feature.ownedFiles.some(
+          (file) => file.path === "src/main/kotlin/com/example/jobs/Handler.kt",
+        ),
+    );
+
+    expect(framework?.ownedFiles[0]?.reason).toContain("external type org.framework.FrameworkBase");
+  });
+
   it("normalizes root Gradle source groups", async () => {
     const root = await fixtureRoot("clawpatch-root-gradle-map-");
     await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3099,14 +3099,18 @@ describe("mapFeatures", () => {
         "import kotlin.time.*",
         "import org.scheduler.*",
         "",
-        "open class LocalBase",
-        "",
         "class JobFactory : LocalBase(), JobFactoryBase<Job>() {",
         "  fun buildJob(): Job = TODO()",
+        "  fun local(): LocalBase = TODO()",
         '  fun label(): String = "job"',
         "}",
         "",
       ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/jobs/LocalBase.kt",
+      "package com.example.jobs\nopen class LocalBase\n",
     );
 
     const project = await detectProject(root);

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3082,6 +3082,18 @@ describe("mapFeatures", () => {
         "",
       ].join("\n"),
     );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/jobs/InternalHandler.kt",
+      [
+        "package com.example.jobs",
+        "",
+        "import org.framework.FrameworkBase",
+        "",
+        "class InternalHandler internal constructor(dep: Any) : FrameworkBase(dep)",
+        "",
+      ].join("\n"),
+    );
 
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
@@ -3096,6 +3108,9 @@ describe("mapFeatures", () => {
     expect(framework?.ownedFiles[0]?.reason).toContain("external type org.framework.FrameworkBase");
     expect(framework?.ownedFiles.map((file) => file.path)).toContain(
       "src/main/kotlin/com/example/jobs/InjectedHandler.kt",
+    );
+    expect(framework?.ownedFiles.map((file) => file.path)).toContain(
+      "src/main/kotlin/com/example/jobs/InternalHandler.kt",
     );
   });
 

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2443,7 +2443,11 @@ describe("mapFeatures", () => {
         "",
       ].join("\n"),
     );
-    await writeFixture(root, "app/build.gradle.kts", 'plugins { id("com.android.application") }\n');
+    await writeFixture(
+      root,
+      "app/build.gradle.kts",
+      "plugins { alias(libs.plugins.android.application) }\n",
+    );
     await writeFixture(
       root,
       "app/src/main/kotlin/com/example/ui/MainActivity.kt",
@@ -2807,6 +2811,7 @@ describe("mapFeatures", () => {
       "apps/android/build.gradle.kts",
       [
         'plugins { id("org.jetbrains.kotlin.jvm") }',
+        "plugins { alias(libs.plugins.android.application).apply(false) }",
         '// id("com.android.application")',
         '/* android { namespace = "example" } */',
         "",
@@ -2961,7 +2966,7 @@ describe("mapFeatures", () => {
       [
         "package com.example.jobs",
         "",
-        "import java.util.*",
+        "import kotlin.time.*",
         "import org.scheduler.*",
         "",
         "open class LocalBase",

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3065,7 +3065,20 @@ describe("mapFeatures", () => {
         "",
         "import org.framework.FrameworkBase",
         "",
-        "class Handler : FrameworkBase(dep, config)",
+        "class Handler : FrameworkBase(dep = dep, config = config)",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/jobs/InjectedHandler.kt",
+      [
+        "package com.example.jobs",
+        "",
+        "import jakarta.inject.Inject",
+        "import org.framework.FrameworkBase",
+        "",
+        "class InjectedHandler @Inject constructor(dep: Any) : FrameworkBase(dep)",
         "",
       ].join("\n"),
     );
@@ -3081,6 +3094,40 @@ describe("mapFeatures", () => {
     );
 
     expect(framework?.ownedFiles[0]?.reason).toContain("external type org.framework.FrameworkBase");
+    expect(framework?.ownedFiles.map((file) => file.path)).toContain(
+      "src/main/kotlin/com/example/jobs/InjectedHandler.kt",
+    );
+  });
+
+  it("maps Kotlin Spring components as application services", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-spring-component-map-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("org.jetbrains.kotlin.jvm") }\n');
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/app/BillingComponent.kt",
+      [
+        "package com.example.app",
+        "",
+        "import org.springframework.stereotype.Component",
+        "",
+        "@Component",
+        "class BillingComponent",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const service = result.features.find(
+      (feature) =>
+        feature.source === "kotlin-server-role-application-service" &&
+        feature.ownedFiles.some(
+          (file) => file.path === "src/main/kotlin/com/example/app/BillingComponent.kt",
+        ),
+    );
+
+    expect(service?.ownedFiles[0]?.reason).toContain("service annotation @Component");
   });
 
   it("normalizes root Gradle source groups", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2427,7 +2427,6 @@ describe("mapFeatures", () => {
       'plugins { id("com.android.application") version "1.0" apply false }\n',
     );
     await writeFixture(root, "app/build.gradle.kts", 'plugins { id("com.android.application") }\n');
-    await writeFixture(root, "app/src/main/AndroidManifest.xml", "<manifest />\n");
     await writeFixture(
       root,
       "app/src/main/kotlin/com/example/ui/MainActivity.kt",
@@ -2522,6 +2521,7 @@ describe("mapFeatures", () => {
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
     const titles = result.features.map((feature) => feature.title);
+    const gradleModule = result.features.find((feature) => feature.title === "Gradle module app");
     const ui = result.features.find((feature) =>
       feature.title.startsWith("Kotlin Android role UI entrypoint "),
     );
@@ -2541,6 +2541,7 @@ describe("mapFeatures", () => {
     expect(project.detected.languages).toContain("kotlin");
     expect(project.detected.packageManagers).toContain("gradle");
     expect(titles).toContain("Gradle module app");
+    expect(gradleModule?.tags).toEqual(expect.arrayContaining(["gradle", "kotlin", "android"]));
     expect(ui?.source).toBe("kotlin-android-role-ui-entrypoint");
     expect(ui?.kind).toBe("ui-flow");
     expect(ui?.confidence).toBe("high");
@@ -2658,8 +2659,17 @@ describe("mapFeatures", () => {
     ]);
     expect(service?.source).toBe("kotlin-server-role-application-service");
     expect(persistence?.source).toBe("kotlin-server-role-persistence-boundary");
-    expect(clientFeatures.some((feature) => feature.confidence === "high")).toBe(true);
-    expect(clientFeatures.some((feature) => feature.confidence === "medium")).toBe(true);
+    const clientFiles = clientFeatures.flatMap((feature) =>
+      feature.ownedFiles.map((file) => file.path),
+    );
+    expect(clientFeatures).toHaveLength(1);
+    expect(clientFeatures[0]?.confidence).toBe("high");
+    expect(clientFiles).toEqual(
+      expect.arrayContaining([
+        "src/main/kotlin/com/example/client/RemoteClient.kt",
+        "src/main/kotlin/com/example/network/FallbackClient.kt",
+      ]),
+    );
   });
 
   it("keeps Kotlin feature IDs stable when confidence changes", async () => {
@@ -2670,6 +2680,11 @@ describe("mapFeatures", () => {
       root,
       "src/main/kotlin/com/example/network/FallbackClient.kt",
       "package com.example.network\nclass FallbackClient\n",
+    );
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/network/BackupClient.kt",
+      "package com.example.network\nclass BackupClient\n",
     );
 
     const project = await detectProject(root);
@@ -2707,6 +2722,10 @@ describe("mapFeatures", () => {
     expect(fallbackBefore?.confidence).toBe("medium");
     expect(fallbackAfter?.confidence).toBe("high");
     expect(fallbackAfter?.featureId).toBe(fallbackBefore?.featureId);
+    expect(fallbackAfter?.ownedFiles.map((file) => file.path).toSorted()).toEqual([
+      "src/main/kotlin/com/example/network/BackupClient.kt",
+      "src/main/kotlin/com/example/network/FallbackClient.kt",
+    ]);
   });
 
   it("does not infer Android roles from non-Android Gradle module paths", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2424,7 +2424,7 @@ describe("mapFeatures", () => {
     await writeFixture(
       root,
       "build.gradle.kts",
-      'plugins { id("com.android.application") version "1.0" apply false }\n',
+      'plugins { id("com.android.application").version("1.0").apply(false) }\n',
     );
     await writeFixture(
       root,
@@ -2484,6 +2484,18 @@ describe("mapFeatures", () => {
         "",
         "@Database(entities = [], version = 1)",
         "abstract class AppDatabase : RoomDatabase()",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/data/UserRepository.kt",
+      [
+        "package com.example.data",
+        "",
+        "import javax.inject.Inject",
+        "",
+        "class UserRepository @Inject constructor()",
         "",
       ].join("\n"),
     );
@@ -2583,6 +2595,9 @@ describe("mapFeatures", () => {
       "app/src/main/kotlin/com/example/ui/MainActivity.kt",
     );
     expect(data?.trustBoundaries).toEqual(expect.arrayContaining(["database", "serialization"]));
+    expect(data?.ownedFiles.map((file) => file.path)).toContain(
+      "app/src/main/kotlin/com/example/data/UserRepository.kt",
+    );
     expect(client?.trustBoundaries).toEqual(
       expect.arrayContaining(["network", "external-api", "serialization"]),
     );
@@ -2946,6 +2961,7 @@ describe("mapFeatures", () => {
       [
         "package com.example.jobs",
         "",
+        "import java.util.*",
         "import org.scheduler.*",
         "",
         "open class LocalBase",

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2467,6 +2467,21 @@ describe("mapFeatures", () => {
     );
     await writeFixture(
       root,
+      "app/src/main/kotlin/com/example/ui/ProfileFragment.kt",
+      [
+        "package com.example.ui",
+        "",
+        "import dagger.hilt.android.AndroidEntryPoint",
+        "",
+        "@AndroidEntryPoint",
+        "class ProfileFragment : BaseFragment()",
+        "",
+        "open class BaseFragment",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
       "app/src/main/kotlin/com/example/ui/MainViewModel.kt",
       [
         "package com.example.ui",
@@ -2590,6 +2605,9 @@ describe("mapFeatures", () => {
     expect(ui?.confidence).toBe("high");
     expect(ui?.ownedFiles.map((file) => file.path)).toContain(
       "app/src/main/kotlin/com/example/ui/MainActivity.kt",
+    );
+    expect(ui?.ownedFiles.map((file) => file.path)).toContain(
+      "app/src/main/kotlin/com/example/ui/ProfileFragment.kt",
     );
     expect(ui?.tests).toEqual([
       { path: "app/src/test/kotlin/com/example/ui/MainActivityTest.kt", command: null },
@@ -2869,6 +2887,35 @@ describe("mapFeatures", () => {
     ).toBe(false);
   });
 
+  it("does not treat project-local Android supertype names as framework roles", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-android-local-supertype-");
+    await writeFixture(root, "settings.gradle.kts", 'pluginManagement {}\ninclude(":app")\n');
+    await writeFixture(root, "app/build.gradle.kts", 'plugins { id("com.android.library") }\n');
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/domain/Service.kt",
+      "package com.example.domain\nopen class Service\n",
+    );
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/domain/Billing.kt",
+      "package com.example.domain\nclass Billing : Service()\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "kotlin-android-role-ui-entrypoint" &&
+          feature.ownedFiles.some(
+            (file) => file.path === "app/src/main/kotlin/com/example/domain/Billing.kt",
+          ),
+      ),
+    ).toBe(false);
+  });
+
   it("does not treat Compose runtime state imports as UI roles", async () => {
     const root = await fixtureRoot("clawpatch-kotlin-android-compose-state-");
     await writeFixture(root, "settings.gradle.kts", 'pluginManagement {}\ninclude(":app")\n');
@@ -3089,7 +3136,7 @@ describe("mapFeatures", () => {
         "",
         "import org.framework.FrameworkBase",
         "",
-        "class Handler : FrameworkBase(dep = dep, config = config)",
+        "class Handler(callback: () -> Unit) : FrameworkBase(dep = dep, config = config)",
         "",
       ].join("\n"),
     );

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3473,6 +3473,20 @@ describe("mapFeatures", () => {
     );
     await writeFixture(
       root,
+      "src/main/java/com/acme/security/SslFactory.java",
+      [
+        "package com.acme.security;",
+        "",
+        "import javax.net.ssl.SSLContext;",
+        "",
+        "public class SslFactory {",
+        "  public SSLContext context() { return null; }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
       "src/main/java/com/acme/local/LocalCommandAdapter.java",
       [
         "package com.acme.local;",
@@ -3530,6 +3544,9 @@ describe("mapFeatures", () => {
         "src/main/java/com/acme/jobs/JobFactory.java",
       ].toSorted(),
     );
+    expect(
+      bySource.get("jvm-role-framework-component")?.ownedFiles.map((file) => file.path),
+    ).not.toContain("src/main/java/com/acme/security/SslFactory.java");
     expect(
       bySource
         .get("jvm-role-extension-boundary")

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2634,6 +2634,22 @@ describe("mapFeatures", () => {
     );
     await writeFixture(
       root,
+      "src/main/kotlin/com/example/config/AppConfig.kt",
+      [
+        "package com.example.config",
+        "",
+        "import org.springframework.context.annotation.Bean",
+        "import org.springframework.context.annotation.Configuration",
+        "",
+        "@Configuration",
+        "class AppConfig {",
+        '  @Bean fun name(): String = "orders"',
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
       "src/test/kotlin/com/example/api/OrderControllerTest.kt",
       "package com.example.api\nclass OrderControllerTest\n",
     );
@@ -2652,6 +2668,9 @@ describe("mapFeatures", () => {
     const clientFeatures = result.features.filter((feature) =>
       feature.title.startsWith("Kotlin server role external client "),
     );
+    const configuration = result.features.find((feature) =>
+      feature.title.startsWith("Kotlin server role configuration "),
+    );
 
     expect(web?.source).toBe("kotlin-server-role-web-entrypoint");
     expect(web?.tests).toEqual([
@@ -2659,6 +2678,10 @@ describe("mapFeatures", () => {
     ]);
     expect(service?.source).toBe("kotlin-server-role-application-service");
     expect(persistence?.source).toBe("kotlin-server-role-persistence-boundary");
+    expect(configuration?.source).toBe("kotlin-server-role-configuration");
+    expect(configuration?.ownedFiles.map((file) => file.path)).toContain(
+      "src/main/kotlin/com/example/config/AppConfig.kt",
+    );
     const clientFiles = clientFeatures.flatMap((feature) =>
       feature.ownedFiles.map((file) => file.path),
     );
@@ -2747,6 +2770,38 @@ describe("mapFeatures", () => {
 
     expect(
       result.features.some((feature) => feature.source.startsWith("kotlin-android-role-")),
+    ).toBe(false);
+  });
+
+  it("does not treat non-entrypoint Android framework imports as UI roles", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-android-non-ui-import-");
+    await writeFixture(root, "settings.gradle.kts", 'pluginManagement {}\ninclude(":app")\n');
+    await writeFixture(root, "app/build.gradle.kts", 'plugins { id("com.android.library") }\n');
+    await writeFixture(
+      root,
+      "app/src/main/kotlin/com/example/alerts/Notifier.kt",
+      [
+        "package com.example.alerts",
+        "",
+        "import android.app.Notification",
+        "import android.app.PendingIntent",
+        "",
+        "class Notifier(private val notification: Notification, private val intent: PendingIntent)",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "kotlin-android-role-ui-entrypoint" &&
+          feature.ownedFiles.some(
+            (file) => file.path === "app/src/main/kotlin/com/example/alerts/Notifier.kt",
+          ),
+      ),
     ).toBe(false);
   });
 

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2811,7 +2811,10 @@ describe("mapFeatures", () => {
       "apps/android/build.gradle.kts",
       [
         'plugins { id("org.jetbrains.kotlin.jvm") }',
-        "plugins { alias(libs.plugins.android.application).apply(false) }",
+        "plugins {",
+        "  alias(libs.plugins.android.application)",
+        "    .apply(false)",
+        "}",
         '// id("com.android.application")',
         '/* android { namespace = "example" } */',
         "",
@@ -3411,6 +3414,18 @@ describe("mapFeatures", () => {
     );
     await writeFixture(
       root,
+      "src/main/java/com/acme/ext/ServletFilter.java",
+      [
+        "package com.acme.ext;",
+        "",
+        "import jakarta.servlet.Filter;",
+        "",
+        "public class ServletFilter implements Filter {}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
       "src/main/java/com/acme/local/LocalCommandAdapter.java",
       [
         "package com.acme.local;",
@@ -3463,6 +3478,7 @@ describe("mapFeatures", () => {
         "src/main/java/com/acme/ext/HelperFirstAdapter.java",
         "src/main/java/com/acme/ext/PluginAdapter.java",
         "src/main/java/com/acme/ext/RecordPlugin.java",
+        "src/main/java/com/acme/ext/ServletFilter.java",
         "src/main/java/com/acme/jobs/GenericJobFactory.java",
         "src/main/java/com/acme/jobs/JobFactory.java",
       ].toSorted(),
@@ -3476,6 +3492,7 @@ describe("mapFeatures", () => {
       "src/main/java/com/acme/ext/HelperFirstAdapter.java",
       "src/main/java/com/acme/ext/PluginAdapter.java",
       "src/main/java/com/acme/ext/RecordPlugin.java",
+      "src/main/java/com/acme/ext/ServletFilter.java",
       "src/main/java/com/acme/local/LocalCommandAdapter.java",
       "src/main/java/com/google/myapp/GuavaAdapter.java",
     ]);

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2693,6 +2693,21 @@ describe("mapFeatures", () => {
     );
     await writeFixture(
       root,
+      "src/main/kotlin/com/example/client/GitHubApi.kt",
+      [
+        "package com.example.client",
+        "",
+        "import retrofit2.http.GET",
+        "",
+        "interface GitHubApi {",
+        '  @GET("/users")',
+        "  fun users(): String",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
       "src/main/kotlin/com/example/network/FallbackClient.kt",
       "package com.example.network\nclass FallbackClient\n",
     );
@@ -2742,6 +2757,9 @@ describe("mapFeatures", () => {
     );
 
     expect(web?.source).toBe("kotlin-server-role-web-entrypoint");
+    expect(web?.ownedFiles.map((file) => file.path)).not.toContain(
+      "src/main/kotlin/com/example/client/GitHubApi.kt",
+    );
     expect(web?.tests).toEqual([
       { path: "src/test/kotlin/com/example/api/OrderControllerTest.kt", command: null },
     ]);
@@ -2758,6 +2776,7 @@ describe("mapFeatures", () => {
     expect(clientFeatures[0]?.confidence).toBe("high");
     expect(clientFiles).toEqual(
       expect.arrayContaining([
+        "src/main/kotlin/com/example/client/GitHubApi.kt",
         "src/main/kotlin/com/example/client/RemoteClient.kt",
         "src/main/kotlin/com/example/network/FallbackClient.kt",
         "src/main/kotlin/com/example/network/PaymentClient.kt",

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2790,7 +2790,12 @@ describe("mapFeatures", () => {
     await writeFixture(
       root,
       "apps/android/build.gradle.kts",
-      'plugins { id("org.jetbrains.kotlin.jvm") }\n',
+      [
+        'plugins { id("org.jetbrains.kotlin.jvm") }',
+        '// id("com.android.application")',
+        '/* android { namespace = "example" } */',
+        "",
+      ].join("\n"),
     );
     await writeFixture(
       root,
@@ -2804,6 +2809,9 @@ describe("mapFeatures", () => {
     expect(
       result.features.some((feature) => feature.source.startsWith("kotlin-android-role-")),
     ).toBe(false);
+    expect(
+      result.features.find((feature) => feature.title === "Gradle module apps/android")?.tags,
+    ).not.toContain("android");
   });
 
   it("does not treat non-entrypoint Android framework imports as UI roles", async () => {
@@ -2976,6 +2984,37 @@ describe("mapFeatures", () => {
     expect(framework?.ownedFiles[0]?.reason).toContain("external type org.scheduler.");
     expect(framework?.ownedFiles[0]?.reason).not.toContain("org.scheduler.LocalBase");
     expect(framework?.ownedFiles[0]?.reason).not.toContain("org.scheduler.String");
+  });
+
+  it("does not treat Kotlin stdlib return types as framework components", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-stdlib-type-map-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("org.jetbrains.kotlin.jvm") }\n');
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/util/Timeouts.kt",
+      [
+        "package com.example.util",
+        "",
+        "import kotlin.time.Duration",
+        "",
+        "fun timeout(): Duration = Duration.ZERO",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "kotlin-server-role-framework-component" &&
+          feature.ownedFiles.some(
+            (file) => file.path === "src/main/kotlin/com/example/util/Timeouts.kt",
+          ),
+      ),
+    ).toBe(false);
   });
 
   it("normalizes root Gradle source groups", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -3310,6 +3310,34 @@ describe("mapFeatures", () => {
     ).toBe(true);
   });
 
+  it("does not treat project-local nested Kotlin types as external frameworks", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-local-nested-type-map-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("org.jetbrains.kotlin.jvm") }\n');
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/Outer.kt",
+      [
+        "package com.example",
+        "",
+        "class Outer { open class Base }",
+        "class Handler : Outer.Base()",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "kotlin-server-role-framework-component" &&
+          feature.ownedFiles.some((file) => file.path === "src/main/kotlin/com/example/Outer.kt"),
+      ),
+    ).toBe(false);
+  });
+
   it("normalizes root Gradle source groups", async () => {
     const root = await fixtureRoot("clawpatch-root-gradle-map-");
     await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -2491,7 +2491,7 @@ describe("mapFeatures", () => {
       [
         "package com.example.ui",
         "",
-        "import androidx.lifecycle.ViewModel",
+        "import androidx.lifecycle.*",
         "",
         "class MainViewModel : ViewModel()",
         "",
@@ -3270,6 +3270,46 @@ describe("mapFeatures", () => {
     expect(service?.ownedFiles[0]?.reason).toContain("service annotation @Component");
   });
 
+  it("does not treat qualified Kotlin annotations as type imports", async () => {
+    const root = await fixtureRoot("clawpatch-kotlin-qualified-annotation-type-map-");
+    await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("org.jetbrains.kotlin.jvm") }\n');
+    await writeFixture(
+      root,
+      "src/main/kotlin/com/example/app/Billing.kt",
+      [
+        "package com.example.app",
+        "",
+        "@org.springframework.stereotype.Service",
+        "class Billing : Service",
+        "interface Service",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "kotlin-server-role-framework-component" &&
+          feature.ownedFiles.some(
+            (file) => file.path === "src/main/kotlin/com/example/app/Billing.kt",
+          ),
+      ),
+    ).toBe(false);
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "kotlin-server-role-application-service" &&
+          feature.ownedFiles.some(
+            (file) => file.path === "src/main/kotlin/com/example/app/Billing.kt",
+          ),
+      ),
+    ).toBe(true);
+  });
+
   it("normalizes root Gradle source groups", async () => {
     const root = await fixtureRoot("clawpatch-root-gradle-map-");
     await writeFixture(root, "settings.gradle.kts", "pluginManagement {}\n");
@@ -3614,6 +3654,45 @@ describe("mapFeatures", () => {
       "src/main/java/com/acme/local/LocalCommandAdapter.java",
       "src/main/java/com/google/myapp/GuavaAdapter.java",
     ]);
+  });
+
+  it("does not treat qualified Java annotations as type imports", async () => {
+    const root = await fixtureRoot("clawpatch-java-qualified-annotation-type-map-");
+    await writeFixture(root, "build.gradle.kts", 'plugins { id("java") }\n');
+    await writeFixture(
+      root,
+      "src/main/java/com/acme/app/Billing.java",
+      [
+        "package com.acme.app;",
+        "",
+        "@org.springframework.stereotype.Service",
+        "public class Billing implements Service {}",
+        "interface Service {}",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "jvm-role-framework-component" &&
+          feature.ownedFiles.some(
+            (file) => file.path === "src/main/java/com/acme/app/Billing.java",
+          ),
+      ),
+    ).toBe(false);
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.source === "jvm-role-application-service" &&
+          feature.ownedFiles.some(
+            (file) => file.path === "src/main/java/com/acme/app/Billing.java",
+          ),
+      ),
+    ).toBe(true);
   });
 
   it("ignores vendored SwiftPM manifests during detection", async () => {

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -968,7 +968,7 @@ function parseJavaDeclarations(source: string): JavaDeclaration[] {
 function parseKotlinDeclarations(source: string): KotlinDeclaration[] {
   const declarations: KotlinDeclaration[] = [];
   const declarationPattern =
-    /\b(?:(?:data|sealed|open|abstract|final|inner|value|annotation)\s+)*(?:(enum)\s+)?(?:(fun)\s+)?(class|interface|object)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*<[^{};]*>)?(?:\s+(?:@[A-Za-z_][A-Za-z0-9_.]*(?:\([^{}]*?\))?\s+)*constructor\s*\([^{}]*?\)|\s*\([^{}]*?\))?(?:\s*:\s*([^{\n]+))?/gsu;
+    /\b(?:(?:data|sealed|open|abstract|final|inner|value|annotation)\s+)*(?:(enum)\s+)?(?:(fun)\s+)?(class|interface|object)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*<[^{};]*>)?(?:\s+(?:(?:@[A-Za-z_][A-Za-z0-9_.]*(?:\([^{}]*?\))?|public|private|protected|internal)\s+)*constructor\s*\([^{}]*?\)|\s*\([^{}]*?\))?(?:\s*:\s*([^{\n]+))?/gsu;
   for (const match of source.matchAll(declarationPattern)) {
     const rawKind = match[3];
     const name = match[4];

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -775,6 +775,9 @@ function kotlinDeclarationRoleEvidence(
 }
 
 function kotlinImportedTypeMatches(info: KotlinFileInfo, type: string, allowed: string[]): boolean {
+  if (allowed.includes(type)) {
+    return true;
+  }
   const direct = info.imports.get(type);
   return direct !== undefined && allowed.includes(direct);
 }
@@ -804,6 +807,9 @@ function kotlinImportForType(
   projectTypes: Set<string>,
   projectPackages: Set<string>,
 ): string | undefined {
+  if (type.includes(".")) {
+    return type.startsWith("kotlin.") ? undefined : type;
+  }
   const direct = info.imports.get(type);
   if (direct !== undefined) {
     return direct.startsWith("kotlin.") ? undefined : direct;
@@ -968,7 +974,11 @@ function parseKotlinFile(source: string): KotlinFileInfo {
   )) {
     const raw = match[1];
     if (raw !== undefined) {
-      annotations.add(raw.split(".").at(-1) ?? raw);
+      const simple = raw.split(".").at(-1) ?? raw;
+      annotations.add(simple);
+      if (raw.includes(".")) {
+        imports.set(simple, raw);
+      }
     }
   }
 
@@ -1251,9 +1261,7 @@ function baseKotlinTypeName(raw: string): string {
     raw
       .replace(/\([^()]*\)/gu, "")
       .replace(/\?.*$/su, "")
-      .split(".")
-      .at(-1)
-      ?.replace(/[^A-Za-z0-9_]/gu, "")
+      .replace(/[^A-Za-z0-9_.]/gu, "")
       .trim() ?? ""
   );
 }

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -196,7 +196,7 @@ async function gradleProjectSeeds(root: string, gradleRoot: string): Promise<Fea
     const testFiles = (await walk(root, [sourceRoot]))
       .filter(isGradleSourceFile)
       .filter((file) => isGradleTestFile(moduleRoot, file));
-    const tags = gradleTags(buildFile, sourceFiles);
+    const tags = await gradleTags(root, buildFile, sourceFiles);
 
     seeds.push({
       title: `Gradle module ${moduleRoot}`,
@@ -360,45 +360,16 @@ function kotlinRoleGroups(
   label: string;
   symbol: string;
 }> {
-  const groups = kotlinFilesByConfidence(byFile).flatMap(([confidence, files]) =>
-    partitionFileGroups(sourceRoot, files, maxOwnedFiles).map((group) => ({
-      confidence,
-      group,
-      label: `${group.label} (${confidence})`,
-      symbol: group.label,
-    })),
-  );
-  const symbolCounts = new Map<string, number>();
-  for (const group of groups) {
-    symbolCounts.set(group.symbol, (symbolCounts.get(group.symbol) ?? 0) + 1);
-  }
-  return groups.map((group) => ({
-    ...group,
-    symbol:
-      (symbolCounts.get(group.symbol) ?? 0) > 1
-        ? `${group.symbol} (${group.confidence})`
-        : group.symbol,
+  return partitionFileGroups(sourceRoot, [...byFile.keys()], maxOwnedFiles).map((group) => ({
+    confidence: group.files.some((path) =>
+      (byFile.get(path) ?? []).some((item) => item.confidence === "high"),
+    )
+      ? "high"
+      : "medium",
+    group,
+    label: group.label,
+    symbol: group.label,
   }));
-}
-
-function kotlinFilesByConfidence(
-  byFile: Map<string, Array<{ reason: string; confidence: FeatureSeed["confidence"] }>>,
-): Array<[FeatureSeed["confidence"], string[]]> {
-  const buckets = new Map<FeatureSeed["confidence"], string[]>();
-  for (const [path, evidence] of byFile) {
-    const confidence = evidence.some((item) => item.confidence === "high") ? "high" : "medium";
-    const files = buckets.get(confidence) ?? [];
-    files.push(path);
-    buckets.set(confidence, files);
-  }
-  const order = new Map<FeatureSeed["confidence"], number>([
-    ["high", 0],
-    ["medium", 1],
-    ["low", 2],
-  ]);
-  return [...buckets.entries()].toSorted(
-    ([left], [right]) => (order.get(left) ?? 99) - (order.get(right) ?? 99),
-  );
 }
 
 function kotlinRoleSource(role: KotlinRoleKey): string {
@@ -1375,7 +1346,11 @@ function associatedGradleTests(files: string[], testFiles: string[]): SeedTestRe
     .map((path) => ({ path, command: null }));
 }
 
-function gradleTags(buildFile: string, sourceFiles: string[]): string[] {
+async function gradleTags(
+  root: string,
+  buildFile: string,
+  sourceFiles: string[],
+): Promise<string[]> {
   const tags = ["gradle"];
   if (
     buildFile.endsWith(".kts") ||
@@ -1383,7 +1358,12 @@ function gradleTags(buildFile: string, sourceFiles: string[]): string[] {
   ) {
     tags.push("kotlin");
   }
-  if (sourceFiles.some((file) => file.endsWith("AndroidManifest.xml"))) {
+  const buildSource = await readFile(join(root, buildFile), "utf8").catch(() => "");
+  if (
+    /\bcom\.android\.(?:application|library|test|dynamic-feature)\b/u.test(buildSource) ||
+    /\bandroid\s*\{/u.test(buildSource) ||
+    sourceFiles.some((file) => file.endsWith("AndroidManifest.xml"))
+  ) {
     tags.push("android");
   }
   return tags;

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -1093,7 +1093,7 @@ function methodReturnEvidence(info: JavaFileInfo, projectPackages: Set<string>):
 }
 
 function isExternalProjectImport(full: string, projectPackages: Set<string>): boolean {
-  if (/^(?:java|javax|jakarta|kotlin)\./u.test(full)) {
+  if (/^(?:java|kotlin)\./u.test(full)) {
     return false;
   }
   for (const packageName of projectPackages) {
@@ -1435,18 +1435,16 @@ async function gradleTags(
 }
 
 function appliesAndroidGradlePlugin(source: string): boolean {
-  for (const line of source.split("\n")) {
-    if (
-      (/\bid\s*(?:\(\s*)?["']com\.android\.(?:application|library|test|dynamic-feature)["']/u.test(
-        line,
-      ) ||
-        /\balias\s*\(\s*libs\.plugins\.[A-Za-z0-9_.]*android[A-Za-z0-9_.]*\s*\)/iu.test(line)) &&
-      !/(?:\bapply\s+false\b|\.apply\s*\(\s*false\s*\))/u.test(line)
-    ) {
-      return true;
-    }
-  }
-  return false;
+  const androidPluginPattern =
+    String.raw`\bid\s*(?:\(\s*)?["']com\.android\.(?:application|library|test|dynamic-feature)["']\s*\)?` +
+    "|" +
+    String.raw`\balias\s*\(\s*libs\.plugins\.[A-Za-z0-9_.]*android[A-Za-z0-9_.]*\s*\)`;
+  const disabledAndroidPlugin = new RegExp(
+    String.raw`(?:${androidPluginPattern})(?:\s*\.version\s*\([^)]*\)|\s+version\s+["'][^"']+["'])?\s*(?:\.apply\s*\(\s*false\s*\)|\bapply\s+false\b)`,
+    "giu",
+  );
+  const activeSource = source.replace(disabledAndroidPlugin, "");
+  return new RegExp(androidPluginPattern, "iu").test(activeSource);
 }
 
 function stripGradleComments(source: string): string {

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -552,7 +552,10 @@ function kotlinFrameworkRoleEvidence(
         confidence: "high",
       });
     }
-    if (!isAndroid && ["Service", "ApplicationScoped", "Singleton", "Named"].includes(annotation)) {
+    if (
+      !isAndroid &&
+      ["Service", "Component", "ApplicationScoped", "Singleton", "Named"].includes(annotation)
+    ) {
       evidence.push({
         role: "server-application-service",
         reason: `service annotation @${annotation}`,
@@ -965,7 +968,7 @@ function parseJavaDeclarations(source: string): JavaDeclaration[] {
 function parseKotlinDeclarations(source: string): KotlinDeclaration[] {
   const declarations: KotlinDeclaration[] = [];
   const declarationPattern =
-    /\b(?:(?:data|sealed|open|abstract|final|inner|value|annotation)\s+)*(?:(enum)\s+)?(?:(fun)\s+)?(class|interface|object)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*<[^{};]*>)?(?:\s*\([^{}]*?\))?(?:\s*:\s*([^={}\n]+))?/gsu;
+    /\b(?:(?:data|sealed|open|abstract|final|inner|value|annotation)\s+)*(?:(enum)\s+)?(?:(fun)\s+)?(class|interface|object)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*<[^{};]*>)?(?:\s+(?:@[A-Za-z_][A-Za-z0-9_.]*(?:\([^{}]*?\))?\s+)*constructor\s*\([^{}]*?\)|\s*\([^{}]*?\))?(?:\s*:\s*([^{\n]+))?/gsu;
   for (const match of source.matchAll(declarationPattern)) {
     const rawKind = match[3];
     const name = match[4];

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -1112,7 +1112,11 @@ function isExternalProjectImport(full: string, projectPackages: Set<string>): bo
   if (/^(?:java|kotlin)\./u.test(full)) {
     return false;
   }
-  if (/^javax\./u.test(full) && !/^javax\.(?:servlet|ws\.rs)\./u.test(full)) {
+  if (
+    full.startsWith("javax.") &&
+    !full.startsWith("javax.servlet.") &&
+    !full.startsWith("javax.ws.rs.")
+  ) {
     return false;
   }
   for (const packageName of projectPackages) {

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -177,6 +177,22 @@ type KotlinFileInfo = {
   declarations: KotlinDeclaration[];
   functionReturnTypes: Set<string>;
 };
+const kotlinServerWebAnnotationNames = new Set([
+  "Controller",
+  "RestController",
+  "RequestMapping",
+  "GetMapping",
+  "PostMapping",
+  "PutMapping",
+  "DeleteMapping",
+  "PatchMapping",
+  "Path",
+  "GET",
+  "POST",
+  "PUT",
+  "DELETE",
+  "PATCH",
+]);
 
 export async function gradleSeeds(root: string): Promise<FeatureSeed[]> {
   const roots = await discoverGradleRoots(root);
@@ -537,25 +553,7 @@ function kotlinFrameworkRoleEvidence(
         confidence: "high",
       });
     }
-    if (
-      !isAndroid &&
-      [
-        "Controller",
-        "RestController",
-        "RequestMapping",
-        "GetMapping",
-        "PostMapping",
-        "PutMapping",
-        "DeleteMapping",
-        "PatchMapping",
-        "Path",
-        "GET",
-        "POST",
-        "PUT",
-        "DELETE",
-        "PATCH",
-      ].includes(annotation)
-    ) {
+    if (!isAndroid && isKotlinServerWebAnnotation(annotation, info)) {
       evidence.push({
         role: "server-web-entrypoint",
         reason: `server web annotation @${annotation}`,
@@ -638,14 +636,7 @@ function kotlinFrameworkRoleEvidence(
         confidence: "high",
       });
     }
-    if (
-      !isAndroid &&
-      (full.startsWith("org.springframework.web.bind.annotation.") ||
-        full.startsWith("io.ktor.server.") ||
-        full.startsWith("org.http4k.") ||
-        full.startsWith("io.javalin.") ||
-        /^(?:jakarta|javax)\.ws\.rs\./u.test(full))
-    ) {
+    if (!isAndroid && isKotlinServerWebImport(full)) {
       evidence.push({
         role: "server-web-entrypoint",
         reason: `server web import ${full}`,
@@ -727,6 +718,32 @@ function kotlinFrameworkRoleEvidence(
   }
 
   return dedupeKotlinEvidence(evidence);
+}
+
+function isKotlinServerWebAnnotation(annotation: string, info: KotlinFileInfo): boolean {
+  if (!kotlinServerWebAnnotationNames.has(annotation)) {
+    return false;
+  }
+  const imported = info.imports.get(annotation);
+  if (imported !== undefined) {
+    return isKotlinServerWebImport(imported);
+  }
+  for (const full of info.imports.values()) {
+    if (full.endsWith(".*") && isKotlinServerWebImport(full)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isKotlinServerWebImport(full: string): boolean {
+  return (
+    full.startsWith("org.springframework.web.bind.annotation.") ||
+    full.startsWith("io.ktor.server.") ||
+    full.startsWith("org.http4k.") ||
+    full.startsWith("io.javalin.") ||
+    /^(?:jakarta|javax)\.ws\.rs\./u.test(full)
+  );
 }
 
 function kotlinDeclarationRoleEvidence(
@@ -901,7 +918,11 @@ function parseJavaFile(source: string): JavaFileInfo {
   for (const match of stripped.matchAll(/@([A-Za-z_][A-Za-z0-9_.]*)/gu)) {
     const raw = match[1];
     if (raw !== undefined) {
-      annotations.add(raw.split(".").at(-1) ?? raw);
+      const simple = raw.split(".").at(-1) ?? raw;
+      annotations.add(simple);
+      if (raw.includes(".")) {
+        imports.set(simple, raw);
+      }
     }
   }
 

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -310,6 +310,9 @@ async function kotlinRoleSeeds(
     const source = await readFile(join(root, filePath), "utf8");
     kotlinFiles.push({ filePath, info: parseKotlinFile(source) });
   }
+  if (kotlinFiles.length === 0) {
+    return [];
+  }
   const javaFiles: Array<{ filePath: string; info: JavaFileInfo }> = [];
   for (const filePath of sourceFiles.filter((file) => file.endsWith(".java"))) {
     const source = await readFile(join(root, filePath), "utf8");
@@ -821,6 +824,10 @@ function kotlinImportForType(
   projectPackages: Set<string>,
 ): string | undefined {
   if (type.includes(".")) {
+    const rootType = type.split(".")[0];
+    if (rootType !== undefined && projectTypes.has(rootType)) {
+      return undefined;
+    }
     return type.startsWith("kotlin.") ? undefined : type;
   }
   const direct = info.imports.get(type);

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -173,6 +173,7 @@ type KotlinDeclaration = {
 type KotlinFileInfo = {
   packageName: string | null;
   annotations: Set<string>;
+  annotationImports: Map<string, string>;
   imports: Map<string, string>;
   declarations: KotlinDeclaration[];
   functionReturnTypes: Set<string>;
@@ -724,6 +725,10 @@ function isKotlinServerWebAnnotation(annotation: string, info: KotlinFileInfo): 
   if (!kotlinServerWebAnnotationNames.has(annotation)) {
     return false;
   }
+  const qualified = info.annotationImports.get(annotation);
+  if (qualified !== undefined) {
+    return isKotlinServerWebImport(qualified);
+  }
   const imported = info.imports.get(annotation);
   if (imported !== undefined) {
     return isKotlinServerWebImport(imported);
@@ -779,7 +784,15 @@ function kotlinImportedTypeMatches(info: KotlinFileInfo, type: string, allowed: 
     return true;
   }
   const direct = info.imports.get(type);
-  return direct !== undefined && allowed.includes(direct);
+  if (direct !== undefined && allowed.includes(direct)) {
+    return true;
+  }
+  for (const full of info.imports.values()) {
+    if (full.endsWith(".*") && allowed.includes(`${full.slice(0, -1)}${type}`)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function kotlinFunctionReturnRoleEvidence(
@@ -924,11 +937,7 @@ function parseJavaFile(source: string): JavaFileInfo {
   for (const match of stripped.matchAll(/@([A-Za-z_][A-Za-z0-9_.]*)/gu)) {
     const raw = match[1];
     if (raw !== undefined) {
-      const simple = raw.split(".").at(-1) ?? raw;
-      annotations.add(simple);
-      if (raw.includes(".")) {
-        imports.set(simple, raw);
-      }
+      annotations.add(raw.split(".").at(-1) ?? raw);
     }
   }
 
@@ -969,6 +978,7 @@ function parseKotlinFile(source: string): KotlinFileInfo {
   }
 
   const annotations = new Set<string>();
+  const annotationImports = new Map<string, string>();
   for (const match of stripped.matchAll(
     /@(?:[A-Za-z_][A-Za-z0-9_]*:)?([A-Za-z_][A-Za-z0-9_.]*)/gu,
   )) {
@@ -977,7 +987,7 @@ function parseKotlinFile(source: string): KotlinFileInfo {
       const simple = raw.split(".").at(-1) ?? raw;
       annotations.add(simple);
       if (raw.includes(".")) {
-        imports.set(simple, raw);
+        annotationImports.set(simple, raw);
       }
     }
   }
@@ -995,6 +1005,7 @@ function parseKotlinFile(source: string): KotlinFileInfo {
   return {
     packageName,
     annotations,
+    annotationImports,
     imports,
     declarations: parseKotlinDeclarations(stripped),
     functionReturnTypes,

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -77,6 +77,100 @@ type JavaFileInfo = {
   declarations: JavaDeclaration[];
   methodReturnTypes: Set<string>;
 };
+const kotlinRoleDefinitions = {
+  "android-ui-entrypoint": {
+    title: "UI entrypoint",
+    kind: "ui-flow",
+    tags: ["kotlin", "android", "ui"],
+    trustBoundaries: ["user-input", "serialization"],
+  },
+  "android-view-model": {
+    title: "view model",
+    kind: "service",
+    tags: ["kotlin", "android", "view-model"],
+    trustBoundaries: [],
+  },
+  "android-data-boundary": {
+    title: "data boundary",
+    kind: "service",
+    tags: ["kotlin", "android", "data"],
+    trustBoundaries: ["database", "serialization"],
+  },
+  "android-external-client": {
+    title: "external client",
+    kind: "service",
+    tags: ["kotlin", "android", "network"],
+    trustBoundaries: ["network", "external-api", "serialization"],
+  },
+  "android-dependency-injection": {
+    title: "dependency injection",
+    kind: "config",
+    tags: ["kotlin", "android", "di"],
+    trustBoundaries: ["serialization"],
+  },
+  "server-web-entrypoint": {
+    title: "web entrypoint",
+    kind: "route",
+    tags: ["kotlin", "server", "web"],
+    trustBoundaries: ["network", "user-input", "serialization"],
+  },
+  "server-application-service": {
+    title: "application service",
+    kind: "service",
+    tags: ["kotlin", "server", "service"],
+    trustBoundaries: [],
+  },
+  "server-persistence-boundary": {
+    title: "persistence boundary",
+    kind: "service",
+    tags: ["kotlin", "server", "persistence"],
+    trustBoundaries: ["database", "serialization"],
+  },
+  "server-external-client": {
+    title: "external client",
+    kind: "service",
+    tags: ["kotlin", "server", "external-api"],
+    trustBoundaries: ["network", "external-api", "serialization"],
+  },
+  "server-framework-component": {
+    title: "framework component",
+    kind: "library",
+    tags: ["kotlin", "server", "framework"],
+    trustBoundaries: [],
+  },
+  "server-extension-boundary": {
+    title: "extension boundary",
+    kind: "library",
+    tags: ["kotlin", "server", "interface"],
+    trustBoundaries: [],
+  },
+} as const satisfies Record<
+  string,
+  {
+    title: string;
+    kind: FeatureSeed["kind"];
+    tags: string[];
+    trustBoundaries: FeatureSeed["trustBoundaries"];
+  }
+>;
+type KotlinRoleKey = keyof typeof kotlinRoleDefinitions;
+type KotlinRoleEvidence = {
+  role: KotlinRoleKey;
+  reason: string;
+  confidence: FeatureSeed["confidence"];
+};
+type KotlinDeclaration = {
+  kind: "class" | "interface" | "object";
+  name: string;
+  supertypes: string[];
+};
+type KotlinFileInfo = {
+  packageName: string | null;
+  annotations: Set<string>;
+  imports: Map<string, string>;
+  declarations: KotlinDeclaration[];
+  functionReturnTypes: Set<string>;
+};
 
 export async function gradleSeeds(root: string): Promise<FeatureSeed[]> {
   const roots = await discoverGradleRoots(root);
@@ -146,6 +240,9 @@ async function gradleProjectSeeds(root: string, gradleRoot: string): Promise<Fea
     }
 
     seeds.push(...(await jvmRoleSeeds(root, buildFile, sourceRoot, sourceFiles, testFiles, tags)));
+    seeds.push(
+      ...(await kotlinRoleSeeds(root, buildFile, sourceRoot, sourceFiles, testFiles, tags)),
+    );
 
     if (testFiles.length > 0) {
       for (const group of partitionFileGroups(sourceRoot, testFiles, maxOwnedFiles)) {
@@ -171,6 +268,144 @@ async function gradleProjectSeeds(root: string, gradleRoot: string): Promise<Fea
     }
   }
   return seeds;
+}
+
+async function kotlinRoleSeeds(
+  root: string,
+  buildFile: string,
+  sourceRoot: string,
+  sourceFiles: string[],
+  testFiles: string[],
+  tags: string[],
+): Promise<FeatureSeed[]> {
+  const matches = new Map<
+    KotlinRoleKey,
+    Map<string, Array<{ reason: string; confidence: FeatureSeed["confidence"] }>>
+  >();
+  const kotlinFiles: Array<{ filePath: string; info: KotlinFileInfo }> = [];
+  for (const filePath of sourceFiles.filter((file) => file.endsWith(".kt"))) {
+    const source = await readFile(join(root, filePath), "utf8");
+    kotlinFiles.push({ filePath, info: parseKotlinFile(source) });
+  }
+  const projectPackages = new Set(
+    kotlinFiles.flatMap(({ info }) => (info.packageName === null ? [] : [info.packageName])),
+  );
+  const projectTypes = new Set(
+    kotlinFiles.flatMap(({ info }) => info.declarations.map((declaration) => declaration.name)),
+  );
+
+  for (const { filePath, info } of kotlinFiles) {
+    const frameworkEvidence = kotlinFrameworkRoleEvidence(
+      info,
+      tags,
+      projectPackages,
+      projectTypes,
+    );
+    const evidence =
+      frameworkEvidence.length > 0 ? frameworkEvidence : kotlinPathRoleEvidence(filePath, tags);
+    for (const item of evidence) {
+      const byFile = matches.get(item.role) ?? new Map();
+      const reasons = byFile.get(filePath) ?? [];
+      reasons.push({ reason: item.reason, confidence: item.confidence });
+      byFile.set(filePath, reasons);
+      matches.set(item.role, byFile);
+    }
+  }
+
+  const seeds: FeatureSeed[] = [];
+  for (const [role, byFile] of [...matches.entries()].toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    const definition = kotlinRoleDefinitions[role];
+    const platform = role.startsWith("android-") ? "Android" : "server";
+    const groups = kotlinRoleGroups(sourceRoot, byFile);
+    for (const { confidence, group, label, symbol } of groups) {
+      const tests = associatedGradleTests(group.files, testFiles);
+      seeds.push({
+        title: `Kotlin ${platform} role ${definition.title} ${label}`,
+        summary: `Kotlin ${platform.toLowerCase()} ${definition.title} group ${label} with ${group.files.length} files, classified from Kotlin code evidence.`,
+        kind: definition.kind,
+        source: kotlinRoleSource(role),
+        confidence,
+        entryPath: buildFile,
+        symbol,
+        route: null,
+        command: null,
+        ownedFiles: group.files.map((path) => ({
+          path,
+          reason: `kotlin ${definition.title} evidence: ${unique(
+            (byFile.get(path) ?? []).map((item) => item.reason),
+          ).join("; ")}`,
+        })),
+        contextFiles: tests.map((test) => ({
+          path: test.path,
+          reason: "associated gradle test",
+        })),
+        tests,
+        tags: [...tags, ...definition.tags],
+        trustBoundaries: definition.trustBoundaries,
+        skipNearbyTests: true,
+      });
+    }
+  }
+  return seeds;
+}
+
+function kotlinRoleGroups(
+  sourceRoot: string,
+  byFile: Map<string, Array<{ reason: string; confidence: FeatureSeed["confidence"] }>>,
+): Array<{
+  confidence: FeatureSeed["confidence"];
+  group: { label: string; files: string[] };
+  label: string;
+  symbol: string;
+}> {
+  const groups = kotlinFilesByConfidence(byFile).flatMap(([confidence, files]) =>
+    partitionFileGroups(sourceRoot, files, maxOwnedFiles).map((group) => ({
+      confidence,
+      group,
+      label: `${group.label} (${confidence})`,
+      symbol: group.label,
+    })),
+  );
+  const symbolCounts = new Map<string, number>();
+  for (const group of groups) {
+    symbolCounts.set(group.symbol, (symbolCounts.get(group.symbol) ?? 0) + 1);
+  }
+  return groups.map((group) => ({
+    ...group,
+    symbol:
+      (symbolCounts.get(group.symbol) ?? 0) > 1
+        ? `${group.symbol} (${group.confidence})`
+        : group.symbol,
+  }));
+}
+
+function kotlinFilesByConfidence(
+  byFile: Map<string, Array<{ reason: string; confidence: FeatureSeed["confidence"] }>>,
+): Array<[FeatureSeed["confidence"], string[]]> {
+  const buckets = new Map<FeatureSeed["confidence"], string[]>();
+  for (const [path, evidence] of byFile) {
+    const confidence = evidence.some((item) => item.confidence === "high") ? "high" : "medium";
+    const files = buckets.get(confidence) ?? [];
+    files.push(path);
+    buckets.set(confidence, files);
+  }
+  const order = new Map<FeatureSeed["confidence"], number>([
+    ["high", 0],
+    ["medium", 1],
+    ["low", 2],
+  ]);
+  return [...buckets.entries()].toSorted(
+    ([left], [right]) => (order.get(left) ?? 99) - (order.get(right) ?? 99),
+  );
+}
+
+function kotlinRoleSource(role: KotlinRoleKey): string {
+  if (role.startsWith("android-")) {
+    return `kotlin-android-role-${role.slice("android-".length)}`;
+  }
+  return `kotlin-server-role-${role.slice("server-".length)}`;
 }
 
 async function jvmRoleSeeds(
@@ -242,6 +477,377 @@ function jvmRoleEvidence(info: JavaFileInfo, projectPackages: Set<string>): JvmR
   return dedupeEvidence(evidence);
 }
 
+function kotlinFrameworkRoleEvidence(
+  info: KotlinFileInfo,
+  tags: string[],
+  projectPackages: Set<string>,
+  projectTypes: Set<string>,
+): KotlinRoleEvidence[] {
+  const evidence: KotlinRoleEvidence[] = [];
+  const isAndroid = tags.includes("android");
+  for (const annotation of info.annotations) {
+    if (isAndroid && ["Composable"].includes(annotation)) {
+      evidence.push({
+        role: "android-ui-entrypoint",
+        reason: `annotation @${annotation}`,
+        confidence: "high",
+      });
+    }
+    if (isAndroid && ["HiltViewModel"].includes(annotation)) {
+      evidence.push({
+        role: "android-view-model",
+        reason: `annotation @${annotation}`,
+        confidence: "high",
+      });
+    }
+    if (isAndroid && ["Entity", "Dao", "Database", "Embedded", "Relation"].includes(annotation)) {
+      evidence.push({
+        role: "android-data-boundary",
+        reason: `Room annotation @${annotation}`,
+        confidence: "high",
+      });
+    }
+    if (
+      isAndroid &&
+      [
+        "AndroidEntryPoint",
+        "HiltAndroidApp",
+        "Module",
+        "InstallIn",
+        "Provides",
+        "Binds",
+        "Inject",
+        "Singleton",
+        "Component",
+        "DependencyGraph",
+        "BindingContainer",
+        "ContributesBinding",
+      ].includes(annotation)
+    ) {
+      evidence.push({
+        role: "android-dependency-injection",
+        reason: `dependency injection annotation @${annotation}`,
+        confidence: "high",
+      });
+    }
+    if (
+      !isAndroid &&
+      [
+        "Controller",
+        "RestController",
+        "RequestMapping",
+        "GetMapping",
+        "PostMapping",
+        "PutMapping",
+        "DeleteMapping",
+        "PatchMapping",
+        "Path",
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+      ].includes(annotation)
+    ) {
+      evidence.push({
+        role: "server-web-entrypoint",
+        reason: `server web annotation @${annotation}`,
+        confidence: "high",
+      });
+    }
+    if (!isAndroid && ["Service", "ApplicationScoped", "Singleton", "Named"].includes(annotation)) {
+      evidence.push({
+        role: "server-application-service",
+        reason: `service annotation @${annotation}`,
+        confidence: "high",
+      });
+    }
+    if (!isAndroid && ["Repository", "Table", "MappedSuperclass"].includes(annotation)) {
+      evidence.push({
+        role: "server-persistence-boundary",
+        reason: `persistence annotation @${annotation}`,
+        confidence: "high",
+      });
+    }
+  }
+
+  for (const full of info.imports.values()) {
+    if (
+      isAndroid &&
+      (full.startsWith("android.app.") ||
+        full.startsWith("android.content.BroadcastReceiver") ||
+        full.startsWith("androidx.activity.") ||
+        full.startsWith("androidx.appcompat.app.") ||
+        full.startsWith("androidx.compose.") ||
+        full.startsWith("androidx.fragment.app.") ||
+        full.startsWith("androidx.lifecycle.LifecycleService"))
+    ) {
+      evidence.push({
+        role: "android-ui-entrypoint",
+        reason: `Android UI import ${full}`,
+        confidence: "high",
+      });
+    }
+    if (
+      isAndroid &&
+      (full === "androidx.lifecycle.ViewModel" || full === "androidx.lifecycle.AndroidViewModel")
+    ) {
+      evidence.push({
+        role: "android-view-model",
+        reason: `Android ViewModel import ${full}`,
+        confidence: "high",
+      });
+    }
+    if (isAndroid && full.startsWith("androidx.room.")) {
+      evidence.push({
+        role: "android-data-boundary",
+        reason: `Room import ${full}`,
+        confidence: "high",
+      });
+    }
+    if (isKotlinExternalClientImport(full)) {
+      evidence.push({
+        role: isAndroid ? "android-external-client" : "server-external-client",
+        reason: `external client import ${full}`,
+        confidence: "high",
+      });
+    }
+    if (
+      isAndroid &&
+      (full.startsWith("dagger.") ||
+        full.startsWith("javax.inject.") ||
+        full.startsWith("jakarta.inject.") ||
+        full.startsWith("org.koin.") ||
+        full.startsWith("me.tatarka.inject.") ||
+        full.startsWith("dev.zacsweers.metro."))
+    ) {
+      const reason = full.startsWith("dev.zacsweers.metro.")
+        ? `Metro import ${full}`
+        : `dependency injection import ${full}`;
+      evidence.push({
+        role: "android-dependency-injection",
+        reason,
+        confidence: "high",
+      });
+    }
+    if (
+      !isAndroid &&
+      (full.startsWith("org.springframework.web.bind.annotation.") ||
+        full.startsWith("io.ktor.server.") ||
+        full.startsWith("org.http4k.") ||
+        full.startsWith("io.javalin.") ||
+        /^(?:jakarta|javax)\.ws\.rs\./u.test(full))
+    ) {
+      evidence.push({
+        role: "server-web-entrypoint",
+        reason: `server web import ${full}`,
+        confidence: "high",
+      });
+    }
+    if (
+      !isAndroid &&
+      (/^(?:jakarta|javax)\.persistence\./u.test(full) ||
+        full.startsWith("org.hibernate.") ||
+        full.startsWith("org.jetbrains.exposed.") ||
+        full.startsWith("org.jooq.") ||
+        isSpringDataPersistenceImport(full) ||
+        full.startsWith("java.sql."))
+    ) {
+      evidence.push({
+        role: "server-persistence-boundary",
+        reason: `persistence import ${full}`,
+        confidence: "high",
+      });
+    }
+  }
+
+  for (const declaration of info.declarations) {
+    for (const type of declaration.supertypes) {
+      if (
+        isAndroid &&
+        [
+          "Activity",
+          "AppCompatActivity",
+          "ComponentActivity",
+          "Fragment",
+          "Service",
+          "BroadcastReceiver",
+        ].includes(type)
+      ) {
+        evidence.push({
+          role: "android-ui-entrypoint",
+          reason: `inherits Android UI type ${type}`,
+          confidence: "high",
+        });
+      }
+      if (isAndroid && ["ViewModel", "AndroidViewModel"].includes(type)) {
+        evidence.push({
+          role: "android-view-model",
+          reason: `inherits Android ViewModel type ${type}`,
+          confidence: "high",
+        });
+      }
+      if (isAndroid && ["RoomDatabase"].includes(type)) {
+        evidence.push({
+          role: "android-data-boundary",
+          reason: `inherits Room type ${type}`,
+          confidence: "high",
+        });
+      }
+    }
+  }
+  if (!isAndroid) {
+    evidence.push(...kotlinDeclarationRoleEvidence(info, projectPackages, projectTypes));
+    evidence.push(...kotlinFunctionReturnRoleEvidence(info, projectPackages, projectTypes));
+  }
+
+  return dedupeKotlinEvidence(evidence);
+}
+
+function kotlinDeclarationRoleEvidence(
+  info: KotlinFileInfo,
+  projectPackages: Set<string>,
+  projectTypes: Set<string>,
+): KotlinRoleEvidence[] {
+  const evidence: KotlinRoleEvidence[] = [];
+  for (const declaration of info.declarations) {
+    if (declaration.kind === "interface") {
+      evidence.push({
+        role: "server-extension-boundary",
+        reason: `interface declaration ${declaration.name}`,
+        confidence: "medium",
+      });
+    }
+    for (const type of declaration.supertypes) {
+      const full = kotlinImportForType(info, type, projectTypes);
+      if (full !== undefined && isExternalProjectImport(full, projectPackages)) {
+        evidence.push({
+          role: "server-framework-component",
+          reason: `inherits external type ${full}`,
+          confidence: "high",
+        });
+      }
+    }
+  }
+  return evidence;
+}
+
+function kotlinFunctionReturnRoleEvidence(
+  info: KotlinFileInfo,
+  projectPackages: Set<string>,
+  projectTypes: Set<string>,
+): KotlinRoleEvidence[] {
+  const evidence: KotlinRoleEvidence[] = [];
+  for (const type of info.functionReturnTypes) {
+    const full = kotlinImportForType(info, type, projectTypes);
+    if (full !== undefined && isExternalProjectImport(full, projectPackages)) {
+      evidence.push({
+        role: "server-framework-component",
+        reason: `returns external type ${full}`,
+        confidence: "high",
+      });
+    }
+  }
+  return evidence;
+}
+
+function kotlinImportForType(
+  info: KotlinFileInfo,
+  type: string,
+  projectTypes: Set<string>,
+): string | undefined {
+  const direct = info.imports.get(type);
+  if (direct !== undefined) {
+    return direct;
+  }
+  if (projectTypes.has(type) || isKotlinImplicitType(type)) {
+    return undefined;
+  }
+  for (const full of info.imports.values()) {
+    if (full.endsWith(".*")) {
+      return `${full.slice(0, -1)}${type}`;
+    }
+  }
+  return undefined;
+}
+
+function isKotlinImplicitType(type: string): boolean {
+  return [
+    "Any",
+    "Array",
+    "Boolean",
+    "Byte",
+    "Char",
+    "CharSequence",
+    "Collection",
+    "Double",
+    "Exception",
+    "Float",
+    "Int",
+    "Iterable",
+    "List",
+    "Long",
+    "Map",
+    "MutableCollection",
+    "MutableList",
+    "MutableMap",
+    "MutableSet",
+    "Nothing",
+    "Number",
+    "Pair",
+    "Result",
+    "Sequence",
+    "Set",
+    "Short",
+    "String",
+    "Throwable",
+    "Triple",
+    "Unit",
+  ].includes(type);
+}
+
+function kotlinPathRoleEvidence(filePath: string, tags: string[]): KotlinRoleEvidence[] {
+  const normalized = normalize(filePath).toLowerCase();
+  const isAndroid = tags.includes("android");
+  const evidence: KotlinRoleEvidence[] = [];
+  if (isAndroid && /(^|\/)ui(\/|$)/u.test(normalized)) {
+    evidence.push({
+      role: "android-ui-entrypoint",
+      reason: "path segment ui",
+      confidence: "medium",
+    });
+  }
+  if (/(^|\/)(?:repository|data|database)(\/|$)/u.test(normalized)) {
+    evidence.push({
+      role: isAndroid ? "android-data-boundary" : "server-persistence-boundary",
+      reason: "path segment data boundary",
+      confidence: "medium",
+    });
+  }
+  if (/(^|\/)network(\/|$)/u.test(normalized)) {
+    evidence.push({
+      role: isAndroid ? "android-external-client" : "server-external-client",
+      reason: "path segment network",
+      confidence: "medium",
+    });
+  }
+  if (isAndroid && /(^|\/)di(\/|$)/u.test(normalized)) {
+    evidence.push({
+      role: "android-dependency-injection",
+      reason: "path segment di",
+      confidence: "medium",
+    });
+  }
+  if (!isAndroid && /(^|\/)domain(\/|$)/u.test(normalized)) {
+    evidence.push({
+      role: "server-application-service",
+      reason: "path segment domain",
+      confidence: "medium",
+    });
+  }
+  return evidence;
+}
+
 function parseJavaFile(source: string): JavaFileInfo {
   const stripped = stripJavaComments(source);
   const packageName = /^\s*package\s+([A-Za-z0-9_.]+)\s*;/mu.exec(stripped)?.[1] ?? null;
@@ -281,6 +887,52 @@ function parseJavaFile(source: string): JavaFileInfo {
   };
 }
 
+function parseKotlinFile(source: string): KotlinFileInfo {
+  const stripped = stripKotlinComments(source);
+  const packageName = /^\s*package\s+([A-Za-z0-9_.]+)\s*;?/mu.exec(stripped)?.[1] ?? null;
+  const imports = new Map<string, string>();
+  for (const match of stripped.matchAll(
+    /^\s*import\s+([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)(\.\*)?(?:\s+as\s+([A-Za-z_][A-Za-z0-9_]*))?\s*;?/gmu,
+  )) {
+    const target = match[1];
+    const wildcard = match[2];
+    const alias = match[3];
+    const full = target === undefined ? undefined : `${target}${wildcard ?? ""}`;
+    const simple = alias ?? (wildcard === undefined ? target?.split(".").at(-1) : target);
+    if (full !== undefined && simple !== undefined) {
+      imports.set(simple, full);
+    }
+  }
+
+  const annotations = new Set<string>();
+  for (const match of stripped.matchAll(
+    /@(?:[A-Za-z_][A-Za-z0-9_]*:)?([A-Za-z_][A-Za-z0-9_.]*)/gu,
+  )) {
+    const raw = match[1];
+    if (raw !== undefined) {
+      annotations.add(raw.split(".").at(-1) ?? raw);
+    }
+  }
+
+  const functionReturnTypes = new Set<string>();
+  for (const match of stripped.matchAll(
+    /\bfun\s*(?:<[^>{}\n]*>\s*)?(?:[A-Za-z_][A-Za-z0-9_.]*\s*\.\s*)?[A-Za-z_][A-Za-z0-9_]*\s*\([^(){}]*\)\s*:\s*([^=\n{]+)/gu,
+  )) {
+    const type = match[1];
+    if (type !== undefined) {
+      functionReturnTypes.add(baseKotlinTypeName(stripGenericParameters(type)));
+    }
+  }
+
+  return {
+    packageName,
+    annotations,
+    imports,
+    declarations: parseKotlinDeclarations(stripped),
+    functionReturnTypes,
+  };
+}
+
 function parseJavaDeclarations(source: string): JavaDeclaration[] {
   const declarations: JavaDeclaration[] = [];
   const declarationPattern =
@@ -296,6 +948,25 @@ function parseJavaDeclarations(source: string): JavaDeclaration[] {
       name,
       extendsTypes: match[3] === undefined ? [] : javaTypeNames(match[3]),
       implementsTypes: match[4] === undefined ? [] : javaTypeNames(match[4]),
+    });
+  }
+  return declarations;
+}
+
+function parseKotlinDeclarations(source: string): KotlinDeclaration[] {
+  const declarations: KotlinDeclaration[] = [];
+  const declarationPattern =
+    /\b(?:(?:data|sealed|open|abstract|final|inner|value|annotation)\s+)*(?:(enum)\s+)?(?:(fun)\s+)?(class|interface|object)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*<[^{};]*>)?(?:\s*\([^{}]*?\))?(?:\s*:\s*([^={}\n]+))?/gsu;
+  for (const match of source.matchAll(declarationPattern)) {
+    const rawKind = match[3];
+    const name = match[4];
+    if (rawKind === undefined || name === undefined) {
+      continue;
+    }
+    declarations.push({
+      kind: rawKind as KotlinDeclaration["kind"],
+      name,
+      supertypes: match[5] === undefined ? [] : kotlinTypeNames(match[5]),
     });
   }
   return declarations;
@@ -423,9 +1094,66 @@ function isNetworkClientImport(full: string): boolean {
   );
 }
 
+function isKotlinExternalClientImport(full: string): boolean {
+  return (
+    isNetworkClientImport(full) ||
+    full.startsWith("retrofit2.") ||
+    full.startsWith("okhttp3.") ||
+    full.startsWith("io.ktor.client.") ||
+    full.startsWith("io.grpc.") ||
+    full.startsWith("software.amazon.awssdk.") ||
+    full.startsWith("com.google.cloud.") ||
+    full.startsWith("com.azure.")
+  );
+}
+
+function isSpringDataPersistenceImport(full: string): boolean {
+  return (
+    full.startsWith("org.springframework.data.repository.") ||
+    full.startsWith("org.springframework.data.jdbc.") ||
+    full.startsWith("org.springframework.data.jpa.") ||
+    full.startsWith("org.springframework.data.r2dbc.") ||
+    full.startsWith("org.springframework.data.mongodb.") ||
+    full.startsWith("org.springframework.data.redis.") ||
+    full.startsWith("org.springframework.data.cassandra.") ||
+    full.startsWith("org.springframework.data.elasticsearch.") ||
+    full.startsWith("org.springframework.data.neo4j.") ||
+    full.startsWith("org.springframework.data.couchbase.")
+  );
+}
+
 function javaTypeNames(raw: string): string[] {
   return splitJavaTypeList(raw)
     .map((type) => baseJavaTypeName(stripGenericParameters(type)))
+    .filter((type) => type.length > 0);
+}
+
+function kotlinTypeNames(raw: string): string[] {
+  const parts: string[] = [];
+  let angleDepth = 0;
+  let parenDepth = 0;
+  let current = "";
+  for (const char of raw) {
+    if (char === "<") {
+      angleDepth += 1;
+    } else if (char === ">") {
+      angleDepth = Math.max(0, angleDepth - 1);
+    } else if (char === "(") {
+      parenDepth += 1;
+    } else if (char === ")") {
+      parenDepth = Math.max(0, parenDepth - 1);
+    }
+    if (char === "," && angleDepth === 0 && parenDepth === 0) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  parts.push(current);
+  return parts
+    .flatMap((type) => splitJavaTypeList(type))
+    .map((type) => baseKotlinTypeName(stripGenericParameters(type)))
     .filter((type) => type.length > 0);
 }
 
@@ -436,6 +1164,18 @@ function baseJavaTypeName(raw: string): string {
       .split(".")
       .at(-1)
       ?.replace(/[^A-Za-z0-9_$]/gu, "")
+      .trim() ?? ""
+  );
+}
+
+function baseKotlinTypeName(raw: string): string {
+  return (
+    raw
+      .replace(/\([^()]*\)/gu, "")
+      .replace(/\?.*$/su, "")
+      .split(".")
+      .at(-1)
+      ?.replace(/[^A-Za-z0-9_]/gu, "")
       .trim() ?? ""
   );
 }
@@ -486,10 +1226,26 @@ function stripJavaComments(source: string): string {
     .replace(/\/\/.*$/gmu, "");
 }
 
+function stripKotlinComments(source: string): string {
+  return stripJavaComments(source);
+}
+
 function dedupeEvidence(evidence: JvmRoleEvidence[]): JvmRoleEvidence[] {
   const seen = new Set<string>();
   return evidence.filter((item) => {
     const key = `${item.role}:${item.reason}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function dedupeKotlinEvidence(evidence: KotlinRoleEvidence[]): KotlinRoleEvidence[] {
+  const seen = new Set<string>();
+  return evidence.filter((item) => {
+    const key = `${item.role}:${item.reason}:${item.confidence}`;
     if (seen.has(key)) {
       return false;
     }
@@ -627,10 +1383,7 @@ function gradleTags(buildFile: string, sourceFiles: string[]): string[] {
   ) {
     tags.push("kotlin");
   }
-  if (
-    sourceFiles.some((file) => file.endsWith("AndroidManifest.xml")) ||
-    buildFile.includes("android")
-  ) {
+  if (sourceFiles.some((file) => file.endsWith("AndroidManifest.xml"))) {
     tags.push("android");
   }
   return tags;

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -784,7 +784,7 @@ function kotlinImportForType(
   for (const full of info.imports.values()) {
     if (full.endsWith(".*")) {
       if (full.startsWith("kotlin.")) {
-        return undefined;
+        continue;
       }
       const candidate = `${full.slice(0, -1)}${type}`;
       if (isExternalProjectImport(candidate, projectPackages)) {
@@ -1437,9 +1437,10 @@ async function gradleTags(
 function appliesAndroidGradlePlugin(source: string): boolean {
   for (const line of source.split("\n")) {
     if (
-      /\bid\s*(?:\(\s*)?["']com\.android\.(?:application|library|test|dynamic-feature)["']/u.test(
+      (/\bid\s*(?:\(\s*)?["']com\.android\.(?:application|library|test|dynamic-feature)["']/u.test(
         line,
-      ) &&
+      ) ||
+        /\balias\s*\(\s*libs\.plugins\.[A-Za-z0-9_.]*android[A-Za-z0-9_.]*\s*\)/iu.test(line)) &&
       !/(?:\bapply\s+false\b|\.apply\s*\(\s*false\s*\))/u.test(line)
     ) {
       return true;

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -327,6 +327,13 @@ async function kotlinRoleSeeds(
     ...kotlinFiles.flatMap(({ info }) => info.declarations.map((declaration) => declaration.name)),
     ...javaFiles.flatMap(({ info }) => info.declarations.map((declaration) => declaration.name)),
   ]);
+  const projectPackageTypes = new Set(
+    [...kotlinFiles, ...javaFiles].flatMap(({ info }) =>
+      info.packageName === null
+        ? []
+        : info.declarations.map((declaration) => `${info.packageName}.${declaration.name}`),
+    ),
+  );
 
   for (const { filePath, info } of kotlinFiles) {
     const frameworkEvidence = kotlinFrameworkRoleEvidence(
@@ -334,6 +341,7 @@ async function kotlinRoleSeeds(
       tags,
       projectPackages,
       projectTypes,
+      projectPackageTypes,
     );
     const evidence = kotlinEvidenceWithPathFallback(
       frameworkEvidence,
@@ -509,6 +517,7 @@ function kotlinFrameworkRoleEvidence(
   tags: string[],
   projectPackages: Set<string>,
   projectTypes: Set<string>,
+  projectPackageTypes: Set<string>,
 ): KotlinRoleEvidence[] {
   const evidence: KotlinRoleEvidence[] = [];
   const isAndroid = tags.includes("android");
@@ -717,8 +726,12 @@ function kotlinFrameworkRoleEvidence(
     }
   }
   if (!isAndroid) {
-    evidence.push(...kotlinDeclarationRoleEvidence(info, projectPackages, projectTypes));
-    evidence.push(...kotlinFunctionReturnRoleEvidence(info, projectPackages, projectTypes));
+    evidence.push(
+      ...kotlinDeclarationRoleEvidence(info, projectPackages, projectTypes, projectPackageTypes),
+    );
+    evidence.push(
+      ...kotlinFunctionReturnRoleEvidence(info, projectPackages, projectTypes, projectPackageTypes),
+    );
   }
 
   return dedupeKotlinEvidence(evidence);
@@ -758,6 +771,7 @@ function kotlinDeclarationRoleEvidence(
   info: KotlinFileInfo,
   projectPackages: Set<string>,
   projectTypes: Set<string>,
+  projectPackageTypes: Set<string>,
 ): KotlinRoleEvidence[] {
   const evidence: KotlinRoleEvidence[] = [];
   for (const declaration of info.declarations) {
@@ -769,7 +783,13 @@ function kotlinDeclarationRoleEvidence(
       });
     }
     for (const type of declaration.supertypes) {
-      const full = kotlinImportForType(info, type, projectTypes, projectPackages);
+      const full = kotlinImportForType(
+        info,
+        type,
+        projectTypes,
+        projectPackages,
+        projectPackageTypes,
+      );
       if (full !== undefined && isExternalProjectImport(full, projectPackages)) {
         evidence.push({
           role: "server-framework-component",
@@ -802,10 +822,17 @@ function kotlinFunctionReturnRoleEvidence(
   info: KotlinFileInfo,
   projectPackages: Set<string>,
   projectTypes: Set<string>,
+  projectPackageTypes: Set<string>,
 ): KotlinRoleEvidence[] {
   const evidence: KotlinRoleEvidence[] = [];
   for (const type of info.functionReturnTypes) {
-    const full = kotlinImportForType(info, type, projectTypes, projectPackages);
+    const full = kotlinImportForType(
+      info,
+      type,
+      projectTypes,
+      projectPackages,
+      projectPackageTypes,
+    );
     if (full !== undefined && isExternalProjectImport(full, projectPackages)) {
       evidence.push({
         role: "server-framework-component",
@@ -822,6 +849,7 @@ function kotlinImportForType(
   type: string,
   projectTypes: Set<string>,
   projectPackages: Set<string>,
+  projectPackageTypes: Set<string>,
 ): string | undefined {
   if (type.includes(".")) {
     const rootType = type.split(".")[0];
@@ -831,6 +859,9 @@ function kotlinImportForType(
     return type.startsWith("kotlin.") ? undefined : type;
   }
   if (info.declarations.some((declaration) => declaration.name === type)) {
+    return undefined;
+  }
+  if (info.packageName !== null && projectPackageTypes.has(`${info.packageName}.${type}`)) {
     return undefined;
   }
   const direct = info.imports.get(type);

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -293,12 +293,20 @@ async function kotlinRoleSeeds(
     const source = await readFile(join(root, filePath), "utf8");
     kotlinFiles.push({ filePath, info: parseKotlinFile(source) });
   }
+  const javaFiles: Array<{ filePath: string; info: JavaFileInfo }> = [];
+  for (const filePath of sourceFiles.filter((file) => file.endsWith(".java"))) {
+    const source = await readFile(join(root, filePath), "utf8");
+    javaFiles.push({ filePath, info: parseJavaFile(source) });
+  }
   const projectPackages = new Set(
-    kotlinFiles.flatMap(({ info }) => (info.packageName === null ? [] : [info.packageName])),
+    [...kotlinFiles, ...javaFiles].flatMap(({ info }) =>
+      info.packageName === null ? [] : [info.packageName],
+    ),
   );
-  const projectTypes = new Set(
-    kotlinFiles.flatMap(({ info }) => info.declarations.map((declaration) => declaration.name)),
-  );
+  const projectTypes = new Set([
+    ...kotlinFiles.flatMap(({ info }) => info.declarations.map((declaration) => declaration.name)),
+    ...javaFiles.flatMap(({ info }) => info.declarations.map((declaration) => declaration.name)),
+  ]);
 
   for (const { filePath, info } of kotlinFiles) {
     const frameworkEvidence = kotlinFrameworkRoleEvidence(
@@ -1164,7 +1172,6 @@ function kotlinTypeNames(raw: string): string[] {
   }
   parts.push(current);
   return parts
-    .flatMap((type) => splitJavaTypeList(type))
     .map((type) => baseKotlinTypeName(stripGenericParameters(type)))
     .filter((type) => type.length > 0);
 }

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -307,8 +307,10 @@ async function kotlinRoleSeeds(
       projectPackages,
       projectTypes,
     );
-    const evidence =
-      frameworkEvidence.length > 0 ? frameworkEvidence : kotlinPathRoleEvidence(filePath, tags);
+    const evidence = kotlinEvidenceWithPathFallback(
+      frameworkEvidence,
+      kotlinPathRoleEvidence(filePath, tags),
+    );
     for (const item of evidence) {
       const byFile = matches.get(item.role) ?? new Map();
       const reasons = byFile.get(filePath) ?? [];
@@ -383,6 +385,16 @@ function kotlinRoleSource(role: KotlinRoleKey): string {
     return `kotlin-android-role-${role.slice("android-".length)}`;
   }
   return `kotlin-server-role-${role.slice("server-".length)}`;
+}
+
+function kotlinEvidenceWithPathFallback(
+  frameworkEvidence: KotlinRoleEvidence[],
+  pathEvidence: KotlinRoleEvidence[],
+): KotlinRoleEvidence[] {
+  if (frameworkEvidence.every((item) => item.role === "server-extension-boundary")) {
+    return dedupeKotlinEvidence([...frameworkEvidence, ...pathEvidence]);
+  }
+  return frameworkEvidence;
 }
 
 async function jvmRoleSeeds(
@@ -1094,16 +1106,14 @@ function isKotlinExternalClientImport(full: string): boolean {
 }
 
 function isAndroidEntrypointImport(full: string): boolean {
-  return (
-    [
-      "android.app.Activity",
-      "android.content.BroadcastReceiver",
-      "androidx.activity.ComponentActivity",
-      "androidx.appcompat.app.AppCompatActivity",
-      "androidx.fragment.app.Fragment",
-      "androidx.lifecycle.LifecycleService",
-    ].includes(full) || full.startsWith("androidx.compose.")
-  );
+  return [
+    "android.app.Activity",
+    "android.content.BroadcastReceiver",
+    "androidx.activity.ComponentActivity",
+    "androidx.appcompat.app.AppCompatActivity",
+    "androidx.fragment.app.Fragment",
+    "androidx.lifecycle.LifecycleService",
+  ].includes(full);
 }
 
 function isSpringDataPersistenceImport(full: string): boolean {
@@ -1388,13 +1398,27 @@ async function gradleTags(
   }
   const buildSource = await readFile(join(root, buildFile), "utf8").catch(() => "");
   if (
-    /\bcom\.android\.(?:application|library|test|dynamic-feature)\b/u.test(buildSource) ||
+    appliesAndroidGradlePlugin(buildSource) ||
     /\bandroid\s*\{/u.test(buildSource) ||
     sourceFiles.some((file) => file.endsWith("AndroidManifest.xml"))
   ) {
     tags.push("android");
   }
   return tags;
+}
+
+function appliesAndroidGradlePlugin(source: string): boolean {
+  for (const line of source.split("\n")) {
+    if (
+      /\bid\s*(?:\(\s*)?["']com\.android\.(?:application|library|test|dynamic-feature)["']/u.test(
+        line,
+      ) &&
+      !/\bapply\s+false\b/u.test(line)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function isGradleSourceFile(path: string): boolean {

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -402,6 +402,14 @@ function kotlinEvidenceWithPathFallback(
   if (frameworkEvidence.every((item) => item.role === "server-extension-boundary")) {
     return dedupeKotlinEvidence([...frameworkEvidence, ...pathEvidence]);
   }
+  if (frameworkEvidence.every((item) => item.role === "android-dependency-injection")) {
+    return dedupeKotlinEvidence([
+      ...frameworkEvidence,
+      ...pathEvidence.filter((item) =>
+        ["android-data-boundary", "android-external-client"].includes(item.role),
+      ),
+    ]);
+  }
   return frameworkEvidence;
 }
 
@@ -728,7 +736,7 @@ function kotlinDeclarationRoleEvidence(
       });
     }
     for (const type of declaration.supertypes) {
-      const full = kotlinImportForType(info, type, projectTypes);
+      const full = kotlinImportForType(info, type, projectTypes, projectPackages);
       if (full !== undefined && isExternalProjectImport(full, projectPackages)) {
         evidence.push({
           role: "server-framework-component",
@@ -748,7 +756,7 @@ function kotlinFunctionReturnRoleEvidence(
 ): KotlinRoleEvidence[] {
   const evidence: KotlinRoleEvidence[] = [];
   for (const type of info.functionReturnTypes) {
-    const full = kotlinImportForType(info, type, projectTypes);
+    const full = kotlinImportForType(info, type, projectTypes, projectPackages);
     if (full !== undefined && isExternalProjectImport(full, projectPackages)) {
       evidence.push({
         role: "server-framework-component",
@@ -764,6 +772,7 @@ function kotlinImportForType(
   info: KotlinFileInfo,
   type: string,
   projectTypes: Set<string>,
+  projectPackages: Set<string>,
 ): string | undefined {
   const direct = info.imports.get(type);
   if (direct !== undefined) {
@@ -777,7 +786,10 @@ function kotlinImportForType(
       if (full.startsWith("kotlin.")) {
         return undefined;
       }
-      return `${full.slice(0, -1)}${type}`;
+      const candidate = `${full.slice(0, -1)}${type}`;
+      if (isExternalProjectImport(candidate, projectPackages)) {
+        return candidate;
+      }
     }
   }
   return undefined;
@@ -1428,7 +1440,7 @@ function appliesAndroidGradlePlugin(source: string): boolean {
       /\bid\s*(?:\(\s*)?["']com\.android\.(?:application|library|test|dynamic-feature)["']/u.test(
         line,
       ) &&
-      !/\bapply\s+false\b/u.test(line)
+      !/(?:\bapply\s+false\b|\.apply\s*\(\s*false\s*\))/u.test(line)
     ) {
       return true;
     }

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -1112,6 +1112,9 @@ function isExternalProjectImport(full: string, projectPackages: Set<string>): bo
   if (/^(?:java|kotlin)\./u.test(full)) {
     return false;
   }
+  if (/^javax\./u.test(full) && !/^javax\.(?:servlet|ws\.rs)\./u.test(full)) {
+    return false;
+  }
   for (const packageName of projectPackages) {
     if (full.startsWith(`${packageName}.`)) {
       return false;

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -132,6 +132,12 @@ const kotlinRoleDefinitions = {
     tags: ["kotlin", "server", "external-api"],
     trustBoundaries: ["network", "external-api", "serialization"],
   },
+  "server-configuration": {
+    title: "configuration",
+    kind: "config",
+    tags: ["kotlin", "server", "config"],
+    trustBoundaries: ["filesystem"],
+  },
   "server-framework-component": {
     title: "framework component",
     kind: "library",
@@ -540,22 +546,20 @@ function kotlinFrameworkRoleEvidence(
         confidence: "high",
       });
     }
+    if (!isAndroid && ["Configuration", "Bean", "ConfigurationProperties"].includes(annotation)) {
+      evidence.push({
+        role: "server-configuration",
+        reason: `configuration annotation @${annotation}`,
+        confidence: "high",
+      });
+    }
   }
 
   for (const full of info.imports.values()) {
-    if (
-      isAndroid &&
-      (full.startsWith("android.app.") ||
-        full.startsWith("android.content.BroadcastReceiver") ||
-        full.startsWith("androidx.activity.") ||
-        full.startsWith("androidx.appcompat.app.") ||
-        full.startsWith("androidx.compose.") ||
-        full.startsWith("androidx.fragment.app.") ||
-        full.startsWith("androidx.lifecycle.LifecycleService"))
-    ) {
+    if (isAndroid && isAndroidEntrypointImport(full)) {
       evidence.push({
         role: "android-ui-entrypoint",
-        reason: `Android UI import ${full}`,
+        reason: `Android entrypoint import ${full}`,
         confidence: "high",
       });
     }
@@ -627,6 +631,17 @@ function kotlinFrameworkRoleEvidence(
       evidence.push({
         role: "server-persistence-boundary",
         reason: `persistence import ${full}`,
+        confidence: "high",
+      });
+    }
+    if (
+      !isAndroid &&
+      (full.startsWith("org.springframework.context.annotation.") ||
+        full.startsWith("org.springframework.boot.context.properties."))
+    ) {
+      evidence.push({
+        role: "server-configuration",
+        reason: `configuration import ${full}`,
         confidence: "high",
       });
     }
@@ -1075,6 +1090,19 @@ function isKotlinExternalClientImport(full: string): boolean {
     full.startsWith("software.amazon.awssdk.") ||
     full.startsWith("com.google.cloud.") ||
     full.startsWith("com.azure.")
+  );
+}
+
+function isAndroidEntrypointImport(full: string): boolean {
+  return (
+    [
+      "android.app.Activity",
+      "android.content.BroadcastReceiver",
+      "androidx.activity.ComponentActivity",
+      "androidx.appcompat.app.AppCompatActivity",
+      "androidx.fragment.app.Fragment",
+      "androidx.lifecycle.LifecycleService",
+    ].includes(full) || full.startsWith("androidx.compose.")
   );
 }
 

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -406,7 +406,9 @@ function kotlinEvidenceWithPathFallback(
     return dedupeKotlinEvidence([
       ...frameworkEvidence,
       ...pathEvidence.filter((item) =>
-        ["android-data-boundary", "android-external-client"].includes(item.role),
+        ["android-ui-entrypoint", "android-data-boundary", "android-external-client"].includes(
+          item.role,
+        ),
       ),
     ]);
   }
@@ -682,14 +684,14 @@ function kotlinFrameworkRoleEvidence(
     for (const type of declaration.supertypes) {
       if (
         isAndroid &&
-        [
-          "Activity",
-          "AppCompatActivity",
-          "ComponentActivity",
-          "Fragment",
-          "Service",
-          "BroadcastReceiver",
-        ].includes(type)
+        kotlinImportedTypeMatches(info, type, [
+          "android.app.Activity",
+          "android.app.Service",
+          "android.content.BroadcastReceiver",
+          "androidx.activity.ComponentActivity",
+          "androidx.appcompat.app.AppCompatActivity",
+          "androidx.fragment.app.Fragment",
+        ])
       ) {
         evidence.push({
           role: "android-ui-entrypoint",
@@ -697,14 +699,20 @@ function kotlinFrameworkRoleEvidence(
           confidence: "high",
         });
       }
-      if (isAndroid && ["ViewModel", "AndroidViewModel"].includes(type)) {
+      if (
+        isAndroid &&
+        kotlinImportedTypeMatches(info, type, [
+          "androidx.lifecycle.ViewModel",
+          "androidx.lifecycle.AndroidViewModel",
+        ])
+      ) {
         evidence.push({
           role: "android-view-model",
           reason: `inherits Android ViewModel type ${type}`,
           confidence: "high",
         });
       }
-      if (isAndroid && ["RoomDatabase"].includes(type)) {
+      if (isAndroid && kotlinImportedTypeMatches(info, type, ["androidx.room.RoomDatabase"])) {
         evidence.push({
           role: "android-data-boundary",
           reason: `inherits Room type ${type}`,
@@ -747,6 +755,11 @@ function kotlinDeclarationRoleEvidence(
     }
   }
   return evidence;
+}
+
+function kotlinImportedTypeMatches(info: KotlinFileInfo, type: string, allowed: string[]): boolean {
+  const direct = info.imports.get(type);
+  return direct !== undefined && allowed.includes(direct);
 }
 
 function kotlinFunctionReturnRoleEvidence(
@@ -979,8 +992,11 @@ function parseJavaDeclarations(source: string): JavaDeclaration[] {
 
 function parseKotlinDeclarations(source: string): KotlinDeclaration[] {
   const declarations: KotlinDeclaration[] = [];
-  const declarationPattern =
-    /\b(?:(?:data|sealed|open|abstract|final|inner|value|annotation)\s+)*(?:(enum)\s+)?(?:(fun)\s+)?(class|interface|object)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*<[^{};]*>)?(?:\s+(?:(?:@[A-Za-z_][A-Za-z0-9_.]*(?:\([^{}]*?\))?|public|private|protected|internal)\s+)*constructor\s*\([^{}]*?\)|\s*\([^{}]*?\))?(?:\s*:\s*([^{\n]+))?/gsu;
+  const primaryConstructor = String.raw`\((?:[^(){}]|\([^(){}]*\))*\)`;
+  const declarationPattern = new RegExp(
+    String.raw`\b(?:(?:data|sealed|open|abstract|final|inner|value|annotation)\s+)*(?:(enum)\s+)?(?:(fun)\s+)?(class|interface|object)\s+([A-Za-z_][A-Za-z0-9_]*)(?:\s*<[^{};]*>)?(?:\s+(?:(?:@[A-Za-z_][A-Za-z0-9_.]*(?:\([^{}]*?\))?|public|private|protected|internal)\s+)*constructor\s*${primaryConstructor}|\s*${primaryConstructor})?(?:\s*:\s*([^{\n]+))?`,
+    "gsu",
+  );
   for (const match of source.matchAll(declarationPattern)) {
     const rawKind = match[3];
     const name = match[4];

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -830,11 +830,14 @@ function kotlinImportForType(
     }
     return type.startsWith("kotlin.") ? undefined : type;
   }
+  if (info.declarations.some((declaration) => declaration.name === type)) {
+    return undefined;
+  }
   const direct = info.imports.get(type);
   if (direct !== undefined) {
     return direct.startsWith("kotlin.") ? undefined : direct;
   }
-  if (projectTypes.has(type) || isKotlinImplicitType(type)) {
+  if (isKotlinImplicitType(type)) {
     return undefined;
   }
   for (const full of info.imports.values()) {
@@ -847,6 +850,9 @@ function kotlinImportForType(
         return candidate;
       }
     }
+  }
+  if (projectTypes.has(type)) {
+    return undefined;
   }
   return undefined;
 }
@@ -1505,10 +1511,15 @@ async function gradleTags(
 }
 
 function appliesAndroidGradlePlugin(source: string): boolean {
+  const androidPluginId = String.raw`com\.android\.(?:application|library|test|dynamic-feature)`;
   const androidPluginPattern =
-    String.raw`\bid\s*(?:\(\s*)?["']com\.android\.(?:application|library|test|dynamic-feature)["']\s*\)?` +
+    String.raw`\bid\s*(?:\(\s*)?["']${androidPluginId}["']\s*\)?` +
     "|" +
-    String.raw`\balias\s*\(\s*libs\.plugins\.[A-Za-z0-9_.]*android[A-Za-z0-9_.]*\s*\)`;
+    String.raw`\balias\s*\(\s*libs\.plugins\.[A-Za-z0-9_.]*android[A-Za-z0-9_.]*\s*\)` +
+    "|" +
+    String.raw`\bapply\s+plugin\s*:\s*["']${androidPluginId}["']` +
+    "|" +
+    String.raw`\bapply\s*\(\s*plugin\s*=\s*["']${androidPluginId}["']\s*\)`;
   const disabledAndroidPlugin = new RegExp(
     String.raw`(?:${androidPluginPattern})(?:\s*\.version\s*\([^)]*\)|\s+version\s+["'][^"']+["'])?\s*(?:\.apply\s*\(\s*false\s*\)|\bapply\s+false\b)`,
     "giu",

--- a/src/mappers/gradle.ts
+++ b/src/mappers/gradle.ts
@@ -756,13 +756,16 @@ function kotlinImportForType(
 ): string | undefined {
   const direct = info.imports.get(type);
   if (direct !== undefined) {
-    return direct;
+    return direct.startsWith("kotlin.") ? undefined : direct;
   }
   if (projectTypes.has(type) || isKotlinImplicitType(type)) {
     return undefined;
   }
   for (const full of info.imports.values()) {
     if (full.endsWith(".*")) {
+      if (full.startsWith("kotlin.")) {
+        return undefined;
+      }
       return `${full.slice(0, -1)}${type}`;
     }
   }
@@ -1067,7 +1070,7 @@ function methodReturnEvidence(info: JavaFileInfo, projectPackages: Set<string>):
 }
 
 function isExternalProjectImport(full: string, projectPackages: Set<string>): boolean {
-  if (/^(?:java|javax|jakarta)\./u.test(full)) {
+  if (/^(?:java|javax|jakarta|kotlin)\./u.test(full)) {
     return false;
   }
   for (const packageName of projectPackages) {
@@ -1396,7 +1399,9 @@ async function gradleTags(
   ) {
     tags.push("kotlin");
   }
-  const buildSource = await readFile(join(root, buildFile), "utf8").catch(() => "");
+  const buildSource = stripGradleComments(
+    await readFile(join(root, buildFile), "utf8").catch(() => ""),
+  );
   if (
     appliesAndroidGradlePlugin(buildSource) ||
     /\bandroid\s*\{/u.test(buildSource) ||
@@ -1419,6 +1424,10 @@ function appliesAndroidGradlePlugin(source: string): boolean {
     }
   }
   return false;
+}
+
+function stripGradleComments(source: string): string {
+  return stripJavaComments(source);
 }
 
 function isGradleSourceFile(path: string): boolean {


### PR DESCRIPTION
## Summary
- Add Kotlin semantic role mapping for Gradle-backed projects, covering Android and server-side Kotlin roles.
- Detect Android UI entrypoints, ViewModels, Room/data boundaries, external clients, and DI frameworks including Metro.
- Add server-side Kotlin role evidence, fallback grouping, regression tests, and documentation.

## Test Plan
- pnpm typecheck && pnpm lint && pnpm test && pnpm build
- pnpm format:check
