### PR TITLE
feat(website): add repo atlas

### DIFF
--- a/website/assets/repo-atlas.json
+++ b/website/assets/repo-atlas.json
@@ -1,0 +1,103 @@
+{
+  "generatedAt": "2026-05-17T06:03:57+00:00",
+  "owner": "dwaynehelena",
+  "source": "GitHub API via gh repo list; private raw copy kept locally outside the public repo",
+  "privacy": "Public page exposes public repository links plus aggregate private coverage only. Private repository names and descriptions are intentionally not committed.",
+  "totals": {
+    "all": 138,
+    "public": 5,
+    "private": 133,
+    "archived": 0,
+    "forks": 2
+  },
+  "activity": {
+    "updatedWithin7Days": 6,
+    "updatedWithin30Days": 14,
+    "updatedWithin90Days": 127,
+    "updatedWithin365Days": 136
+  },
+  "languages": {
+    "Python": 84,
+    "Unspecified": 23,
+    "HTML": 13,
+    "TypeScript": 9,
+    "JavaScript": 7,
+    "C#": 1,
+    "Shell": 1
+  },
+  "categories": {
+    "Claw project capsules": 99,
+    "AI agents and automation": 15,
+    "Apps and experiments": 13,
+    "Dashboards and observability": 6,
+    "Home, energy, and renovation": 3,
+    "Finance and trading": 2
+  },
+  "publicRepos": [
+    {
+      "name": "dwaynehelena/south-coast-sconces",
+      "description": "No public description yet.",
+      "url": "https://github.com/dwaynehelena/south-coast-sconces",
+      "homepageUrl": "https://south-coast-sconces.vercel.app",
+      "language": "TypeScript",
+      "stars": 0,
+      "forks": 0,
+      "updatedAt": "2026-05-12T23:06:02Z",
+      "topics": [],
+      "archived": false,
+      "fork": false
+    },
+    {
+      "name": "dwaynehelena/free-power",
+      "description": "No public description yet.",
+      "url": "https://github.com/dwaynehelena/free-power",
+      "homepageUrl": "https://free-power.vercel.app",
+      "language": "Python",
+      "stars": 0,
+      "forks": 0,
+      "updatedAt": "2026-05-01T01:04:52Z",
+      "topics": [],
+      "archived": false,
+      "fork": false
+    },
+    {
+      "name": "dwaynehelena/agent-state",
+      "description": "Multi-agent state persistence system",
+      "url": "https://github.com/dwaynehelena/agent-state",
+      "homepageUrl": "",
+      "language": "Shell",
+      "stars": 0,
+      "forks": 0,
+      "updatedAt": "2026-04-30T21:28:16Z",
+      "topics": [],
+      "archived": false,
+      "fork": false
+    },
+    {
+      "name": "dwaynehelena/autoresearch",
+      "description": "AI agents running research on single-GPU nanochat training automatically",
+      "url": "https://github.com/dwaynehelena/autoresearch",
+      "homepageUrl": "",
+      "language": "Python",
+      "stars": 0,
+      "forks": 0,
+      "updatedAt": "2026-04-05T09:18:53Z",
+      "topics": [],
+      "archived": false,
+      "fork": true
+    },
+    {
+      "name": "dwaynehelena/autoagent",
+      "description": "autonomous harness engineering",
+      "url": "https://github.com/dwaynehelena/autoagent",
+      "homepageUrl": "",
+      "language": "Python",
+      "stars": 0,
+      "forks": 0,
+      "updatedAt": "2026-04-05T09:18:50Z",
+      "topics": [],
+      "archived": false,
+      "fork": true
+    }
+  ]
+}

--- a/website/index.html
+++ b/website/index.html
@@ -768,6 +768,199 @@
         font-size: 0.92rem;
       }
 
