### PR TITLE
feat(mapper): add .NET mapper for C#, F#, and Visual Basic projects

### DIFF
--- a/.clawpatch/config.json
+++ b/.clawpatch/config.json
@@ -1,0 +1,36 @@
+{
+  "schemaVersion": 1,
+  "stateDir": ".clawpatch",
+  "include": ["**/*"],
+  "exclude": [
+    "node_modules/**",
+    "dist/**",
+    "build/**",
+    "target/**",
+    ".build/**",
+    ".git/**",
+    ".clawpatch/**"
+  ],
+  "provider": {
+    "name": "codex",
+    "model": null,
+    "reasoningEffort": null
+  },
+  "commands": {
+    "typecheck": "pnpm typecheck",
+    "lint": "pnpm lint",
+    "format": "pnpm format",
+    "test": "pnpm test"
+  },
+  "review": {
+    "maxContextFiles": 24,
+    "maxOwnedFiles": 12,
+    "maxFindingsPerFeature": 10,
+    "minConfidenceToFix": "medium"
+  },
+  "git": {
+    "requireCleanWorktreeForFix": true,
+    "commit": false,
+    "openPr": false
+  }
+}

--- a/.clawpatch/project.json
+++ b/.clawpatch/project.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "projectId": "prj_https-github-com-danielmarbach-c_9c64f3f999",
+  "name": "clawpatch",
+  "rootPath": "/Users/danielmarbach/Projects/clawpatch",
+  "git": {
+    "remoteUrl": "https://github.com/danielmarbach/clawpatch.git",
+    "defaultBranch": "main",
+    "currentBranch": "feat/dotnet-mapper",
+    "headSha": "604f7febaeb948e7cae3e22aa8c97940df49fb80"
+  },
+  "detected": {
+    "languages": ["typescript", "javascript"],
+    "frameworks": ["vitest"],
+    "packageManagers": ["pnpm"],
+    "commands": {
+      "typecheck": "pnpm typecheck",
+      "lint": "pnpm lint",
+      "format": "pnpm format",
+      "test": "pnpm test"
+    }
+  },
+  "createdAt": "2026-05-17T12:52:06.186Z",
+  "updatedAt": "2026-05-17T12:52:06.186Z"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.1 - Unreleased
 
+- Added deterministic .NET mapper for C#, F#, and Visual Basic projects discovered from `.sln` and `.slnx` solution files with standalone fallback. Maps console apps, ASP.NET Core web apps, libraries, and test suites. Detects test projects by naming convention and framework packages (xUnit, NUnit, MSTest, TUnit). Default commands: `dotnet build`, `dotnet format --verify-no-changes`, `dotnet format`, `dotnet test`.
 - Added explicit Codex reasoning effort selection via `--reasoning-effort`, `CLAWPATCH_REASONING_EFFORT`, and provider config, with `doctor` reporting the active setting.
 - Added deterministic Express, Fastify, and Hono route mapping for Node projects, thanks @rohitjavvadi.
 - Fixed provider commands with relative `--root` paths by canonicalizing explicit roots before invoking Codex or other providers.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ validation commands and records a patch attempt under `.clawpatch/`.
 - Kotlin Android semantic roles for UI entrypoints, ViewModels, data
   boundaries, external clients, and dependency injection, including Metro
 - Ruby project metadata, executables, source groups, RSpec/Minitest suites
+- .NET C#, F#, and Visual Basic console apps, web apps, libraries, and test
+  suites from `.sln`/`.slnx` solution files or standalone project files
 - Rust `src/main.rs`, `src/bin/*.rs`, `src/lib.rs`, `crates/*`, and
   `tests/*.rs`
 - C/C++ standalone `main()` files, CMake `add_executable` / `add_library`

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -57,6 +57,8 @@ Supported deterministic mappers today:
 - Laravel/PHP projects from `composer.json` and `artisan`, including controllers
   referenced by routes, form requests, Artisan commands, jobs, services, models,
   migrations, seeders, Composer scripts, and grouped PHP test suites
+- .NET C#, F#, and Visual Basic console apps, web apps, libraries, and test suites
+  discovered from `.sln`/`.slnx` solution files or standalone project files
 - common config files
 
 The default mapper does not call a model. It uses repo conventions and cheap
@@ -147,6 +149,19 @@ Ruby mapping covers project metadata, executables, source groups, RSpec and
 Minitest suites, and Rails app structure. Rails legacy `config/secrets.yml`,
 `config/database.yml`, and `config/initializers/secret_token.rb` are not mapped
 as reviewable config because they can contain provider-sensitive secrets.
