### PR TITLE
fix(mapper): recognize bun text lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.1 - Unreleased
 
 - Fixed Express route mapping for aliased Router imports that follow block comment banners, thanks @rohitjavvadi.
+- Fixed Bun package-manager detection to recognize the text `bun.lock` lockfile, thanks @austinm911.
 
 ## 0.3.0 - 2026-05-18
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -289,6 +289,7 @@ async function detectPackageManagers(root: string): Promise<string[]> {
     ["pnpm", "pnpm-lock.yaml"],
     ["npm", "package-lock.json"],
     ["yarn", "yarn.lock"],
+    ["bun", "bun.lock"],
     ["bun", "bun.lockb"],
   ];
   for (const [name, file] of nodeChecks) {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -327,6 +327,53 @@ describe("mapFeatures", () => {
     ]);
   });
 
+  it("uses bun workspace commands when the root has a text bun lockfile", async () => {
+    const root = await fixtureRoot("clawpatch-task-graph-bun-lock-");
+    await writeFixture(
+      root,
+      "package.json",
+      JSON.stringify(
+        {
+          name: "workspace-root",
+          packageManager: "bun@1.3.3",
+          workspaces: ["apps/*"],
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(root, "bun.lock", "");
+    await writeFixture(
+      root,
+      "apps/web/package.json",
+      JSON.stringify(
+        {
+          name: "web",
+          scripts: { test: "vitest run", build: "next build" },
+          dependencies: { next: "1.0.0" },
+        },
+        null,
+        2,
+      ),
+    );
+    await writeFixture(
+      root,
+      "apps/web/app/page.tsx",
+      "export default function Page() { return null; }\n",
+    );
+    await writeFixture(root, "apps/web/app/page.test.tsx", "test('page', () => {});\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const route = result.features.find((feature) => feature.title === "web route /");
+
+    expect(project.detected.packageManagers).toContain("bun");
+    expect(project.detected.commands.test).toBeNull();
+    expect(route?.tests).toEqual([
+      { path: "apps/web/app/page.test.tsx", command: "bun --cwd apps/web run test" },
+    ]);
+  });
+
   it("keeps Nx target commands on the workspace package manager", async () => {
     const root = await fixtureRoot("clawpatch-map-nx-root-package-manager-");
     await writeFixture(
@@ -3236,7 +3283,7 @@ describe("mapFeatures", () => {
 
   it("uses bun run for root React package scripts", async () => {
     const root = await fixtureRoot("clawpatch-react-root-bun-");
-    await writeFixture(root, "bun.lockb", "");
+    await writeFixture(root, "bun.lock", "");
     await writeFixture(
       root,
       "package.json",

--- a/src/mappers/projects.ts
+++ b/src/mappers/projects.ts
@@ -125,6 +125,7 @@ async function nodePackageManagerForPackage(
     "pnpm-lock.yaml",
     "pnpm-workspace.yaml",
     "yarn.lock",
+    "bun.lock",
     "bun.lockb",
     "package-lock.json",
   ]) {
@@ -662,7 +663,7 @@ async function detectNodePackageManager(root: string): Promise<string> {
   if (await pathExists(join(root, "yarn.lock"))) {
     return "yarn";
   }
-  if (await pathExists(join(root, "bun.lockb"))) {
+  if ((await pathExists(join(root, "bun.lock"))) || (await pathExists(join(root, "bun.lockb")))) {
     return "bun";
   }
   return "npm";

--- a/src/mappers/react.ts
+++ b/src/mappers/react.ts
@@ -259,6 +259,7 @@ async function hasPackageManagerMarker(root: string, packageRoot: string): Promi
     (await pathExists(join(root, packageRoot, "pnpm-workspace.yaml"))) ||
     (await pathExists(join(root, packageRoot, "package-lock.json"))) ||
     (await pathExists(join(root, packageRoot, "yarn.lock"))) ||
+    (await pathExists(join(root, packageRoot, "bun.lock"))) ||
     (await pathExists(join(root, packageRoot, "bun.lockb")))
   );
 }

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -279,7 +279,7 @@ export async function detectNodePackageManager(root: string): Promise<string> {
   if (await pathExists(join(root, "yarn.lock"))) {
     return "yarn";
   }
-  if (await pathExists(join(root, "bun.lockb"))) {
+  if ((await pathExists(join(root, "bun.lock"))) || (await pathExists(join(root, "bun.lockb")))) {
     return "bun";
   }
   return "npm";


### PR DESCRIPTION
## Summary
- recognize Bun's current text lockfile, bun.lock, anywhere clawpatch detects Bun package managers
- keep legacy bun.lockb detection in place
- add a Bun workspace regression test that expects package-local validation commands to use bun --cwd

## Validation
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test src/mapper.test.ts
- pnpm build