+      /* Repo atlas */
+      .repo-atlas {
+        margin: 34px 0 50px;
+        padding: clamp(24px, 4vw, 42px);
+        border: 2px solid var(--line);
+        border-radius: 24px;
+        background:
+          radial-gradient(circle at top right, var(--accent-soft), transparent 38%),
+          linear-gradient(135deg, var(--paper) 0%, var(--sand-light) 100%);
+        box-shadow: var(--shadow-card);
+      }
+
+      .repo-atlas h2 {
+        margin: 0 0 10px;
+        color: var(--ink);
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        line-height: 1.05;
+        letter-spacing: -0.03em;
+      }
+
+      .atlas-head {
+        max-width: 78ch;
+        margin-bottom: 26px;
+      }
+
+      .atlas-head p:not(.eyebrow) {
+        margin: 0;
+        color: var(--muted);
+        font-size: 1.05rem;
+      }
+
+      .atlas-stats {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 14px;
+        margin: 24px 0 28px;
+      }
+
+      .atlas-stat {
+        padding: 18px;
+        border: 2px solid var(--line);
+        border-radius: 16px;
+        background: var(--paper);
+        box-shadow: 0 4px 14px rgba(0, 0, 0, 0.04);
+      }
+
+      .atlas-stat strong {
+        display: block;
+        color: var(--ink);
+        font-size: clamp(1.8rem, 4vw, 2.8rem);
+        line-height: 1;
+        letter-spacing: -0.04em;
+      }
+
+      .atlas-stat span {
+        display: block;
+        margin-top: 8px;
+        color: var(--muted);
+        font-size: 0.78rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .atlas-panels {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        gap: 18px;
+        margin: 0 0 24px;
+      }
+
+      .atlas-panel {
+        border: 2px solid var(--line);
+        border-radius: 18px;
+        background: var(--paper);
+        padding: 20px;
+      }
+
+      .atlas-panel h3,
+      .public-showcase h3 {
+        margin: 0 0 14px;
+        color: var(--ink);
+        font-size: 1rem;
+      }
+
+      .signal-list {
+        display: grid;
+        gap: 10px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .signal-list li {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+        gap: 14px;
+        color: var(--text);
+        font-size: 0.92rem;
+      }
+
+      .signal-list b {
+        color: var(--ink);
+        font-weight: 650;
+      }
+
+      .signal-list code {
+        font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+        color: var(--accent-strong);
+        background: var(--accent-soft);
+        border-radius: 999px;
+        padding: 3px 8px;
+        font-size: 0.82rem;
+      }
+
+      .repo-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 14px;
+      }
+
+      .repo-card {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        min-height: 190px;
+        padding: 18px;
+        border: 2px solid var(--line);
+        border-radius: 16px;
+        background: var(--paper);
+        color: var(--text);
+        text-decoration: none;
+        transition:
+          transform 0.2s,
+          border-color 0.2s,
+          box-shadow 0.2s;
+      }
+
+      .repo-card:hover {
+        transform: translateY(-3px);
+        border-color: var(--secondary);
+        box-shadow: var(--shadow-float);
+        text-decoration: none;
+      }
+
+      .repo-card h4 {
+        margin: 0;
+        color: var(--ink);
+        font-size: 1rem;
+        line-height: 1.25;
+      }
+
+      .repo-card p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.88rem;
+        line-height: 1.5;
+        flex: 1;
+      }
+
+      .repo-meta,
+      .repo-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 7px;
+      }
+
+      .repo-meta span,
+      .repo-tags span {
+        border-radius: 999px;
+        padding: 3px 8px;
+        background: var(--accent-soft);
+        color: var(--accent-strong);
+        font-size: 0.72rem;
+        font-weight: 700;
+      }
+
+      .repo-tags span {
+        background: rgba(42, 157, 143, 0.12);
+        color: var(--ocean-deep);
+      }
+
+      :root[data-theme="dark"] .repo-tags span {
+        color: var(--ocean-light);
+      }
+
+      .atlas-note {
+        margin: 18px 0 0;
+        color: var(--muted);
+        font-size: 0.86rem;
+      }
+
       /* Mobile responsive */
       @media (max-width: 900px) {
         .shell {
@@ -790,7 +983,9 @@
           font-size: 2.5rem;
         }
 
-        .features-grid {
+        .features-grid,
+        .atlas-stats,
+        .atlas-panels {
           grid-template-columns: 1fr;
         }
       }
@@ -980,6 +1175,7 @@
           </section>
           <section>
             <h2>Core Features</h2>
+            <a class="nav-link" href="#repo-atlas">Repo Atlas</a>
             <a class="nav-link" href="#initialization">Initialization</a>
             <a class="nav-link" href="#feature-mapping">Feature Mapping</a>
             <a class="nav-link" href="#code-review">Code Review</a>
@@ -1091,6 +1287,65 @@
             </p>
           </div>
         </div>
+
+        <section class="repo-atlas" id="repo-atlas" aria-labelledby="repo-atlas-title">
+          <div class="atlas-head">
+            <p class="eyebrow">Repo Atlas · GitHub inventory</p>
+            <h2 id="repo-atlas-title">All repos, inventoried without leaking the vault</h2>
+            <p>
+              This is the public inventory surface for Dwayne’s GitHub estate. Public repos are
+              linked below; private repo names and descriptions stay out of the public Pages
+              artifact while the aggregate coverage still shows the full operating field.
+            </p>
+          </div>
+
+          <div class="atlas-stats" aria-label="Repository coverage totals">
+            <div class="atlas-stat">
+              <strong data-atlas-total>138</strong>
+              <span>repos discovered</span>
+            </div>
+            <div class="atlas-stat">
+              <strong data-atlas-public>5</strong>
+              <span>public links</span>
+            </div>
+            <div class="atlas-stat">
+              <strong data-atlas-private>133</strong>
+              <span>private covered</span>
+            </div>
+            <div class="atlas-stat">
+              <strong data-atlas-recent>0</strong>
+              <span>updated in 30d</span>
+            </div>
+          </div>
+
+          <div class="atlas-panels">
+            <div class="atlas-panel">
+              <h3>Workload lanes</h3>
+              <ol class="signal-list" id="atlas-categories">
+                <li><b>Loading GitHub categories</b><code>…</code></li>
+              </ol>
+            </div>
+            <div class="atlas-panel">
+              <h3>Language mix</h3>
+              <ol class="signal-list" id="atlas-languages">
+                <li><b>Loading language totals</b><code>…</code></li>
+              </ol>
+            </div>
+          </div>
+
+          <div class="public-showcase">
+            <h3>Public repo links</h3>
+            <div class="repo-grid" id="public-repos" aria-live="polite">
+              <article class="repo-card">
+                <h4>Loading public repositories…</h4>
+                <p>Fetching the static atlas generated from GitHub metadata.</p>
+              </article>
+            </div>
+          </div>
+          <p class="atlas-note" id="atlas-note">
+            Public-safe atlas. Private repository metadata is counted, not published.
+          </p>
+        </section>
 
         <div class="doc">
           <h2 id="quickstart">Quick Start</h2>
@@ -1390,6 +1645,74 @@
         if (systemDark.addEventListener) systemDark.addEventListener("change", onSystemChange);
         else if (systemDark.addListener) systemDark.addListener(onSystemChange);
       }