+
+.NET mapping covers C# (`.csproj`), F# (`.fsproj`), and Visual Basic (`.vbproj`)
+projects. Projects are discovered from `.sln` and `.slnx` solution files when
+present, falling back to standalone project file discovery when no solution
+exists. Console executables and ASP.NET Core web apps are mapped as top-level
+features with `Program.cs` as the preferred entrypoint. Library projects are
+mapped with their first source file. Test projects are detected by naming
+convention (`.Tests`/`.Specs` suffix) or by test framework package references
+(xUnit, NUnit, MSTest, TUnit). Associated test files are linked to their
+corresponding library features when names match. Default commands are
+`dotnet build` (typecheck), `dotnet format --verify-no-changes` (lint),
+`dotnet format` (format), and `dotnet test` (test). `bin/` and `obj/`
+directories are excluded from source walks.
 
 Known gaps:
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -229,6 +229,9 @@ async function languageDefaultCommands(
   ) {
     return gradleDefaultCommands(root);
   }
+  if (languages.some((lang) => dotnetLanguages.has(lang))) {
+    return dotnetDefaultCommands();
+  }
   if (languages.includes("ruby")) {
     return rubyDefaultCommands(root);
   }
@@ -342,11 +345,20 @@ async function detectPackageManagers(root: string): Promise<string[]> {
   if ((await isRubyProject(root)) && !found.some((name) => rubyPackageManagers.has(name))) {
     found.push((await hasBundlerConfig(root)) ? "bundler" : "ruby");
   }
+  if (
+    !found.includes("dotnet") &&
+    ((await containsFileWithExtension(root, ".csproj", 5)) ||
+      (await containsFileWithExtension(root, ".fsproj", 5)) ||
+      (await containsFileWithExtension(root, ".vbproj", 5)))
+  ) {
+    found.push("dotnet");
+  }
   return found;
 }
 
 const pythonPackageManagers = new Set(["uv", "poetry", "pdm", "hatch", "pip", "python"]);
 const rubyPackageManagers = new Set(["bundler", "ruby"]);
