### PR TITLE
Fix docs search and mobile nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `clawpatch review --prompt-file` to append extra reviewer guidance from a file or stdin, thanks @dpdanpittman.
 - Added deterministic Express, Fastify, and Hono route mapping for Node projects, thanks @rohitjavvadi.
 - Fixed Express route mapping to recognize aliased Router factories from imports, CommonJS destructuring, and direct assignments, thanks @rohitjavvadi.
+- Fixed docs search matching, empty-state display, and mobile sidebar navigation, thanks @cloudsolutiongmbh.
 - Added conservative Django `urls.py` route mapping for `path`, `re_path`, and legacy `url` declarations, thanks @rohitjavvadi.
 - Fixed provider commands with relative `--root` paths by canonicalizing explicit roots before invoking Codex or other providers.
 - Added first-pass Elixir Mix/Phoenix mapping for project metadata, contexts, Phoenix web slices, runtime config, Ecto migrations, project scripts, ExUnit tests, and Mix validation defaults, thanks @tears-mysthrala.

--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -82,7 +82,6 @@ describe("runCommandArgs", () => {
         childScript,
         [
           "import { writeFileSync } from 'node:fs';",
-          `writeFileSync(${JSON.stringify(ready)}, 'ready');`,
           "process.on('SIGTERM', () => {});",
           `setTimeout(() => writeFileSync(${JSON.stringify(marker)}, 'alive'), 1000);`,
           "setInterval(() => {}, 1000);",
@@ -92,14 +91,12 @@ describe("runCommandArgs", () => {
       await writeFile(
         parentScript,
         [
-          "import { existsSync } from 'node:fs';",
+          "import { writeFileSync } from 'node:fs';",
           "import { spawn } from 'node:child_process';",
-          `spawn(process.execPath, [${JSON.stringify(childScript)}], { stdio: ['ignore', 'inherit', 'inherit'] });`,
-          "const started = Date.now();",
-          `const ready = ${JSON.stringify(ready)};`,
-          "const timer = setInterval(() => {",
-          "  if (existsSync(ready) || Date.now() - started > 1000) clearInterval(timer);",
-          "}, 10);",
+          `const child = spawn(process.execPath, [${JSON.stringify(childScript)}], { stdio: ['ignore', 'inherit', 'inherit'] });`,
+          "child.on('error', () => {});",
+          `writeFileSync(${JSON.stringify(ready)}, 'ready');`,
+          "setInterval(() => {}, 1000);",
         ].join("\n"),
         "utf8",
       );

--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -83,6 +83,7 @@ describe("runCommandArgs", () => {
         [
           "import { writeFileSync } from 'node:fs';",
           "process.on('SIGTERM', () => {});",
+          "process.send?.('ready');",
           `setTimeout(() => writeFileSync(${JSON.stringify(marker)}, 'alive'), 1000);`,
           "setInterval(() => {}, 1000);",
         ].join("\n"),
@@ -93,9 +94,9 @@ describe("runCommandArgs", () => {
         [
           "import { writeFileSync } from 'node:fs';",
           "import { spawn } from 'node:child_process';",
-          `const child = spawn(process.execPath, [${JSON.stringify(childScript)}], { stdio: ['ignore', 'inherit', 'inherit'] });`,
+          `const child = spawn(process.execPath, [${JSON.stringify(childScript)}], { stdio: ['ignore', 'inherit', 'inherit', 'ipc'] });`,
           "child.on('error', () => {});",
-          `writeFileSync(${JSON.stringify(ready)}, 'ready');`,
+          `child.on('message', (message) => { if (message === 'ready') writeFileSync(${JSON.stringify(ready)}, 'ready'); });`,
           "setInterval(() => {}, 1000);",
         ].join("\n"),
         "utf8",

--- a/website/index.html
+++ b/website/index.html
@@ -111,6 +111,11 @@
       * {
         box-sizing: border-box;
       }
+
+      [hidden] {
+        display: none !important;
+      }
+
       html {
         scroll-behavior: smooth;
         scroll-padding-top: 24px;
@@ -404,6 +409,12 @@
       .search input:focus {
         border-color: var(--accent);
         box-shadow: 0 0 0 4px var(--accent-soft);
+      }
+
+      .search-empty {
+        color: var(--muted);
+        font-size: 0.85rem;
+        margin: -12px 0 20px;
       }
 
       nav section {
@@ -780,6 +791,46 @@
           height: auto;
           transform: none;
           box-shadow: none;
+          padding: 18px 20px;
+        }
+
+        .sidebar-head {
+          margin-bottom: 14px;
+        }
+
+        .search {
+          margin-bottom: 14px;
+        }
+
+        .search-empty {
+          margin: -4px 0 12px;
+        }
+
+        nav {
+          display: flex;
+          gap: 8px;
+          margin: 0 -20px;
+          overflow-x: auto;
+          padding: 0 20px 4px;
+          scrollbar-width: thin;
+        }
+
+        nav section {
+          display: flex;
+          flex: 0 0 auto;
+          gap: 8px;
+          margin: 0;
+        }
+
+        nav h2 {
+          display: none;
+        }
+
+        .nav-link {
+          background: var(--paper);
+          border: 1px solid var(--line);
+          flex: 0 0 auto;
+          white-space: nowrap;
         }
 
         main {
@@ -971,6 +1022,7 @@
           <span>Search</span>
           <input id="doc-search" type="search" placeholder="init, review, fix" />
         </label>
+        <p id="search-empty" class="search-empty" hidden>No matching sections.</p>
         <nav>
           <section>
             <h2>Getting Started</h2>
@@ -1393,17 +1445,31 @@
 
       // Search functionality
       const input = document.getElementById("doc-search");
+      const emptyState = document.getElementById("search-empty");
       input?.addEventListener("input", () => {
         const q = input.value.trim().toLowerCase();
+        let anyResult = false;
         document.querySelectorAll("nav section").forEach((sec) => {
+          const sectionLabel = sec.querySelector("h2")?.textContent?.toLowerCase() || "";
           let any = false;
           sec.querySelectorAll(".nav-link").forEach((a) => {
-            const m = !q || a.textContent.toLowerCase().includes(q);
-            a.style.display = m ? "block" : "none";
+            const haystack = [
+              a.textContent,
+              a.getAttribute("href"),
+              a.getAttribute("aria-label"),
+              sectionLabel,
+            ]
+              .filter(Boolean)
+              .join(" ")
+              .toLowerCase();
+            const m = !q || haystack.includes(q);
+            a.hidden = !m;
             if (m) any = true;
           });
-          sec.style.display = any ? "block" : "none";
+          sec.hidden = !any;
+          if (any) anyResult = true;
         });
+        if (emptyState) emptyState.hidden = anyResult || !q;
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- make website search match section labels and hrefs, with a clear empty state
- keep hidden search results hidden on mobile while turning the sidebar nav into a compact horizontal rail
- make the timeout descendant-kill test deterministic by marking readiness in the parent after spawning the child

## Validation
- pnpm run typecheck
- pnpm run lint
- pnpm run format:check
- pnpm test
- gstack browse against local website: search config/no-match, mobile 390px, dark mode, no console errors
- anchor check: 13 anchors, 0 missing