### PR TITLE
feat(provider): add grok CLI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added FastAPI route feature mapping and kept root/web Python project detection in sync.
 - Added Laravel/PHP feature mapping for routes, controllers, form requests, Artisan commands, jobs, services, models, migrations, seeders, Composer scripts, and PHP tests, thanks @Jonathanm10.
 - Added Kotlin semantic role mapping for Gradle projects, including Android UI, ViewModel, data, external client, dependency injection, and server-side role slices, thanks @mrmans0n.
+- Added a Grok CLI provider for review, fix, revalidate, and doctor flows, thanks @ebastos.
 - Added `--since <ref>` on `clawpatch review` and `clawpatch revalidate` to restrict runs to features whose owned or context files changed since the given git ref, thanks @mvanhorn.
 - Added Flask route feature mapping for Python projects, including `web/` source roots, common root entry files, non-list method literals, and Python framework detection.
 - Added Next.js route mapping for `src/app` and `src/pages` layouts, thanks @obatried.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -13,9 +13,12 @@ clawpatch doctor
 
 Provider names today:
 
-- `codex`: shells out to `codex exec`
+- `codex`: shells out to `codex exec` (default)
+- `grok`: shells out to the xAI Grok Build CLI in headless mode (`grok --prompt-file`)
 - `mock`: deterministic provider for tests and fixtures
 - `mock-fail`: failure provider for tests
+
+### Codex
 
 Codex invocation:
 
@@ -25,19 +28,42 @@ Codex invocation:
 - output: strict JSON schema via `--output-schema`
 - final message capture: `--output-last-message`
 