+
+      // Repo atlas
+      function formatDate(value) {
+        if (!value) return "unknown";
+        try {
+          return new Intl.DateTimeFormat("en-AU", { dateStyle: "medium" }).format(new Date(value));
+        } catch (e) {
+          return value;
+        }
+      }
+
+      function topEntries(record, limit) {
+        return Object.entries(record || {})
+          .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+          .slice(0, limit);
+      }
+
+      function renderSignalList(id, entries) {
+        const node = document.getElementById(id);
+        if (!node) return;
+        node.innerHTML = entries
+          .map(([label, count]) => `<li><b>${label}</b><code>${count}</code></li>`)
+          .join("");
+      }
+
+      function renderPublicRepos(repos) {
+        const node = document.getElementById("public-repos");
+        if (!node) return;
+        node.innerHTML = (repos || [])
+          .map((repo) => {
+            const tags = (repo.topics || [])
+              .slice(0, 3)
+              .map((tag) => `<span>${tag}</span>`)
+              .join("");
+            const home = repo.homepageUrl ? `<span>site</span>` : "";
+            return `<a class="repo-card" href="${repo.url}" rel="noopener" target="_blank">
+              <h4>${repo.name}</h4>
+              <p>${repo.description}</p>
+              <div class="repo-meta"><span>${repo.language}</span><span>★ ${repo.stars}</span><span>updated ${formatDate(repo.updatedAt)}</span>${home}</div>
+              <div class="repo-tags">${tags}</div>
+            </a>`;
+          })
+          .join("");
+      }
+
+      fetch("assets/repo-atlas.json")
+        .then((res) => {
+          if (!res.ok) throw new Error(`atlas ${res.status}`);
+          return res.json();
+        })
+        .then((atlas) => {
+          document.querySelector("[data-atlas-total]").textContent = atlas.totals.all;
+          document.querySelector("[data-atlas-public]").textContent = atlas.totals.public;
+          document.querySelector("[data-atlas-private]").textContent = atlas.totals.private;
+          document.querySelector("[data-atlas-recent]").textContent =
+            atlas.activity.updatedWithin30Days;
+          renderSignalList("atlas-categories", topEntries(atlas.categories, 7));
+          renderSignalList("atlas-languages", topEntries(atlas.languages, 7));
+          renderPublicRepos(atlas.publicRepos);
+          const note = document.getElementById("atlas-note");
+          if (note) {
+            note.textContent = `${atlas.privacy} Generated ${formatDate(atlas.generatedAt)} from ${atlas.source}.`;
+          }
+        })
+        .catch((err) => {
+          const note = document.getElementById("atlas-note");
+          if (note) note.textContent = `Repo atlas failed to load: ${err.message}`;
+        });
 
       // Search functionality
       const input = document.getElementById("doc-search");


### PR DESCRIPTION
Adds a public-safe Repo Atlas section to clawpatch.ai.\n\n- Inventories 138 dwaynehelena GitHub repos from gh metadata\n- Shows 5 public repo links\n- Shows 133 private repos as aggregate coverage only\n- Adds language/category/activity totals\n- Keeps private repo names and descriptions out of the public Pages artifact\n\nVerification:\n- corepack pnpm typecheck\n- corepack pnpm lint\n- corepack pnpm test\n- corepack pnpm build\n- corepack pnpm format:check\n- local Pages artifact check\n- browser DOM check: stats 138/5/133/14, 5 public cards, 0 console errors, 0 horizontal overflow