+const dotnetLanguages = new Set(["csharp", "fsharp", "visual-basic"]);
 
 async function isRootGradleProject(root: string): Promise<boolean> {
   return (
@@ -497,6 +509,15 @@ function hasRubocopDependency(dependencies: Set<string>): boolean {
   return [...dependencies].some(
     (dependency) => dependency === "rubocop" || dependency.startsWith("rubocop-"),
   );
+}
+
+function dotnetDefaultCommands(): ProjectCommands {
+  return {
+    typecheck: "dotnet build",
+    lint: "dotnet format --verify-no-changes",
+    format: "dotnet format",
+    test: "dotnet test",
+  };
 }
 
 async function hasBundlerConfig(root: string): Promise<boolean> {
@@ -999,6 +1020,18 @@ async function detectLanguages(root: string): Promise<string[]> {
   }
   if (!languages.includes("php") && (await containsReviewablePhpFile(root))) {
     languages.push("php");
+  }
+  if (!languages.includes("csharp") && (await containsFileWithExtension(root, ".csproj", 5))) {
+    languages.push("csharp");
+  }
+  if (!languages.includes("fsharp") && (await containsFileWithExtension(root, ".fsproj", 5))) {
+    languages.push("fsharp");
+  }
+  if (
+    !languages.includes("visual-basic") &&
+    (await containsFileWithExtension(root, ".vbproj", 5))
+  ) {
+    languages.push("visual-basic");
   }
   return languages;
 }

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -12792,4 +12792,245 @@ let package = Package(
 
     expect(core?.entrypoints[0]?.path).toBe("Sources/Core.swift");
   });
+
+  it("maps .NET C# console app, library, and tests from solution", async () => {
+    const root = await fixtureRoot("clawpatch-dotnet-sln-");
+    await writeFixture(
+      root,
+      "App.sln",
+      [
+        "Microsoft Visual Studio Solution File, Format Version 12.00",
+        "# Visual Studio Version 17",
+        'Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyApp", "src/MyApp/MyApp.csproj", "{AAA11111-1111-1111-1111-111111111111}"',
+        "EndProject",
+        'Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyLib", "src/MyLib/MyLib.csproj", "{BBB22222-2222-2222-2222-222222222222}"',
+        "EndProject",
+        'Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyLib.Tests", "tests/MyLib.Tests/MyLib.Tests.csproj", "{CCC33333-3333-3333-3333-333333333333}"',
+        "EndProject",
+        "Global",
+        "EndGlobal",
+      ].join("\n"),
+    );
+    await writeFixture(
+      root,
+      "src/MyApp/MyApp.csproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n</Project>',
+    );
+    await writeFixture(root, "src/MyApp/Program.cs", 'Console.WriteLine("Hello");\n');
+    await writeFixture(root, "src/MyApp/Helper.cs", "static class Helper { }\n");
+    await writeFixture(
+      root,
+      "src/MyLib/MyLib.csproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Library</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n</Project>',
+    );
+    await writeFixture(root, "src/MyLib/Calculator.cs", "public class Calculator { }\n");
+    await writeFixture(
+      root,
+      "tests/MyLib.Tests/MyLib.Tests.csproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Library</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n<ItemGroup><PackageReference Include="xunit" Version="2.4.2" /></ItemGroup>\n</Project>',
+    );
+    await writeFixture(
+      root,
+      "tests/MyLib.Tests/CalculatorTests.cs",
+      "public class CalculatorTests { [Fact] void Test1() {} }\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const consoleApp = result.features.find(
+      (feature) => feature.title === ".NET console app MyApp",
+    );
+    const library = result.features.find((feature) => feature.title === ".NET library MyLib");
+    const testSuite = result.features.find(
+      (feature) => feature.title === ".NET test suite MyLib.Tests",
+    );
+
+    expect(project.detected.languages).toContain("csharp");
+    expect(project.detected.packageManagers).toContain("dotnet");
+    expect(project.detected.commands.typecheck).toBe("dotnet build");
+    expect(project.detected.commands.lint).toBe("dotnet format --verify-no-changes");
+    expect(project.detected.commands.format).toBe("dotnet format");
+    expect(project.detected.commands.test).toBe("dotnet test");
+    expect(titles).toContain(".NET console app MyApp");
+    expect(titles).toContain(".NET library MyLib");
+    expect(titles).toContain(".NET test suite MyLib.Tests");
+    expect(consoleApp?.entrypoints[0]?.path).toBe("src/MyApp/Program.cs");
+    expect(consoleApp?.entrypoints[0]?.symbol).toBe("Main");
+    expect(consoleApp?.tags).toEqual(expect.arrayContaining(["dotnet", "csharp", "cli"]));
+    expect(consoleApp?.ownedFiles.map((f) => f.path)).toContain("src/MyApp/Helper.cs");
+    expect(consoleApp?.contextFiles).toContainEqual({
+      path: "src/MyApp/MyApp.csproj",
+      reason: "project file",
+    });
+    expect(library?.entrypoints[0]?.path).toBe("src/MyLib/Calculator.cs");
+    expect(library?.tags).toEqual(expect.arrayContaining(["dotnet", "csharp", "library"]));
+    expect(library?.tests).toEqual([
+      { path: "tests/MyLib.Tests/CalculatorTests.cs", command: "dotnet test" },
+    ]);
+    expect(testSuite?.ownedFiles.map((f) => f.path)).toContain(
+      "tests/MyLib.Tests/CalculatorTests.cs",
+    );
+  });
+
+  it("maps .NET web app with ASP.NET Core", async () => {
+    const root = await fixtureRoot("clawpatch-dotnet-web-");
+    await writeFixture(
+      root,
+      "WebApp/WebApp.csproj",
+      '<Project Sdk="Microsoft.NET.Sdk.Web">\n<PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n</Project>',
+    );
+    await writeFixture(root, "WebApp/Program.cs", "var app = WebApplication.Create();\n");
+    await writeFixture(root, "WebApp/WeatherForecast.cs", "public class WeatherForecast { }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const webApp = result.features.find((feature) => feature.title === ".NET web app WebApp");
+
+    expect(project.detected.languages).toContain("csharp");
+    expect(webApp?.kind).toBe("service");
+    expect(webApp?.source).toBe("dotnet-web");
+    expect(webApp?.tags).toEqual(expect.arrayContaining(["dotnet", "csharp", "web"]));
+    expect(webApp?.trustBoundaries).toEqual(
+      expect.arrayContaining(["user-input", "network", "filesystem", "process-exec"]),
+    );
+    expect(webApp?.entrypoints[0]?.path).toBe("WebApp/Program.cs");
+  });
+
+  it("maps .NET F# library and tests", async () => {
+    const root = await fixtureRoot("clawpatch-dotnet-fsharp-");
+    await writeFixture(
+      root,
+      "src/Lib/Lib.fsproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Library</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n</Project>',
+    );
+    await writeFixture(root, "src/Lib/Library.fs", 'module Library\nlet hello () = "world"\n');
+    await writeFixture(
+      root,
+      "tests/Lib.Tests/Lib.Tests.fsproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Library</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n<ItemGroup><PackageReference Include="xunit" Version="2.4.2" /></ItemGroup>\n</Project>',
+    );
+    await writeFixture(root, "tests/Lib.Tests/Tests.fs", "module Tests\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const lib = result.features.find((feature) => feature.title === ".NET library Lib");
+    const testSuite = result.features.find(
+      (feature) => feature.title === ".NET test suite Lib.Tests",
+    );
+
+    expect(project.detected.languages).toContain("fsharp");
+    expect(lib?.tags).toEqual(expect.arrayContaining(["dotnet", "fsharp", "library"]));
+    expect(lib?.entrypoints[0]?.path).toBe("src/Lib/Library.fs");
+    expect(testSuite?.tags).toEqual(expect.arrayContaining(["dotnet", "fsharp", "test"]));
+  });
+
+  it("maps .NET Visual Basic console app", async () => {
+    const root = await fixtureRoot("clawpatch-dotnet-vb-");
+    await writeFixture(
+      root,
+      "VbApp/VbApp.vbproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n</Project>',
+    );
+    await writeFixture(
+      root,
+      "VbApp/Program.vb",
+      "Module Program\nSub Main()\nEnd Sub\nEnd Module\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === ".NET console app VbApp");
+
+    expect(project.detected.languages).toContain("visual-basic");
+    expect(app?.tags).toEqual(expect.arrayContaining(["dotnet", "visual-basic", "cli"]));
+    expect(app?.entrypoints[0]?.path).toBe("VbApp/Program.vb");
+  });
+
+  it("maps .NET projects from .slnx solution file", async () => {
+    const root = await fixtureRoot("clawpatch-dotnet-slnx-");
+    await writeFixture(
+      root,
+      "App.slnx",
+      '<Solution Config="Debug|Any CPU">\n<Project Path="src/App/App.csproj" />\n</Solution>',
+    );
+    await writeFixture(
+      root,
+      "src/App/App.csproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n</Project>',
+    );
+    await writeFixture(root, "src/App/Program.cs", 'Console.WriteLine("Hello");\n');
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === ".NET console app App");
+
+    expect(app?.entrypoints[0]?.path).toBe("src/App/Program.cs");
+  });
+
+  it("maps standalone .NET projects without solution file", async () => {
+    const root = await fixtureRoot("clawpatch-dotnet-standalone-");
+    await writeFixture(
+      root,
+      "MyTool.csproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n</Project>',
+    );
+    await writeFixture(root, "Program.cs", 'Console.WriteLine("Hello");\n');
+    await writeFixture(root, "Util.cs", "static class Util { }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const app = result.features.find((feature) => feature.title === ".NET console app MyTool");
+
+    expect(project.detected.languages).toContain("csharp");
+    expect(app?.entrypoints[0]?.path).toBe("Program.cs");
+    expect(app?.ownedFiles.map((f) => f.path)).toContain("Util.cs");
+  });
+
+  it("detects .NET test projects by naming convention and TUnit package", async () => {
+    const root = await fixtureRoot("clawpatch-dotnet-tunit-");
+    await writeFixture(
+      root,
+      "src/Core/Core.csproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Library</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n</Project>',
+    );
+    await writeFixture(root, "src/Core/Engine.cs", "public class Engine { }\n");
+    await writeFixture(
+      root,
+      "tests/Core.Tests/Core.Tests.csproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Library</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n<ItemGroup><PackageReference Include="TUnit" Version="0.1.0" /></ItemGroup>\n</Project>',
+    );
+    await writeFixture(root, "tests/Core.Tests/EngineTests.cs", "public class EngineTests { }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const lib = result.features.find((feature) => feature.title === ".NET library Core");
+    const testSuite = result.features.find(
+      (feature) => feature.title === ".NET test suite Core.Tests",
+    );
+
+    expect(lib?.tests).toEqual([
+      { path: "tests/Core.Tests/EngineTests.cs", command: "dotnet test" },
+    ]);
+    expect(testSuite?.kind).toBe("test-suite");
+  });
+
+  it("skips dotnet bin and obj directories", async () => {
+    const root = await fixtureRoot("clawpatch-dotnet-skip-");
+    await writeFixture(
+      root,
+      "App.csproj",
+      '<Project Sdk="Microsoft.NET.Sdk">\n<PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net9.0</TargetFramework></PropertyGroup>\n</Project>',
+    );
+    await writeFixture(root, "Program.cs", 'Console.WriteLine("Hello");\n');
+    await writeFixture(root, "bin/Debug/net9.0/built.dll", "fake-binary");
+    await writeFixture(root, "obj/Debug/net9.0/temp.cs", "// generated");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const owned = result.features.flatMap((feature) => feature.ownedFiles.map((ref) => ref.path));
+
+    expect(owned).not.toContain("bin/Debug/net9.0/built.dll");
+    expect(owned).not.toContain("obj/Debug/net9.0/temp.cs");
+  });
 });

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -2,6 +2,7 @@ import { nowIso } from "./fs.js";
 import { stableId } from "./id.js";
 import { cCppSeeds } from "./mappers/c-cpp.js";
 import { configSeeds } from "./mappers/config.js";
+import { dotnetSeeds } from "./mappers/dotnet.js";
 import { goSeeds } from "./mappers/go.js";
 import { appleSeeds } from "./mappers/apple.js";
 import { gradleSeeds } from "./mappers/gradle.js";
@@ -53,6 +54,7 @@ const featureMappers: FeatureMapper[] = [
   { name: "gradle", map: gradleSeeds },
   { name: "laravel", map: laravelSeeds },
   { name: "config", map: configSeeds },
+  { name: "dotnet", map: dotnetSeeds },
 ];
 
 export async function mapFeatures(

--- a/src/mappers/config.ts
+++ b/src/mappers/config.ts
@@ -18,6 +18,9 @@ export async function configSeeds(root: string): Promise<FeatureSeed[]> {
     "composer.lock",
     "phpunit.xml",
     "Makefile",
+    "global.json",
+    "Directory.Build.props",
+    "Directory.Packages.props",
   ];
   const seeds: FeatureSeed[] = [];
   for (const file of candidates) {

--- a/src/mappers/dotnet.ts
+++ b/src/mappers/dotnet.ts
@@ -1,0 +1,369 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathExists } from "../fs.js";
+import { packageTrustBoundaries, shouldSkip, walk } from "./shared.js";
+import { FeatureSeed, SeedTestRef } from "./types.js";
+
+// ── Types ──────────────────────────────────────────────────────
+
+type DotNetLanguage = "csharp" | "fsharp" | "visual-basic";
+
+type DotNetProjectInfo = {
+  dir: string;
+  projectFile: string;
+  name: string;
+  language: DotNetLanguage;
+  outputType: "Exe" | "Library" | "WinExe";
+  isTest: boolean;
+  isWeb: boolean;
+};
+
+// ── Constants ──────────────────────────────────────────────────
+
+const projectExtensions = new Map<string, DotNetLanguage>([
+  [".csproj", "csharp"],
+  [".fsproj", "fsharp"],
+  [".vbproj", "visual-basic"],
+]);
+
+const sourceExtensions: Record<DotNetLanguage, string[]> = {
+  csharp: [".cs"],
+  fsharp: [".fs", ".fsi"],
+  "visual-basic": [".vb"],
+};
+
+const testFrameworkPackages = new Set([
+  "xunit",
+  "nunit",
+  "mstest",
+  "tunit",
+  "Microsoft.NET.Test.Sdk",
+]);
+
+// ── Skip function ──────────────────────────────────────────────
+
+function shouldSkipDotNet(path: string): boolean {
+  if (shouldSkip(path)) {
+    return true;
+  }
+  return /(^|\/)(bin|obj)(\/|$)/u.test(path);
+}
+
+// ── Main export ────────────────────────────────────────────────
+
+export async function dotnetSeeds(root: string): Promise<FeatureSeed[]> {
+  const projects = await discoverDotNetProjects(root);
+  if (projects.length === 0) {
+    return [];
+  }
+
+  const testCommand = "dotnet test";
+  const testProjects = projects.filter((p) => p.isTest);
+  const nonTestProjects = projects.filter((p) => !p.isTest);
+  const sourceCache = new Map<string, string[]>();
+  for (const p of projects) {
+    sourceCache.set(p.projectFile, await projectSourceFiles(root, p));
+  }
+
+  const seeds: FeatureSeed[] = [];
+
+  for (const project of nonTestProjects) {
+    const sourceFiles = sourceCache.get(project.projectFile) ?? [];
+    if (sourceFiles.length === 0) {
+      continue;
+    }
+    const entryPath = findEntryPath(project, sourceFiles);
+    const tests = findAssociatedTests(project, testProjects, sourceCache);
+    const isExe = project.outputType === "Exe" || project.outputType === "WinExe";
+    seeds.push(
+      isExe || project.isWeb
+        ? dotnetExeSeed(project, entryPath, sourceFiles, tests, testCommand)
+        : dotnetLibrarySeed(project, entryPath, sourceFiles, tests, testCommand),
+    );
+  }
+
+  for (const tp of testProjects) {
+    const files = sourceCache.get(tp.projectFile) ?? [];
+    if (files.length === 0) {
+      continue;
+    }
+    seeds.push(dotnetTestSuiteSeed(tp, files, testCommand));
+  }
+
+  return seeds;
+}
+
+// ── Project discovery ──────────────────────────────────────────
+
+async function discoverDotNetProjects(root: string): Promise<DotNetProjectInfo[]> {
+  const solutionProjects = await discoverFromSolutions(root);
+  const projectPaths =
+    solutionProjects.length > 0 ? solutionProjects : await discoverStandaloneProjects(root);
+  return parseDotNetProjects(root, projectPaths);
+}
+
+async function discoverFromSolutions(root: string): Promise<string[]> {
+  const paths = new Set<string>();
+  const files = await walk(root, [""], shouldSkipDotNet);
+  for (const file of files) {
+    if (!file.endsWith(".sln") && !file.endsWith(".slnx")) {
+      continue;
+    }
+    const content = await readFile(join(root, file), "utf8").catch(() => "");
+    if (content.length === 0) {
+      continue;
+    }
+    const solutionDir = file.includes("/") ? file.substring(0, file.lastIndexOf("/")) : "";
+    const projects = file.endsWith(".sln")
+      ? parseSlnProjects(content, solutionDir)
+      : parseSlnxProjects(content, solutionDir);
+    for (const p of projects) {
+      paths.add(p);
+    }
+  }
+  return [...paths].toSorted();
+}
+
+async function discoverStandaloneProjects(root: string): Promise<string[]> {
+  const files = await walk(root, [""], shouldSkipDotNet);
+  const exts = [...projectExtensions.keys()];
+  return files.filter((f) => exts.some((ext) => f.endsWith(ext))).toSorted();
+}
+
+async function parseDotNetProjects(root: string, paths: string[]): Promise<DotNetProjectInfo[]> {
+  const projects: DotNetProjectInfo[] = [];
+  for (const projectPath of paths) {
+    if (!(await pathExists(join(root, projectPath)))) {
+      continue;
+    }
+    const info = await parseProjectFile(root, projectPath);
+    if (info !== null) {
+      projects.push(info);
+    }
+  }
+  return projects;
+}
+
+// ── Project file parsing ───────────────────────────────────────
+
+async function parseProjectFile(
+  root: string,
+  projectPath: string,
+): Promise<DotNetProjectInfo | null> {
+  const content = await readFile(join(root, projectPath), "utf8").catch(() => "");
+  if (!content.includes("<Project")) {
+    return null;
+  }
+
+  const ext = extensionOf(projectPath);
+  const language = projectExtensions.get(ext);
+  if (language === undefined) {
+    return null;
+  }
+
+  const dir = directoryOf(projectPath);
+  const name = baseNameOf(projectPath, ext);
+  const outputType = extractXmlProperty(content, "OutputType") ?? "Library";
+  const isWeb = /Sdk\s*=\s*"Microsoft\.NET\.Sdk\.Web"/u.test(content);
+  const packages = extractPackageReferences(content);
+  const isTest = detectIsTest(name, packages);
+
+  return {
+    dir,
+    projectFile: projectPath,
+    name,
+    language,
+    outputType: outputType as DotNetProjectInfo["outputType"],
+    isTest,
+    isWeb,
+  };
+}
+
+function extractXmlProperty(xml: string, tagName: string): string | null {
+  const match = new RegExp(`<${tagName}[^>]*>\\s*([^<]+?)\\s*</${tagName}>`, "u").exec(xml);
+  return match?.[1]?.trim() ?? null;
+}
+
+function extractPackageReferences(xml: string): string[] {
+  return [...xml.matchAll(/<PackageReference\s+Include="([^"]+)"/gu)]
+    .map((m) => m[1])
+    .filter((v): v is string => v !== undefined);
+}
+
+function detectIsTest(name: string, packages: string[]): boolean {
+  if (/\.(Tests?|Specs?)$/u.test(name)) {
+    return true;
+  }
+  return packages.some((p) => testFrameworkPackages.has(p));
+}
+
+// ── Solution file parsing ──────────────────────────────────────
+
+function parseSlnProjects(content: string, solutionDir: string): string[] {
+  return [
+    ...content.matchAll(/^Project\([^)]+\)\s*=\s*"[^"]*"\s*,\s*"([^"]+\.(?:cs|fs|vb)proj)"/gmu),
+  ]
+    .map((m) => m[1]?.replace(/\\/gu, "/"))
+    .filter((v): v is string => v !== undefined && v.length > 0)
+    .map((p) => (solutionDir === "" ? p : `${solutionDir}/${p}`));
+}
+
+function parseSlnxProjects(content: string, solutionDir: string): string[] {
+  return [...content.matchAll(/Path="([^"]+\.(?:cs|fs|vb)proj)"/gu)]
+    .map((m) => m[1]?.replace(/\\/gu, "/"))
+    .filter((v): v is string => v !== undefined && v.length > 0)
+    .map((p) => (solutionDir === "" ? p : `${solutionDir}/${p}`));
+}
+
+// ── Source file discovery ──────────────────────────────────────
+
+async function projectSourceFiles(root: string, project: DotNetProjectInfo): Promise<string[]> {
+  const exts = sourceExtensions[project.language];
+  const prefix = project.dir === "." ? "" : project.dir;
+  const allFiles = await walk(root, [prefix], shouldSkipDotNet);
+  const projectExts = [...projectExtensions.keys()];
+  return allFiles
+    .filter(
+      (f) => !projectExts.some((ext) => f.endsWith(ext)) && exts.some((ext) => f.endsWith(ext)),
+    )
+    .toSorted();
+}
+
+function findEntryPath(project: DotNetProjectInfo, files: string[]): string {
+  const dir = project.dir === "." ? "" : `${project.dir}/`;
+  for (const ext of sourceExtensions[project.language]) {
+    const program = `${dir}Program${ext}`;
+    if (files.includes(program)) {
+      return program;
+    }
+  }
+  return files[0] ?? `${dir}Program${sourceExtensions[project.language][0]}`;
+}
+
+function findAssociatedTests(
+  project: DotNetProjectInfo,
+  testProjects: DotNetProjectInfo[],
+  sourceCache: Map<string, string[]>,
+): SeedTestRef[] {
+  const refs: SeedTestRef[] = [];
+  for (const tp of testProjects) {
+    const baseName = tp.name.replace(/\.(Tests?|Specs?)$/u, "");
+    if (baseName !== project.name) {
+      continue;
+    }
+    const files = sourceCache.get(tp.projectFile) ?? [];
+    for (const tf of files.slice(0, 5)) {
+      refs.push({ path: tf, command: "dotnet test" });
+    }
+  }
+  return refs;
+}
+
+// ── Seed builders ──────────────────────────────────────────────
+
+function dotnetExeSeed(
+  project: DotNetProjectInfo,
+  entryPath: string,
+  sourceFiles: string[],
+  tests: SeedTestRef[],
+  testCommand: string,
+): FeatureSeed {
+  const isWeb = project.isWeb;
+  return {
+    title: isWeb ? `.NET web app ${project.name}` : `.NET console app ${project.name}`,
+    summary: isWeb
+      ? `ASP.NET Core web application at ${project.projectFile}.`
+      : `.NET executable project at ${project.projectFile}.`,
+    kind: isWeb ? "service" : "cli-command",
+    source: isWeb ? "dotnet-web" : "dotnet-console",
+    confidence: "high",
+    entryPath,
+    symbol: "Main",
+    route: null,
+    command: project.name,
+    tags: ["dotnet", project.language, isWeb ? "web" : "cli"],
+    trustBoundaries: isWeb
+      ? ["user-input", "network", "filesystem", "process-exec"]
+      : ["user-input", "filesystem", "process-exec"],
+    ownedFiles: sourceFiles.map((f) => ({ path: f, reason: "dotnet project source" })),
+    contextFiles: [
+      { path: project.projectFile, reason: "project file" },
+      ...tests.map((t) => ({ path: t.path, reason: "dotnet project test" })),
+    ],
+    tests,
+    testCommand,
+    skipNearbyTests: true,
+  };
+}
+
+function dotnetLibrarySeed(
+  project: DotNetProjectInfo,
+  entryPath: string,
+  sourceFiles: string[],
+  tests: SeedTestRef[],
+  testCommand: string,
+): FeatureSeed {
+  return {
+    title: `.NET library ${project.name}`,
+    summary: `.NET library project at ${project.projectFile} with ${sourceFiles.length} source file(s).`,
+    kind: "library",
+    source: "dotnet-library",
+    confidence: "high",
+    entryPath,
+    symbol: null,
+    route: null,
+    command: null,
+    tags: ["dotnet", project.language, "library"],
+    trustBoundaries: packageTrustBoundaries(project.name),
+    ownedFiles: sourceFiles.map((f) => ({ path: f, reason: "dotnet project source" })),
+    contextFiles: [
+      { path: project.projectFile, reason: "project file" },
+      ...tests.map((t) => ({ path: t.path, reason: "dotnet project test" })),
+    ],
+    tests,
+    testCommand,
+    skipNearbyTests: true,
+  };
+}
+
+function dotnetTestSuiteSeed(
+  project: DotNetProjectInfo,
+  testFiles: string[],
+  testCommand: string,
+): FeatureSeed {
+  return {
+    title: `.NET test suite ${project.name}`,
+    summary: `.NET test project at ${project.projectFile} with ${testFiles.length} test file(s).`,
+    kind: "test-suite",
+    source: "dotnet-test",
+    confidence: "medium",
+    entryPath: testFiles[0] ?? project.projectFile,
+    symbol: null,
+    route: null,
+    command: null,
+    tags: ["dotnet", project.language, "test"],
+    trustBoundaries: [],
+    ownedFiles: testFiles.map((f) => ({ path: f, reason: "dotnet test source" })),
+    contextFiles: [{ path: project.projectFile, reason: "project file" }],
+    testCommand,
+    skipNearbyTests: true,
+  };
+}
+
+// ── Path helpers ───────────────────────────────────────────────
+
+function directoryOf(path: string): string {
+  const lastSlash = path.lastIndexOf("/");
+  return lastSlash === -1 ? "." : path.substring(0, lastSlash);
+}
+
+function baseNameOf(path: string, ext: string): string {
+  const lastSlash = path.lastIndexOf("/");
+  const name = lastSlash === -1 ? path : path.substring(lastSlash + 1);
+  return name.endsWith(ext) ? name.substring(0, name.length - ext.length) : name;
+}
+
+function extensionOf(path: string): string {
+  const lastDot = path.lastIndexOf(".");
+  return lastDot === -1 ? "" : path.substring(lastDot);
+}

--- a/src/mappers/dotnet.ts
+++ b/src/mappers/dotnet.ts
@@ -205,14 +205,27 @@ function parseSlnProjects(content: string, solutionDir: string): string[] {
   ]
     .map((m) => m[1]?.replace(/\\/gu, "/"))
     .filter((v): v is string => v !== undefined && v.length > 0)
-    .map((p) => (solutionDir === "" ? p : `${solutionDir}/${p}`));
+    .map((p) => resolveRelativePath(solutionDir === "" ? p : `${solutionDir}/${p}`));
 }
 
 function parseSlnxProjects(content: string, solutionDir: string): string[] {
   return [...content.matchAll(/Path="([^"]+\.(?:cs|fs|vb)proj)"/gu)]
     .map((m) => m[1]?.replace(/\\/gu, "/"))
     .filter((v): v is string => v !== undefined && v.length > 0)
-    .map((p) => (solutionDir === "" ? p : `${solutionDir}/${p}`));
+    .map((p) => resolveRelativePath(solutionDir === "" ? p : `${solutionDir}/${p}`));
+}
+
+function resolveRelativePath(path: string): string {
+  const parts = path.split("/");
+  const resolved: string[] = [];
+  for (const part of parts) {
+    if (part === ".." && resolved.length > 0 && resolved.at(-1) !== "..") {
+      resolved.pop();
+    } else if (part !== "." && part.length > 0) {
+      resolved.push(part);
+    }
+  }
+  return resolved.join("/");
 }
 
 // ── Source file discovery ──────────────────────────────────────


### PR DESCRIPTION
## .NET mapper for C#, F#, and Visual Basic

### What it does

Adds a deterministic `.NET` mapper that discovers projects via `.sln` and `.slnx` solution files (with standalone fallback when no solution exists) and maps them as reviewable feature slices.

**Language support:** C# (`.csproj`), F# (`.fsproj`), Visual Basic (`.vbproj`)

**Feature types:**
- Console apps (`dotnet-console`) — `OutputType=Exe`
- ASP.NET Core web apps (`dotnet-web`) — `Sdk=Microsoft.NET.Sdk.Web`
- Libraries (`dotnet-library`) — `OutputType=Library`
- Test suites (`dotnet-test`) — detected by naming convention (`.Tests`/`.Specs` suffix) or framework packages (xUnit, NUnit, MSTest, TUnit)

**Default commands:**
- typecheck: `dotnet build`
- lint: `dotnet format --verify-no-changes`
- format: `dotnet format`
- test: `dotnet test`

### Implementation

- `src/mappers/dotnet.ts` — new mapper: solution parsing (`.sln` + `.slnx`), project file XML parsing, source file discovery, test association by name matching, `bin/`/`obj/` exclusion
- `src/detect.ts` — language detection (`csharp`, `fsharp`, `visual-basic`), package manager detection (`dotnet`), default commands
- `src/mapper.ts` — registers the mapper
- `src/mappers/config.ts` — adds `global.json`, `Directory.Build.props`, `Directory.Packages.props` as config candidates
- `docs/feature-mapping.md` — documents .NET mapping support

### Verified against real-world repositories

| Repository | Solution type | Features | Libraries | Tests | Console | Web | Time |
|---|---|---|---|---|---|---|---|
| busly-cli | `.slnx` | 4 | — | 1 | 1 | — | instant |
| RabbitMQPublishBenchmark | `.sln` | 1 | — | — | 1 | — | instant |
| xunit | `.slnx` | 22 | 20 | — | 1 | — | instant |
| rabbitmq-dotnet-client | `.sln` | 20 | 4 | 6 | 8 | — | <1s |
| azure-sdk-for-net | 18+ nested `.sln`/`.slnx` | 1066 | 559 | 446 | 51 | 6 | 8s |
| aws-sdk-net | 7+ nested `.sln` | 1345 | 877 | 455 | 7 | — | 12s |

**Quality audit performed across all repos:**
- ✅ Zero `bin/`/`obj/` path leaks in owned files, context files, tests, or entrypoints
- ✅ All entrypoint paths resolve to existing files
- ✅ Zero duplicate features (found and fixed a dedup bug where the same project appeared with different relative paths from multiple solutions — `resolveRelativePath()` normalizes `..` segments)
- ✅ Test-to-library association: 414 of 446 test suites correctly matched to their library in azure-sdk-for-net; unmatched suites are legitimate (sample projects, test frameworks, etc.)
- ✅ 8 focused test cases covering solution-based discovery, `.slnx` parsing, standalone projects, all three languages, web apps, and build artifact skipping

### Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — zero warnings/errors
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 440 passed, 1 skipped
- [x] `pnpm build` — clean
- [x] Manual verification against 6 real-world .NET repositories above