-Model selection:
+### Grok
+
+The `grok` provider shells out to the local [Grok Build CLI](https://x.ai/cli) 
+
+Install the Grok CLI:
+
+```bash
+curl -fsSL https://x.ai/cli/install.sh | bash
+```
+
+Then ensure `grok --version` works and you are authenticated (browser login or `GROK_CODE_XAI_API_KEY` environment variable).
+
+**Provider selection:**
+
+```bash
+clawpatch review --provider grok
+CLAWPATCH_PROVIDER=grok clawpatch review
+clawpatch fix --finding <id> --provider grok --model grok-build
+clawpatch doctor --provider grok
+```
+
+**Model selection** (works for both `codex` and `grok`):
 
 ```bash
 clawpatch review --model <model>
 CLAWPATCH_MODEL=<model> clawpatch review
 ```
 
-Provider selection:
+#### How the grok provider works
 
-```bash
-clawpatch review --provider codex
-CLAWPATCH_PROVIDER=codex clawpatch review
-```
+- **Headless mode**: Uses `--prompt-file` + `--output-format json --always-approve --verbatim --cwd <root>`.
+- **Read-only operations** (`review`, `revalidate`): Adds `--disallowed-tools "search_replace,run_terminal_cmd,Agent"` so the agent cannot modify files or run shell commands.
+- **Write operations** (`fix`): Uses full `--always-approve` so the agent can edit files and run validation commands.
+- **Structured output**: The inner prompt instructs the model to return strict JSON matching clawpatch's schemas. The provider parses the `text` field of the JSON envelope returned by `--output-format json` and validates it with Zod (same schemas used for Codex).
+- **Large prompts**: Review and fix prompts can be tens of kilobytes (they embed the full source of owned and context files). Passing such prompts via `-p`/`--single` is unreliable, so the provider always uses `--prompt-file` (the intended mechanism for automation and large inputs).
 
 Direct OpenAI, Claude, Gemini, local-model, and multi-model panel providers are
-not implemented yet.
+not implemented yet. The `grok` provider uses the local `grok` binary for the
+best integration with the surrounding Grok Build environment.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -30,7 +30,7 @@ Codex invocation:
 
 ### Grok
 
-The `grok` provider shells out to the local [Grok Build CLI](https://x.ai/cli) 
+The `grok` provider shells out to the local [Grok Build CLI](https://x.ai/cli)
 
 Install the Grok CLI:
 
@@ -38,7 +38,7 @@ Install the Grok CLI:
 curl -fsSL https://x.ai/cli/install.sh | bash
 ```
 
-Then ensure `grok --version` works and you are authenticated (browser login or `GROK_CODE_XAI_API_KEY` environment variable).
+Then ensure `grok --version` works and authenticate using the flow supported by the local Grok CLI.
 
 **Provider selection:**
 
@@ -61,7 +61,7 @@ CLAWPATCH_MODEL=<model> clawpatch review
 - **Headless mode**: Uses `--prompt-file` + `--output-format json --always-approve --verbatim --cwd <root>`.
 - **Read-only operations** (`review`, `revalidate`): Adds `--disallowed-tools "search_replace,run_terminal_cmd,Agent"` so the agent cannot modify files or run shell commands.
 - **Write operations** (`fix`): Uses full `--always-approve` so the agent can edit files and run validation commands.
-- **Structured output**: The inner prompt instructs the model to return strict JSON matching clawpatch's schemas. The provider parses the `text` field of the JSON envelope returned by `--output-format json` and validates it with Zod (same schemas used for Codex).
+- **Structured output**: The inner prompt includes clawpatch's JSON schema. The provider parses the text field of the JSON envelope returned by `--output-format json` and validates it with Zod (same schemas used for Codex).
 - **Large prompts**: Review and fix prompts can be tens of kilobytes (they embed the full source of owned and context files). Passing such prompts via `-p`/`--single` is unreliable, so the provider always uses `--prompt-file` (the intended mechanism for automation and large inputs).
 
 Direct OpenAI, Claude, Gemini, local-model, and multi-model panel providers are

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,7 @@ This guide walks through a complete review workflow from initialization to fixin
 ## Prerequisites
 
 - [Install clawpatch](install.md)
-- Install Codex CLI: `brew install codex`
+- Install Codex CLI (`brew install codex`) **or** the Grok Build CLI (`curl -fsSL https://x.ai/cli/install.sh | bash`)
 - Have a project with code to review
 
 ## 1. Initialize
@@ -77,7 +77,7 @@ This:
 
 - Selects 3 pending features
 - Reviews them in parallel with 3 workers
-- Calls the provider (Codex CLI) for each
+- Calls the selected provider (Codex or Grok CLI) for each
 - Persists findings under `.clawpatch/findings/`
 - Updates feature status
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,7 +10,9 @@ This guide walks through a complete review workflow from initialization to fixin
 ## Prerequisites
 
 - [Install clawpatch](install.md)
-- Install Codex CLI (`brew install codex`) **or** the Grok Build CLI (`curl -fsSL https://x.ai/cli/install.sh | bash`)
+- Install Codex CLI (`brew install codex`) for the default provider, or install
+  the Grok Build CLI (`curl -fsSL https://x.ai/cli/install.sh | bash`) and pass
+  `--provider grok` when reviewing
 - Have a project with code to review
 
 ## 1. Initialize
@@ -72,6 +74,12 @@ Review a few features in parallel:
 
 ```bash
 clawpatch review --limit 3 --jobs 3
+```
+
+Using Grok instead of the default Codex provider:
+
+```bash
+clawpatch review --provider grok --limit 3 --jobs 3
 ```
 
 This:

--- a/src/app.ts
+++ b/src/app.ts
@@ -741,16 +741,29 @@ function mergeFinding(existing: FindingRecord | null, incoming: FindingRecord): 
   };
 }
 
-export async function doctorCommand(context: AppContext): Promise<unknown> {
+export async function doctorCommand(
+  context: AppContext,
+  flags: Record<string, string | boolean> = {},
+): Promise<unknown> {
   const loaded = await loadProjectState(context).catch(() => null);
   const root = loaded?.root ?? context.root;
-  const providerName = loaded?.config.provider.name ?? "codex";
+  const providerName =
+    stringFlag(flags, "provider") ??
+    process.env["CLAWPATCH_PROVIDER"] ??
+    loaded?.config.provider.name ??
+    "codex";
+  const model =
+    stringFlag(flags, "model") ??
+    process.env["CLAWPATCH_MODEL"] ??
+    loaded?.config.provider.model ??
+    null;
   const provider = providerByName(providerName);
   const providerVersion = await provider.check(root);
   return {
     root,
     state: loaded === null ? "missing" : "ok",
     provider: providerName,
+    model,
     providerVersion,
     secrets: "redacted",
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,7 +64,7 @@ async function dispatch(
     case "revalidate":
       return revalidateCommand(context, flags);
     case "doctor":
-      return doctorCommand(context);
+      return doctorCommand(context, flags);
     case "clean-locks":
       return cleanLocksCommand(context);
     default:
@@ -167,7 +167,7 @@ const commandFlags = {
     "provider",
     "model",
   ]),
-  doctor: new Set<string>(),
+  doctor: new Set(["provider", "model"]),
   "clean-locks": new Set<string>(),
 } satisfies Record<string, Set<string>>;
 
@@ -502,6 +502,8 @@ Usage:
   clawpatch doctor [flags]
 
 Flags:
+  --provider <name>
+  --model <name>
   --json
 `);
     return;

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -57,6 +57,7 @@ export async function runCommandArgs(
   args: string[],
   cwd: string,
   input?: string,
+  options: { trimOutput?: boolean } = {},
 ): Promise<CommandResult> {
   const started = Date.now();
   const spawnSpec = commandSpawnSpec(program, args);
@@ -98,8 +99,8 @@ export async function runCommandArgs(
     cwd,
     exitCode,
     durationMs: Date.now() - started,
-    stdout: trimOutput(stdout),
-    stderr: trimOutput(stderr),
+    stdout: options.trimOutput === false ? stdout : trimOutput(stdout),
+    stderr: options.trimOutput === false ? stderr : trimOutput(stderr),
   };
 }
 

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { extractJson, providerByName } from "./provider.js";
+
+describe("extractJson", () => {
+  it("parses strict JSON directly", () => {
+    const input = '{"findings":[],"inspected":{"files":[],"symbols":[],"notes":[]}}';
+    expect(extractJson(input)).toEqual({
+      findings: [],
+      inspected: { files: [], symbols: [], notes: [] },
+    });
+  });
+
+  it("extracts JSON from json code fence", () => {
+    const input = 'Here is the result:\n\n```json\n{"outcome":"fixed","reasoning":"all good","commands":[]}\n```';
+    expect(extractJson(input)).toEqual({ outcome: "fixed", reasoning: "all good", commands: [] });
+  });
+
+  it("extracts JSON from generic code fence", () => {
+    const input = "```\n{\"risk\":\"low\",\"steps\":[]}\n```";
+    expect(extractJson(input)).toEqual({ risk: "low", steps: [] });
+  });
+
+  it("recovers JSON via balanced brace heuristic", () => {
+    const input = "Some leading text { \"title\": \"x\", \"nested\": { \"a\": 1 } } trailing";
+    expect(extractJson(input)).toEqual({ title: "x", nested: { a: 1 } });
+  });
+
+  it("returns null for text with no valid JSON", () => {
+    expect(extractJson("no json here at all")).toBeNull();
+    expect(extractJson("just some words { unbalanced")).toBeNull();
+  });
+});
+
+describe("providerByName", () => {
+  it("returns the grok provider for name 'grok'", () => {
+    const p = providerByName("grok");
+    expect(p.name).toBe("grok");
+    expect(typeof p.check).toBe("function");
+    expect(typeof p.review).toBe("function");
+    expect(typeof p.fix).toBe("function");
+    expect(typeof p.revalidate).toBe("function");
+  });
+
+  it("still supports codex, mock, and mock-fail", () => {
+    expect(providerByName("codex").name).toBe("codex");
+    expect(providerByName("mock").name).toBe("mock");
+    expect(providerByName("mock-fail").name).toBe("mock-fail");
+  });
+});

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -11,17 +11,18 @@ describe("extractJson", () => {
   });
 
   it("extracts JSON from json code fence", () => {
-    const input = 'Here is the result:\n\n```json\n{"outcome":"fixed","reasoning":"all good","commands":[]}\n```';
+    const input =
+      'Here is the result:\n\n```json\n{"outcome":"fixed","reasoning":"all good","commands":[]}\n```';
     expect(extractJson(input)).toEqual({ outcome: "fixed", reasoning: "all good", commands: [] });
   });
 
   it("extracts JSON from generic code fence", () => {
-    const input = "```\n{\"risk\":\"low\",\"steps\":[]}\n```";
+    const input = '```\n{"risk":"low","steps":[]}\n```';
     expect(extractJson(input)).toEqual({ risk: "low", steps: [] });
   });
 
   it("recovers JSON via balanced brace heuristic", () => {
-    const input = "Some leading text { \"title\": \"x\", \"nested\": { \"a\": 1 } } trailing";
+    const input = 'Some leading text { "title": "x", "nested": { "a": 1 } } trailing';
     expect(extractJson(input)).toEqual({ title: "x", nested: { a: 1 } });
   });
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runCommandArgs } from "./exec.js";
@@ -23,6 +23,9 @@ export type Provider = {
 export function providerByName(name: string): Provider {
   if (name === "codex") {
     return codexProvider;
+  }
+  if (name === "grok") {
+    return grokProvider;
   }
   if (name === "mock") {
     return mockProvider;
@@ -52,6 +55,29 @@ const codexProvider: Provider = {
   },
   async revalidate(root: string, prompt: string, model: string | null): Promise<RevalidateOutput> {
     const output = await runCodexJson(root, prompt, model, revalidateJsonSchema);
+    return revalidateOutputSchema.parse(output);
+  },
+};
+
+const grokProvider: Provider = {
+  name: "grok",
+  async check(root: string): Promise<string> {
+    const result = await runCommandArgs("grok", ["--version"], root);
+    if (result.exitCode !== 0) {
+      throw new ClawpatchError("grok CLI not available", 4, "provider-auth");
+    }
+    return result.stdout.trim();
+  },
+  async review(root: string, prompt: string, model: string | null): Promise<ReviewOutput> {
+    const output = await runGrokJson(root, prompt, model, reviewJsonSchema, true);
+    return reviewOutputSchema.parse(output);
+  },
+  async fix(root: string, prompt: string, model: string | null): Promise<FixPlanOutput> {
+    const output = await runGrokJson(root, prompt, model, fixPlanJsonSchema, false);
+    return fixPlanOutputSchema.parse(output);
+  },
+  async revalidate(root: string, prompt: string, model: string | null): Promise<RevalidateOutput> {
+    const output = await runGrokJson(root, prompt, model, revalidateJsonSchema, true);
     return revalidateOutputSchema.parse(output);
   },
 };
@@ -176,6 +202,123 @@ async function runCodexJson(
     throw new ClawpatchError("codex provider produced no JSON output", 8, "malformed-output");
   }
   return JSON.parse(raw) as unknown;
+}
+
+async function runGrokJson(
+  root: string,
+  prompt: string,
+  model: string | null,
+  schema: object,
+  readOnly: boolean,
+): Promise<unknown> {
+  const dir = await mkdtemp(join(tmpdir(), "clawpatch-grok-"));
+  const promptPath = join(dir, "prompt.txt");
+  await writeFile(promptPath, prompt, "utf8");
+
+  try {
+    const args = [
+      "--prompt-file",
+      promptPath,
+      "--output-format",
+      "json",
+      "--always-approve",
+      "--verbatim",
+      "--cwd",
+      root,
+    ];
+    if (model !== null) {
+      args.push("-m", model);
+    }
+    if (readOnly) {
+      args.push("--disallowed-tools", "search_replace,run_terminal_cmd,Agent");
+    }
+    const result = await runCommandArgs("grok", args, root, undefined, { trimOutput: false });
+    if (result.exitCode !== 0) {
+      throw new ClawpatchError(
+        `grok provider failed: ${result.stderr || result.stdout}`,
+        providerExitCode(result.stderr),
+        "provider-failure",
+      );
+    }
+    let envelope: { text?: string };
+    try {
+      envelope = JSON.parse(result.stdout) as { text?: string };
+    } catch {
+      const preview = result.stdout.slice(0, 200).replace(/\s+/gu, " ");
+      throw new ClawpatchError(
+        `grok provider produced no JSON envelope (stdout preview: ${preview})`,
+        8,
+        "malformed-output",
+      );
+    }
+    const text = typeof envelope.text === "string" ? envelope.text : "";
+    if (text.trim().length === 0) {
+      throw new ClawpatchError("grok provider produced empty response", 8, "malformed-output");
+    }
+    const parsed = extractJson(text);
+    if (parsed === null) {
+      throw new ClawpatchError("grok provider produced unparsable JSON", 8, "malformed-output");
+    }
+    return parsed;
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+export function extractJson(text: string): unknown | null {
+  // 1. Direct parse (ideal path when model follows "strict JSON only")
+  try {
+    return JSON.parse(text);
+  } catch {
+    // continue to fallbacks
+  }
+  // 2. Extract from markdown code fence ```json ... ``` or ``` ... ```
+  const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/u);
+  if (fenceMatch && fenceMatch[1]) {
+    const candidate = fenceMatch[1].trim();
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // continue
+    }
+  }
+  // 3. Heuristic: find the first balanced top-level JSON object
+  const firstBrace = text.indexOf("{");
+  if (firstBrace !== -1) {
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    for (let i = firstBrace; i < text.length; i += 1) {
+      const ch = text[i];
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = !inString;
+        continue;
+      }
+      if (!inString) {
+        if (ch === "{") depth += 1;
+        else if (ch === "}") {
+          depth -= 1;
+          if (depth === 0) {
+            const candidate = text.slice(firstBrace, i + 1);
+            try {
+              return JSON.parse(candidate);
+            } catch {
+              return null;
+            }
+          }
+        }
+      }
+    }
+  }
+  return null;
 }
 
 function providerExitCode(stderr: string): number {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -213,7 +213,7 @@ async function runGrokJson(
 ): Promise<unknown> {
   const dir = await mkdtemp(join(tmpdir(), "clawpatch-grok-"));
   const promptPath = join(dir, "prompt.txt");
-  await writeFile(promptPath, prompt, "utf8");
+  await writeFile(promptPath, grokPrompt(prompt, schema), "utf8");
 
   try {
     const args = [
@@ -240,9 +240,9 @@ async function runGrokJson(
         "provider-failure",
       );
     }
-    let envelope: { text?: string };
+    let envelope: unknown;
     try {
-      envelope = JSON.parse(result.stdout) as { text?: string };
+      envelope = JSON.parse(result.stdout) as unknown;
     } catch {
       const preview = result.stdout.slice(0, 200).replace(/\s+/gu, " ");
       throw new ClawpatchError(
@@ -251,11 +251,8 @@ async function runGrokJson(
         "malformed-output",
       );
     }
-    const text = typeof envelope.text === "string" ? envelope.text : "";
-    if (text.trim().length === 0) {
-      throw new ClawpatchError("grok provider produced empty response", 8, "malformed-output");
-    }
-    const parsed = extractJson(text);
+    const text = grokEnvelopeText(envelope);
+    const parsed = text === null ? envelope : extractJson(text);
     if (parsed === null) {
       throw new ClawpatchError("grok provider produced unparsable JSON", 8, "malformed-output");
     }
@@ -265,24 +262,55 @@ async function runGrokJson(
   }
 }
 
+function grokPrompt(prompt: string, schema: object): string {
+  return `${prompt}
+
+Provider output schema:
+${JSON.stringify(schema, null, 2)}
+
+Return only one JSON object matching the schema.`;
+}
+
+function grokEnvelopeText(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  for (const key of ["text", "response", "output", "content"]) {
+    const item = (value as Record<string, unknown>)[key];
+    if (typeof item === "string") {
+      return item;
+    }
+  }
+  const choices = (value as Record<string, unknown>)["choices"];
+  if (Array.isArray(choices)) {
+    const first = choices[0] as unknown;
+    if (typeof first === "object" && first !== null) {
+      const message = (first as Record<string, unknown>)["message"];
+      if (typeof message === "object" && message !== null) {
+        const content = (message as Record<string, unknown>)["content"];
+        if (typeof content === "string") {
+          return content;
+        }
+      }
+    }
+  }
+  return null;
+}
+
 export function extractJson(text: string): unknown | null {
-  // 1. Direct parse (ideal path when model follows "strict JSON only")
   try {
     return JSON.parse(text);
-  } catch {
-    // continue to fallbacks
-  }
-  // 2. Extract from markdown code fence ```json ... ``` or ``` ... ```
+  } catch {}
   const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/u);
   if (fenceMatch && fenceMatch[1]) {
     const candidate = fenceMatch[1].trim();
     try {
       return JSON.parse(candidate);
-    } catch {
-      // continue
-    }
+    } catch {}
   }
-  // 3. Heuristic: find the first balanced top-level JSON object
   const firstBrace = text.indexOf("{");
   if (firstBrace !== -1) {
     let depth = 0;


### PR DESCRIPTION
Add support for using the xAI Grok Build CLI (`grok`) as an AI provider in addition to Codex. The provider uses headless mode with --prompt-file for large review/fix prompts, --always-approve + --verbatim for reliable structured output, and --disallowed-tools for read-only safety on review and revalidate operations.

- Implement grokProvider with runGrokJson + tolerant JSON extraction
- Extend runCommandArgs to support disabling stdout trimming (required for large JSON envelopes from the model)
- Allow --provider/--model on `doctor` command
- Add focused tests for extractJson and provider registration
- Update documentation with implementation details and usage

The grok provider enables users of the Grok CLI to run the full clawpatch workflow (review → fix → revalidate) using their native agent.