### PR TITLE
fix(provider): support Codex in non-Git roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.1 - Unreleased
 
 - Added explicit Codex reasoning effort selection via `--reasoning-effort`, `CLAWPATCH_REASONING_EFFORT`, and provider config, with `doctor` reporting the active setting.
+- Added `--skip-git-repo-check` for Codex-backed map, review, fix, and revalidate commands so initialized non-Git roots can run Codex, thanks @im-zayan.
 - Added deterministic Express, Fastify, and Hono route mapping for Node projects, thanks @rohitjavvadi.
 - Fixed provider commands with relative `--root` paths by canonicalizing explicit roots before invoking Codex or other providers.
 - Improved `clawpatch fix` handoff context and patch-attempt changed-file auditing for dirty-worktree fixes.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Useful flags:
 - `--provider <name>`
 - `--model <name>`
 - `--reasoning-effort <none|minimal|low|medium|high|xhigh>`
+- `--skip-git-repo-check`
 - `--output <path>` / `-o <path>`
 - `--dry-run`
 - `--force`

--- a/src/app.ts
+++ b/src/app.ts
@@ -928,6 +928,7 @@ function applyProviderFlags(
       name: providerName ?? config.provider.name,
       model: model ?? config.provider.model,
       reasoningEffort: reasoningEffort ?? config.provider.reasoningEffort,
+      skipGitRepoCheck: flags["skipGitRepoCheck"] === true,
     },
   };
 }
