### PR TITLE
Improve opencode malformed JSON diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.1 - Unreleased
 
+- Improved OpenCode malformed JSON diagnostics with output length, event kinds, and a bounded preview, thanks @rohitjavvadi.
 - Fixed Express route mapping for aliased Router imports that follow block comment banners, thanks @rohitjavvadi.
 - Fixed Bun package-manager detection to recognize the text `bun.lock` lockfile, thanks @austinm911.
 

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { ClawpatchError } from "./errors.js";
 import { __testing, extractJson, providerByName } from "./provider.js";
+import { safeProviderPreview } from "./provider-json.js";
 import { revalidateOutputSchema, reviewOutputSchema } from "./types.js";
 
 // eslint-disable-next-line no-underscore-dangle
@@ -53,6 +54,10 @@ function expectMalformed(fn: () => unknown, message: RegExp): void {
     return;
   }
   throw new Error("expected malformed-output");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 describe("extractJson", () => {
@@ -482,6 +487,46 @@ describe("extractOpencodeJson", () => {
     const stdout = JSON.stringify({ type: "step_finish", part: { reason: "stop" } });
 
     expectMalformed(() => extractOpencodeJson(stdout), /no extractable text.*step_finish/u);
+  });
+
+  it("treats whitespace-only opencode text as no extractable text", () => {
+    const stdout = [
+      JSON.stringify({ type: "text", part: { text: " \n\t " } }),
+      JSON.stringify({ type: "step_finish", part: { reason: "stop" } }),
+    ].join("\n");
+
+    expectMalformed(() => extractOpencodeJson(stdout), /no extractable text.*text, step_finish/u);
+  });
+
+  it("throws malformed-output with a preview when opencode text is unparsable", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "text",
+        part: { text: '{"findings": [' },
+      }),
+      JSON.stringify({ type: "step_finish", part: { reason: "stop" } }),
+    ].join("\n");
+
+    expectMalformed(
+      () => extractOpencodeJson(stdout),
+      /unparsable JSON.*text chars=14.*observed event kinds: \[text, step_finish\].*output preview: \{"findings": \[/u,
+    );
+  });
+
+  it("bounds the opencode unparsable text preview", () => {
+    const text = `{"findings":["${"x".repeat(300)}`;
+    const stdout = JSON.stringify({
+      type: "text",
+      part: { text },
+    });
+    const preview = safeProviderPreview(text);
+
+    expect(preview.length).toBe(200);
+
+    expectMalformed(
+      () => extractOpencodeJson(stdout),
+      new RegExp(`output preview: ${escapeRegExp(preview)}\\)`, "u"),
+    );
   });
 
   it("throws provider-failure for opencode error events", () => {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -630,7 +630,13 @@ export function extractOpencodeJson(stdout: string): unknown {
   }
   const parsed = extractJson(combined);
   if (parsed === null) {
-    throw new ClawpatchError("opencode provider produced unparsable JSON", 8, "malformed-output");
+    throw new ClawpatchError(
+      `opencode provider produced unparsable JSON ` +
+        `(text chars=${combined.length}, observed event kinds: ` +
+        `[${[...observedKinds].join(", ")}], output preview: ${safeProviderPreview(combined)})`,
+      8,
+      "malformed-output",
+    );
   }
   return parsed;
 }


### PR DESCRIPTION
## Summary

This improves the opencode provider error when it returns text that cannot be parsed as JSON. Instead of only saying the output was unparsable, the error now includes the text length, the opencode event kinds seen, and a short bounded preview so the failure is easier to debug without dumping the full provider output.

I also added regression tests for malformed output, whitespace-only output, and preview truncation.

Fixes #71

## Testing

Ran formatting, lint, TypeScript checks, the focused provider tests, and the full test suite locally.