@@ -936,6 +937,7 @@ function providerOptions(config: ReturnType<typeof applyProviderFlags>) {
   return {
     model: config.provider.model,
     reasoningEffort: config.provider.reasoningEffort,
+    skipGitRepoCheck: config.provider.skipGitRepoCheck,
   };
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -709,7 +709,10 @@ export async function fixCommand(
   const findingId = assertDefined(stringFlag(flags, "finding"), "missing --finding");
   const config = applyProviderFlags(loaded.config, flags);
   const git = await discoverGit(loaded.root);
-  const dirty = await hasSourceDirtyWorktree(loaded.root, loaded.paths.stateDir);
+  const dirty =
+    git.root === null && config.provider.skipGitRepoCheck
+      ? false
+      : await hasSourceDirtyWorktree(loaded.root, loaded.paths.stateDir);
   if (config.git.requireCleanWorktreeForFix && dirty && flags["dryRun"] !== true) {
     throw new ClawpatchError(
       "dirty worktree blocks fix; commit/stash first or use --dry-run",

--- a/src/change-audit.ts
+++ b/src/change-audit.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
-import { lstat, readlink } from "node:fs/promises";
+import { lstat, readdir, readlink } from "node:fs/promises";
 import { relative, resolve } from "node:path";
 import { runCommand } from "./exec.js";
 
@@ -13,10 +13,8 @@ export async function sourceChangedSnapshots(
   root: string,
   stateDir: string,
 ): Promise<Map<string, string> | null> {
-  const paths = await sourceChangedPaths(root, stateDir);
-  if (paths === null) {
-    return null;
-  }
+  const paths =
+    (await sourceChangedPaths(root, stateDir)) ?? (await sourceSnapshotPaths(root, stateDir));
   const snapshots = new Map<string, string>();
   for (const path of [...paths].toSorted()) {
     snapshots.set(path, await pathFingerprint(root, path));
@@ -94,6 +92,49 @@ function isStatePath(path: string, relativeStateDir: string): boolean {
     return false;
   }
   return path === relativeStateDir || path.startsWith(`${relativeStateDir}/`);
+}
+
+async function sourceSnapshotPaths(root: string, stateDir: string): Promise<Set<string>> {
+  const relativeStateDir = normalizePath(relative(root, stateDir));
+  const paths = new Set<string>();
+  await collectSnapshotPaths(root, root, relativeStateDir, paths);
+  return paths;
+}
+
+async function collectSnapshotPaths(
+  root: string,
+  dir: string,
+  relativeStateDir: string,
+  paths: Set<string>,
+): Promise<void> {
+  const entries = await readdir(dir).catch(() => []);
+  for (const entry of entries) {
+    const full = resolve(dir, entry);
+    const path = normalizePath(relative(root, full));
+    if (shouldSkipSnapshotPath(path, relativeStateDir)) {
+      continue;
+    }
+    const info = await lstat(full).catch(() => null);
+    if (info === null || info.isSymbolicLink()) {
+      continue;
+    }
+    if (info.isDirectory()) {
+      await collectSnapshotPaths(root, full, relativeStateDir, paths);
+    } else if (info.isFile()) {
+      paths.add(path);
+    }
+  }
+}
+
+function shouldSkipSnapshotPath(path: string, relativeStateDir: string): boolean {
+  return (
+    isStatePath(path, relativeStateDir) ||
+    /(^|\/)(node_modules|dist|build|coverage|\.build|\.git|\.turbo|\.next|\.vercel|\.venv(?:-[^/]+)?|venv|Pods|Carthage|SourcePackages|DerivedData|__pycache__)(\/|$)/u.test(
+      path,
+    ) ||
+    path === "target" ||
+    path.startsWith("target/")
+  );
 }
 
 function normalizePath(path: string): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -146,7 +146,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
 const commandFlags = {
   init: new Set(["force"]),
-  map: new Set(["dryRun", "source", "provider", "model", "reasoningEffort"]),
+  map: new Set(["dryRun", "source", "provider", "model", "reasoningEffort", "skipGitRepoCheck"]),
   status: new Set<string>(),
   review: new Set([
     "feature",
@@ -157,13 +157,14 @@ const commandFlags = {
     "provider",
     "model",
     "reasoningEffort",
+    "skipGitRepoCheck",
     "dryRun",
   ]),
   report: new Set(["status", "severity", "feature", "project", "category", "triage", "output"]),
   show: new Set(["finding"]),
   next: new Set(["status", "project"]),
   triage: new Set(["finding", "status", "note"]),
-  fix: new Set(["finding", "provider", "model", "reasoningEffort", "dryRun"]),
+  fix: new Set(["finding", "provider", "model", "reasoningEffort", "skipGitRepoCheck", "dryRun"]),
   revalidate: new Set([
     "finding",
     "all",
@@ -177,6 +178,7 @@ const commandFlags = {
     "provider",
     "model",
     "reasoningEffort",
+    "skipGitRepoCheck",
   ]),
   doctor: new Set(["provider", "model", "reasoningEffort"]),
   "clean-locks": new Set<string>(),
@@ -219,6 +221,7 @@ const booleanFlagNames = new Set([
   "no-color",
   "no-input",
   "dry-run",
+  "skip-git-repo-check",
   "force",
   "all",
 ]);
@@ -373,6 +376,7 @@ Flags:
   --provider <name>
   --model <name>
   --reasoning-effort <none|minimal|low|medium|high|xhigh>
+  --skip-git-repo-check
   --dry-run
   --json
   -q, --quiet
@@ -447,6 +451,7 @@ Flags:
   --provider <name>
   --model <name>
   --reasoning-effort <none|minimal|low|medium|high|xhigh>
+  --skip-git-repo-check
   --dry-run
   --json
 `);
@@ -475,6 +480,7 @@ Flags:
   --provider <name>
   --model <name>
   --reasoning-effort <none|minimal|low|medium|high|xhigh>
+  --skip-git-repo-check
   --dry-run
   --json
 `);
@@ -500,6 +506,7 @@ Flags:
   --provider <name>
   --model <name>
   --reasoning-effort <none|minimal|low|medium|high|xhigh>
+  --skip-git-repo-check
   --json
 `);
     return;

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -129,15 +129,27 @@ describe("Codex provider args", () => {
   it("passes model and reasoning effort through explicit CLI config", () => {
     const args = ["exec"];
 
-    addCodexModelArgs(args, { model: "gpt-5.5", reasoningEffort: "xhigh" });
+    addCodexModelArgs(args, {
+      model: "gpt-5.5",
+      reasoningEffort: "xhigh",
+      skipGitRepoCheck: false,
+    });
 
     expect(args).toEqual(["exec", "--model", "gpt-5.5", "-c", 'model_reasoning_effort="xhigh"']);
+  });
+
+  it("passes the Git repo check bypass to Codex when requested", () => {
+    const args = ["exec"];
+
+    addCodexModelArgs(args, { model: null, reasoningEffort: null, skipGitRepoCheck: true });
+
+    expect(args).toEqual(["exec", "--skip-git-repo-check"]);
   });
 
   it("leaves Codex defaults untouched when unset", () => {
     const args = ["exec"];
 
-    addCodexModelArgs(args, { model: null, reasoningEffort: null });
+    addCodexModelArgs(args, { model: null, reasoningEffort: null, skipGitRepoCheck: false });
 
     expect(args).toEqual(["exec"]);
   });

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -28,6 +28,7 @@ export { extractJson } from "./provider-json.js";
 export type ProviderOptions = {
   model: string | null;
   reasoningEffort: ReasoningEffort | null;
+  skipGitRepoCheck: boolean;
 };
 export type Provider = {
   name: string;
@@ -348,6 +349,9 @@ async function runCodexJson(
 }
 
 function addCodexModelArgs(args: string[], options: ProviderOptions): void {
+  if (options.skipGitRepoCheck) {
+    args.push("--skip-git-repo-check");
+  }
   if (options.model !== null) {
     args.push("--model", options.model);
   }

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -2043,6 +2043,27 @@ describe("workflow", () => {
     delete process.env["CLAWPATCH_PROVIDER"];
   });
 
+  it("allows fix in non-Git roots when the Codex Git check is explicitly skipped", async () => {
+    const root = await fixtureRoot("clawpatch-non-git-fix-skip-");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify({ name: "buggy", bin: { buggy: "src/index.ts" } }),
+    );
+    await writeFixture(root, "src/index.ts", "export const value = 'TODO_BUG';\n");
+    process.env["CLAWPATCH_PROVIDER"] = "mock";
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    const reviewed = (await reviewCommand(context, { limit: "1" })) as { next: string };
+    const finding = reviewed.next.split(" ").at(-1) ?? "";
+    const fixed = await fixCommand(context, { finding, skipGitRepoCheck: true });
+
+    expect(fixed).toMatchObject({ dryRun: false, status: "applied" });
+    delete process.env["CLAWPATCH_PROVIDER"];
+  });
+
   it("fails fix when configured validation fails", async () => {
     const root = await fixtureRoot("clawpatch-validation-fail-");
     await runCommand(

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -2058,9 +2058,22 @@ describe("workflow", () => {
     await mapCommand(context);
     const reviewed = (await reviewCommand(context, { limit: "1" })) as { next: string };
     const finding = reviewed.next.split(" ").at(-1) ?? "";
+    const paths = statePaths(join(root, ".clawpatch"));
+    const feature = (await readFeatures(paths))[0];
+    await writeFeature(paths, {
+      ...feature!,
+      tests: [
+        {
+          path: "src/index.test.ts",
+          command: "node -e \"require('node:fs').appendFileSync('src/index.ts','// fixed\\n')\"",
+        },
+      ],
+    });
     const fixed = await fixCommand(context, { finding, skipGitRepoCheck: true });
+    const patches = await readPatchAttempts(paths);
 
-    expect(fixed).toMatchObject({ dryRun: false, status: "applied" });
+    expect(fixed).toMatchObject({ dryRun: false, status: "applied", filesChanged: 1 });
+    expect(patches[0]?.filesChanged).toEqual(["src/index.ts"]);
     delete process.env["CLAWPATCH_PROVIDER"];
   });
 

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -230,6 +230,9 @@ describe("workflow", () => {
       dryRun: true,
       reasoningEffort: "xhigh",
     });
+    expect(parseArgs(["review", "--skip-git-repo-check"]).flags).toMatchObject({
+      skipGitRepoCheck: true,
+    });
     expect(parseArgs(["fix", "--finding", "f", "--dry-run"]).flags).toMatchObject({
       dryRun: true,
       finding: "f",
@@ -1167,13 +1170,13 @@ describe("workflow", () => {
     const first = await mapWithSource(root, project, [], heuristic, {
       source: "agent",
       provider,
-      providerOptions: { model: null, reasoningEffort: null },
+      providerOptions: { model: null, reasoningEffort: null, skipGitRepoCheck: false },
     });
     title = "Background worker package";
     const second = await mapWithSource(root, project, first.features, heuristic, {
       source: "agent",
       provider,
-      providerOptions: { model: null, reasoningEffort: null },
+      providerOptions: { model: null, reasoningEffort: null, skipGitRepoCheck: false },
     });
 
     expect(first.features).toHaveLength(1);


### PR DESCRIPTION
AI-assisted.

## What

Adds an explicit `--skip-git-repo-check` passthrough for Codex-backed provider commands.

## Why

`clawpatch` can initialize and map non-Git project roots, but `codex exec` refuses to run there unless `--skip-git-repo-check` is provided. This gives users an explicit opt-in escape hatch.

## Validation

- `pnpm test src/provider.test.ts src/workflow.test.ts`
- `pnpm typecheck`

## Real behavior proof

Before, `clawpatch review --limit 10` failed from a non-Git project root with:

```text
codex provider failed: Not inside a trusted directory and --skip-git-repo-check was not specified.
```

After, the Codex provider command includes `--skip-git-repo-check` when the clawpatch flag is passed.

I understand this change: it only adds an explicit CLI passthrough to Codex provider invocations and leaves default behavior unchanged.