### PR TITLE
fix(provider): partition invalid review findings instead of failing the whole feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `clawpatch open-pr --patch <id>` to turn an applied patch attempt into an explicit GitHub pull request.
 - Added review prompt provenance and budget accounting for included files, omitted files, prompt bytes, and approximate tokens.
 - Hardened review ingestion so provider findings must cite included files with valid line ranges and matching evidence quotes.
+- Fixed provider review to preserve valid findings when a sibling finding fails per-finding schema validation. Previously a single bad enum value caused the whole feature to lose every finding via a strict `reviewOutputSchema.parse` throw. Dropped findings are now recorded in `run.errors` with `code: "schema-drop"` and do not fail the run.
 - Fixed `clawpatch open-pr` so repositories without default-branch metadata use a dedicated patch branch and let GitHub choose the PR base.
 - Fixed `clawpatch open-pr` retries to push the recorded patch commit instead of any later local branch tip.
 - Fixed first-time `clawpatch open-pr` branch creation to start from the recorded patch base.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added review prompt provenance and budget accounting for included files, omitted files, prompt bytes, and approximate tokens.
 - Hardened review ingestion so provider findings must cite included files with valid line ranges and matching evidence quotes.
 - Fixed provider review to preserve valid findings when a sibling finding fails per-finding schema validation. Previously a single bad enum value caused the whole feature to lose every finding via a strict `reviewOutputSchema.parse` throw. Dropped findings are now recorded in `run.errors` with `code: "schema-drop"` and do not fail the run.
+- Fixed review evidence validation to drop only the offending finding when a quote, line range, or evidence file is rejected by `validateReviewOutput`, instead of failing the whole feature. Dropped findings are recorded in `run.errors` with `code: "validation-drop"` and do not fail the run.
 - Fixed `clawpatch open-pr` so repositories without default-branch metadata use a dedicated patch branch and let GitHub choose the PR base.
 - Fixed `clawpatch open-pr` retries to push the recorded patch commit instead of any later local branch tip.
 - Fixed first-time `clawpatch open-pr` branch creation to start from the recorded patch base.

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,7 +22,7 @@ import { stableId, runId } from "./id.js";
 import { mapWithSource } from "./agent-mapper.js";
 import { mapFeatures } from "./mapper.js";
 import { emitProgress } from "./progress.js";
-import { providerByName } from "./provider.js";
+import { providerByName, type DroppedFinding } from "./provider.js";
 import { buildFixPrompt, buildReviewPromptBundle, buildRevalidatePrompt } from "./prompt.js";
 import type { ReviewMode, ReviewPromptManifest } from "./prompt.js";
 import {
@@ -343,6 +343,15 @@ export async function reviewCommand(
             allowNonPendingFeatureReview: stringFlag(flags, "feature") !== undefined,
           });
           findingIds.push(...reviewed.findingIds);
+          for (const dropped of reviewed.droppedFindings) {
+            errors.push({
+              message:
+                `dropped 1 finding from feature ${feature.featureId} ` +
+                `at ${dropped.path.join(".")}: ${dropped.message}`,
+              code: "schema-drop",
+              error: null,
+            });
+          }
         } catch (error: unknown) {
           errors.push({
             message: error instanceof Error ? error.message : String(error),
@@ -353,7 +362,8 @@ export async function reviewCommand(
       }
     }),
   );
-  if (errors.length > 0) {
+  const fatalErrors = errors.filter((entry) => entry.code !== "schema-drop");
+  if (fatalErrors.length > 0) {
     await writeRun(loaded.paths, {
       ...run,
       status: "failed",
@@ -363,15 +373,16 @@ export async function reviewCommand(
     });
     emitProgress(context, "review", "failed", {
       run: currentRunId,
-      errors: errors.length,
+      errors: fatalErrors.length,
     });
-    throw errors[0]?.error ?? new ClawpatchError("review failed", 1, "review-failed");
+    throw fatalErrors[0]?.error ?? new ClawpatchError("review failed", 1, "review-failed");
   }
   const finished: RunRecord = {
     ...run,
     status: "completed",
     finishedAt: nowIso(),
     findingIds,
+    errors: errors.map(({ message, code }) => ({ message, code })),
   };
   await writeRun(loaded.paths, finished);
   emitProgress(context, "review", "done", {
@@ -635,7 +646,9 @@ type ReviewFeatureOptions = {
   allowNonPendingFeatureReview: boolean;
 };
 
-async function reviewFeature(options: ReviewFeatureOptions): Promise<{ findingIds: string[] }> {
+async function reviewFeature(
+  options: ReviewFeatureOptions,
+): Promise<{ findingIds: string[]; droppedFindings: DroppedFinding[] }> {
   const {
     context,
     loaded,
@@ -680,12 +693,13 @@ async function reviewFeature(options: ReviewFeatureOptions): Promise<{ findingId
       reviewPrompt.prompt,
       providerOptions(config),
     );
+    const droppedFindings: DroppedFinding[] = providerOutput.droppedFindings;
     const reviewOutput = {
-      ...providerOutput,
       findings: reviewFindingsForMode(providerOutput.findings, mode).slice(
         0,
         config.review.maxFindingsPerFeature,
       ),
+      inspected: providerOutput.inspected,
     };
     const output = await validateReviewOutput(
       loaded.root,
@@ -735,7 +749,7 @@ async function reviewFeature(options: ReviewFeatureOptions): Promise<{ findingId
       findings: findingIds.length,
       elapsed: `${Math.round((Date.now() - started) / 1000)}s`,
     });
-    return { findingIds };
+    return { findingIds, droppedFindings };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     if (locked !== null) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,7 +32,7 @@ import {
   renderFindingDetail,
   renderReport,
 } from "./reporting.js";
-import { validateReviewOutput } from "./review-validation.js";
+import { validateReviewOutputPartitioned } from "./review-validation.js";
 import {
   filterFeaturesByChangedFiles,
   filterFeaturesByProject,
@@ -344,11 +344,12 @@ export async function reviewCommand(
           });
           findingIds.push(...reviewed.findingIds);
           for (const dropped of reviewed.droppedFindings) {
+            const code = dropped.layer === "validation" ? "validation-drop" : "schema-drop";
             errors.push({
               message:
                 `dropped 1 finding from feature ${feature.featureId} ` +
                 `at ${dropped.path.join(".")}: ${dropped.message}`,
-              code: "schema-drop",
+              code,
               error: null,
             });
           }
@@ -362,7 +363,9 @@ export async function reviewCommand(
       }
     }),
   );
-  const fatalErrors = errors.filter((entry) => entry.code !== "schema-drop");
+  const fatalErrors = errors.filter(
+    (entry) => entry.code !== "schema-drop" && entry.code !== "validation-drop",
+  );
   if (fatalErrors.length > 0) {
     await writeRun(loaded.paths, {
       ...run,
@@ -693,7 +696,8 @@ async function reviewFeature(
       reviewPrompt.prompt,
       providerOptions(config),
     );
-    const droppedFindings: DroppedFinding[] = providerOutput.droppedFindings;
+    // Layer 1 drops: per-finding schema violations from parseReviewOutput.
+    const droppedFindings: DroppedFinding[] = [...providerOutput.droppedFindings];
     const reviewOutput = {
       findings: reviewFindingsForMode(providerOutput.findings, mode).slice(
         0,
@@ -701,14 +705,18 @@ async function reviewFeature(
       ),
       inspected: providerOutput.inspected,
     };
-    const output = await validateReviewOutput(
+    // Layer 2 drops: per-finding evidence validation (line ranges, quotes,
+    // included files). Partition so a single bad finding doesn't lose the
+    // whole feature.
+    const validated = await validateReviewOutputPartitioned(
       loaded.root,
       lockedFeature,
       config,
       reviewPrompt.manifest,
       reviewOutput,
     );
-    const records = output.findings.map((finding) =>
+    droppedFindings.push(...validated.droppedFindings);
+    const records = validated.findings.map((finding) =>
       findingFromOutput(finding, lockedFeature.featureId, currentRunId),
     );
     const findingIds: string[] = [];

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -14,9 +14,27 @@ const {
   extractOpencodeJson,
   parseAcpxAgent,
   parseCodexJson,
+  parseReviewOutput,
   piThinkingLevel,
   providerJsonSchema,
 } = __testing;
+
+function makeFinding(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    title: "Sample finding",
+    category: "bug",
+    severity: "medium",
+    confidence: "high",
+    evidence: [],
+    reasoning: "Sample reasoning.",
+    reproduction: null,
+    recommendation: "Sample recommendation.",
+    whyTestsDoNotAlreadyCoverThis: "Tests do not encode this case.",
+    suggestedRegressionTest: null,
+    minimumFixScope: "Touch only the offending line.",
+    ...overrides,
+  };
+}
 
 function updateEnvelope(update: object): string {
   return JSON.stringify({
@@ -552,6 +570,85 @@ describe("extractOpencodeJson", () => {
       return;
     }
     throw new Error("expected provider auth failure");
+  });
+});
+
+describe("parseReviewOutput", () => {
+  it("preserves all findings when every finding is valid (fast path)", () => {
+    const output = {
+      findings: [
+        makeFinding({ title: "first", category: "bug" }),
+        makeFinding({ title: "second", category: "security" }),
+        makeFinding({ title: "third", category: "performance" }),
+      ],
+      inspected: { files: ["src/a.ts"], symbols: [], notes: [] },
+    };
+
+    const result = parseReviewOutput(output);
+
+    expect(result.findings).toHaveLength(3);
+    expect(result.findings.map((f) => f.title)).toEqual(["first", "second", "third"]);
+    expect(result.droppedFindings).toEqual([]);
+    expect(result.inspected.files).toEqual(["src/a.ts"]);
+  });
+
+  it("keeps valid siblings when one finding has an invalid category", () => {
+    const output = {
+      findings: [
+        makeFinding({ title: "first", category: "bug" }),
+        makeFinding({ title: "second", category: "security" }),
+        makeFinding({ title: "third", category: "quality" }), // invalid enum value
+        makeFinding({ title: "fourth", category: "performance" }),
+      ],
+      inspected: { files: [], symbols: [], notes: [] },
+    };
+
+    const result = parseReviewOutput(output);
+
+    expect(result.findings).toHaveLength(3);
+    expect(result.findings.map((f) => f.title)).toEqual(["first", "second", "fourth"]);
+    expect(result.droppedFindings).toHaveLength(1);
+    const dropped = result.droppedFindings[0]!;
+    expect(dropped.path[0]).toBe("findings");
+    expect(dropped.path[1]).toBe(2);
+    expect(dropped.path).toContain("category");
+    expect(dropped.message).toBeTypeOf("string");
+    expect(dropped.sample).toContain("quality");
+    expect(dropped.sample.length).toBeLessThanOrEqual(200);
+  });
+
+  it("throws ClawpatchError when findings is not an array", () => {
+    const output = {
+      findings: "not-an-array",
+      inspected: { files: [], symbols: [], notes: [] },
+    };
+
+    try {
+      parseReviewOutput(output);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ClawpatchError);
+      expect((err as ClawpatchError).code).toBe("malformed-output");
+      expect((err as ClawpatchError).exitCode).toBe(8);
+      expect((err as Error).message).toMatch(/findings/u);
+      return;
+    }
+    throw new Error("expected parseReviewOutput to throw on non-array findings");
+  });
+
+  it("truncates oversized samples to 200 characters", () => {
+    const longTitle = "x".repeat(500);
+    const output = {
+      findings: [
+        makeFinding({ title: longTitle, category: "quality" }), // invalid → dropped
+      ],
+      inspected: { files: [], symbols: [], notes: [] },
+    };
+
+    const result = parseReviewOutput(output);
+
+    expect(result.droppedFindings).toHaveLength(1);
+    expect(result.droppedFindings[0]!.sample.length).toBeLessThanOrEqual(200);
+    expect(result.droppedFindings[0]!.sample.endsWith("...")).toBe(true);
   });
 });
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 import { runCommandArgs } from "./exec.js";
 import { ClawpatchError } from "./errors.js";
 import {
@@ -14,10 +15,12 @@ import { extractJson, parseCodexJson, safeProviderPreview } from "./provider-jso
 import {
   AgentMapOutput,
   FixPlanOutput,
-  ReviewOutput,
+  ReviewFinding,
   RevalidateOutput,
   agentMapOutputSchema,
   fixPlanOutputSchema,
+  reviewFindingSchema,
+  reviewInspectedSchema,
   reviewOutputSchema,
   revalidateOutputSchema,
   type ReasoningEffort,
@@ -30,11 +33,98 @@ export type ProviderOptions = {
   reasoningEffort: ReasoningEffort | null;
   skipGitRepoCheck: boolean;
 };
+
+export type DroppedFinding = {
+  path: (string | number)[];
+  message: string;
+  sample: string;
+};
+
+export type PartitionedReviewOutput = {
+  findings: ReviewFinding[];
+  inspected: z.infer<typeof reviewInspectedSchema>;
+  droppedFindings: DroppedFinding[];
+};
+
+const reviewContainerSchema = z.object({
+  findings: z.array(z.unknown()),
+  inspected: reviewInspectedSchema,
+});
+
+function truncateSample(value: unknown): string {
+  let text: string;
+  try {
+    text = JSON.stringify(value);
+  } catch {
+    text = String(value);
+  }
+  if (text === undefined) {
+    text = String(value);
+  }
+  return text.length > 200 ? `${text.slice(0, 197)}...` : text;
+}
+
+export function parseReviewOutput(output: unknown): PartitionedReviewOutput {
+  // Fast path: whole-document parse on success.
+  const whole = reviewOutputSchema.safeParse(output);
+  if (whole.success) {
+    return {
+      findings: whole.data.findings,
+      inspected: whole.data.inspected,
+      droppedFindings: [],
+    };
+  }
+
+  // Fallback: validate container shape, partition findings element-by-element.
+  const container = reviewContainerSchema.safeParse(output);
+  if (!container.success) {
+    // Container shape is fundamentally wrong (e.g. findings is not an array, or
+    // inspected is missing). Preserve today's throw contract via ClawpatchError
+    // so callers see a single clear malformed-output failure.
+    const issue = container.error.issues[0];
+    const where =
+      issue?.path
+        .map((segment) => (typeof segment === "symbol" ? segment.toString() : segment))
+        .join(".") ?? "<root>";
+    const detail = issue?.message ?? "invalid review output shape";
+    throw new ClawpatchError(
+      `provider review output is malformed at ${where}: ${detail}`,
+      8,
+      "malformed-output",
+    );
+  }
+
+  const validFindings: ReviewFinding[] = [];
+  const droppedFindings: DroppedFinding[] = [];
+  container.data.findings.forEach((candidate, idx) => {
+    const result = reviewFindingSchema.safeParse(candidate);
+    if (result.success) {
+      validFindings.push(result.data);
+      return;
+    }
+    const issue = result.error.issues[0];
+    const issuePath = (issue?.path ?? []).map((segment) =>
+      typeof segment === "symbol" ? segment.toString() : segment,
+    );
+    droppedFindings.push({
+      path: ["findings", idx, ...issuePath],
+      message: issue?.message ?? "invalid finding shape",
+      sample: truncateSample(candidate),
+    });
+  });
+
+  return {
+    findings: validFindings,
+    inspected: container.data.inspected,
+    droppedFindings,
+  };
+}
+
 export type Provider = {
   name: string;
   check(root: string): Promise<string>;
   map(root: string, prompt: string, options: ProviderOptions): Promise<AgentMapOutput>;
-  review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput>;
+  review(root: string, prompt: string, options: ProviderOptions): Promise<PartitionedReviewOutput>;
   fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput>;
   revalidate(root: string, prompt: string, options: ProviderOptions): Promise<RevalidateOutput>;
 };
@@ -77,9 +167,13 @@ const codexProvider: Provider = {
     const output = await runCodexJson(root, prompt, options, agentMapJsonSchema);
     return agentMapOutputSchema.parse(output);
   },
-  async review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput> {
+  async review(
+    root: string,
+    prompt: string,
+    options: ProviderOptions,
+  ): Promise<PartitionedReviewOutput> {
     const output = await runCodexJson(root, prompt, options, reviewJsonSchema);
-    return reviewOutputSchema.parse(output);
+    return parseReviewOutput(output);
   },
   async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
     const output = await runCodexJson(root, prompt, options, fixPlanJsonSchema, "workspace-write");
@@ -108,9 +202,13 @@ const opencodeProvider: Provider = {
     const output = await runOpencodeJson(root, prompt, options.model, agentMapJsonSchema, true);
     return agentMapOutputSchema.parse(output);
   },
-  async review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput> {
+  async review(
+    root: string,
+    prompt: string,
+    options: ProviderOptions,
+  ): Promise<PartitionedReviewOutput> {
     const output = await runOpencodeJson(root, prompt, options.model, reviewJsonSchema, true);
-    return reviewOutputSchema.parse(output);
+    return parseReviewOutput(output);
   },
   async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
     const output = await runOpencodeJson(root, prompt, options.model, fixPlanJsonSchema, false);
@@ -147,9 +245,13 @@ const acpxProvider: Provider = {
     const output = await runAcpxJson(root, prompt, options.model, agentMapJsonSchema, "read");
     return agentMapOutputSchema.parse(output);
   },
-  async review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput> {
+  async review(
+    root: string,
+    prompt: string,
+    options: ProviderOptions,
+  ): Promise<PartitionedReviewOutput> {
     const output = await runAcpxJson(root, prompt, options.model, reviewJsonSchema, "read");
-    return reviewOutputSchema.parse(output);
+    return parseReviewOutput(output);
   },
   async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
     const output = await runAcpxJson(root, prompt, options.model, fixPlanJsonSchema, "approve");
@@ -178,9 +280,13 @@ const grokProvider: Provider = {
     const output = await runGrokJson(root, prompt, options.model, agentMapJsonSchema, true);
     return agentMapOutputSchema.parse(output);
   },
-  async review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput> {
+  async review(
+    root: string,
+    prompt: string,
+    options: ProviderOptions,
+  ): Promise<PartitionedReviewOutput> {
     const output = await runGrokJson(root, prompt, options.model, reviewJsonSchema, true);
-    return reviewOutputSchema.parse(output);
+    return parseReviewOutput(output);
   },
   async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
     const output = await runGrokJson(root, prompt, options.model, fixPlanJsonSchema, false);
@@ -211,9 +317,13 @@ const piProvider: Provider = {
     const output = await runPiJson(root, prompt, options, agentMapJsonSchema, true);
     return agentMapOutputSchema.parse(output);
   },
-  async review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput> {
+  async review(
+    root: string,
+    prompt: string,
+    options: ProviderOptions,
+  ): Promise<PartitionedReviewOutput> {
     const output = await runPiJson(root, prompt, options, reviewJsonSchema, true);
-    return reviewOutputSchema.parse(output);
+    return parseReviewOutput(output);
   },
   async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
     const output = await runPiJson(root, prompt, options, fixPlanJsonSchema, false);
@@ -357,9 +467,13 @@ const mockProvider: Provider = {
       notes: ["mock agent map"],
     };
   },
-  async review(_root: string, prompt: string): Promise<ReviewOutput> {
+  async review(_root: string, prompt: string): Promise<PartitionedReviewOutput> {
     if (!prompt.includes("TODO_BUG") && !prompt.includes("BUG:")) {
-      return { findings: [], inspected: { files: [], symbols: [], notes: ["mock clean"] } };
+      return {
+        findings: [],
+        inspected: { files: [], symbols: [], notes: ["mock clean"] },
+        droppedFindings: [],
+      };
     }
     const evidencePath = prompt.includes("BAD_EVIDENCE")
       ? "src/not-included.ts"
@@ -413,6 +527,7 @@ const mockProvider: Provider = {
           },
         ],
         inspected: { files: [evidencePath], symbols: [], notes: ["mock mixed findings"] },
+        droppedFindings: [],
       };
     }
     return {
@@ -441,6 +556,7 @@ const mockProvider: Provider = {
         },
       ],
       inspected: { files: [evidencePath], symbols: [], notes: ["mock finding"] },
+      droppedFindings: [],
     };
   },
   async fix(): Promise<FixPlanOutput> {
@@ -495,7 +611,7 @@ const mockFailProvider: Provider = {
   async map(): Promise<AgentMapOutput> {
     throw new ClawpatchError("mock map failure", 1, "mock-failure");
   },
-  async review(): Promise<ReviewOutput> {
+  async review(): Promise<PartitionedReviewOutput> {
     throw new ClawpatchError("mock review failure", 1, "mock-failure");
   },
   async fix(): Promise<FixPlanOutput> {
@@ -1072,6 +1188,7 @@ export const __testing = {
   extractOpencodeJson,
   parseAcpxAgent,
   parseCodexJson,
+  parseReviewOutput,
   piThinkingLevel,
   providerJsonSchema,
 };

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -34,10 +34,20 @@ export type ProviderOptions = {
   skipGitRepoCheck: boolean;
 };
 
+/**
+ * One review finding rejected by per-finding validation. `layer` records
+ * which gate dropped it: `schema` is the per-finding `reviewFindingSchema`
+ * Zod parse, `validation` is the evidence/quote/line-range check in
+ * `validateReviewOutputPartitioned`. Operators can use `layer` to tell
+ * "the model emitted nonsense for this finding" (schema) apart from
+ * "the model cited a real-looking finding but pointed at the wrong file
+ * or quoted text that isn't there" (validation).
+ */
 export type DroppedFinding = {
   path: (string | number)[];
   message: string;
   sample: string;
+  layer?: "schema" | "validation";
 };
 
 export type PartitionedReviewOutput = {
@@ -110,6 +120,7 @@ export function parseReviewOutput(output: unknown): PartitionedReviewOutput {
       path: ["findings", idx, ...issuePath],
       message: issue?.message ?? "invalid finding shape",
       sample: truncateSample(candidate),
+      layer: "schema",
     });
   });
 

--- a/src/review-validation.test.ts
+++ b/src/review-validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { defaultConfig } from "./config.js";
 import type { ReviewPromptManifest } from "./prompt.js";
-import { validateReviewOutput } from "./review-validation.js";
+import { validateReviewOutput, validateReviewOutputPartitioned } from "./review-validation.js";
 import { fixtureRoot, writeFixture } from "./test-helpers.js";
 import type { FeatureRecord, ReviewOutput } from "./types.js";
 
@@ -117,6 +117,108 @@ describe("validateReviewOutput", () => {
         output("src/index.ts", { startLine: null, endLine: null, quote: "TODO_TAIL" }),
       ),
     ).rejects.toMatchObject({ code: "malformed-output" });
+  });
+});
+
+describe("validateReviewOutputPartitioned", () => {
+  it("returns all findings when every finding's evidence is valid", async () => {
+    const root = await fixtureRoot("clawpatch-review-validation-partition-ok-");
+    await writeFixture(root, "src/index.ts", "const value = 'TODO_BUG';\n");
+
+    const result = await validateReviewOutputPartitioned(
+      root,
+      feature("src/index.ts"),
+      defaultConfig(),
+      manifest("src/index.ts"),
+      output("src/index.ts"),
+    );
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]!.title).toBe("Bug");
+    expect(result.droppedFindings).toEqual([]);
+  });
+
+  it("keeps valid siblings when one finding has a stale quote", async () => {
+    const root = await fixtureRoot("clawpatch-review-validation-partition-quote-");
+    await writeFixture(root, "src/index.ts", "const value = 'TODO_BUG';\n");
+
+    const goodFinding = output("src/index.ts").findings[0]!;
+    const badFinding: ReviewOutput["findings"][number] = {
+      ...goodFinding,
+      title: "Stale quote",
+      evidence: [
+        {
+          path: "src/index.ts",
+          startLine: 1,
+          endLine: 1,
+          symbol: null,
+          quote: "this text does not exist",
+        },
+      ],
+    };
+    const provider: ReviewOutput = {
+      findings: [goodFinding, badFinding, { ...goodFinding, title: "Also good" }],
+      inspected: { files: ["src/index.ts"], symbols: [], notes: [] },
+    };
+
+    const result = await validateReviewOutputPartitioned(
+      root,
+      feature("src/index.ts"),
+      defaultConfig(),
+      manifest("src/index.ts"),
+      provider,
+    );
+
+    expect(result.findings.map((f) => f.title)).toEqual(["Bug", "Also good"]);
+    expect(result.droppedFindings).toHaveLength(1);
+    const dropped = result.droppedFindings[0]!;
+    expect(dropped.path).toEqual(["findings", 1]);
+    expect(dropped.layer).toBe("validation");
+    expect(dropped.message).toMatch(/quote/iu);
+    expect(dropped.sample.length).toBeLessThanOrEqual(200);
+  });
+
+  it("drops findings whose evidence file was not included in the prompt", async () => {
+    const root = await fixtureRoot("clawpatch-review-validation-partition-included-");
+    await writeFixture(root, "src/index.ts", "const value = 'TODO_BUG';\n");
+    await writeFixture(root, "src/other.ts", "const value = 'TODO_BUG';\n");
+
+    const result = await validateReviewOutputPartitioned(
+      root,
+      feature("src/index.ts"),
+      defaultConfig(),
+      manifest("src/index.ts"),
+      output("src/other.ts"),
+    );
+
+    expect(result.findings).toEqual([]);
+    expect(result.droppedFindings).toHaveLength(1);
+    expect(result.droppedFindings[0]!.layer).toBe("validation");
+    expect(result.droppedFindings[0]!.message).toMatch(/not included/iu);
+  });
+
+  it("drops findings with empty evidence arrays without throwing", async () => {
+    const root = await fixtureRoot("clawpatch-review-validation-partition-empty-");
+    await writeFixture(root, "src/index.ts", "const value = 'TODO_BUG';\n");
+
+    const goodFinding = output("src/index.ts").findings[0]!;
+    const provider: ReviewOutput = {
+      findings: [{ ...goodFinding, title: "No evidence", evidence: [] }, goodFinding],
+      inspected: { files: ["src/index.ts"], symbols: [], notes: [] },
+    };
+
+    const result = await validateReviewOutputPartitioned(
+      root,
+      feature("src/index.ts"),
+      defaultConfig(),
+      manifest("src/index.ts"),
+      provider,
+    );
+
+    expect(result.findings.map((f) => f.title)).toEqual(["Bug"]);
+    expect(result.droppedFindings).toHaveLength(1);
+    expect(result.droppedFindings[0]!.path).toEqual(["findings", 0]);
+    expect(result.droppedFindings[0]!.message).toMatch(/no evidence/iu);
   });
 });
 

--- a/src/review-validation.ts
+++ b/src/review-validation.ts
@@ -2,6 +2,7 @@ import { readFile, realpath } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 import { ClawpatchError } from "./errors.js";
 import { REVIEW_PROMPT_FILE_CHAR_LIMIT, type ReviewPromptManifest } from "./prompt.js";
+import type { DroppedFinding } from "./provider.js";
 import { ClawpatchConfig, FeatureRecord, ReviewOutput } from "./types.js";
 
 export async function validateReviewOutput(
@@ -18,21 +19,88 @@ export async function validateReviewOutput(
   const cache = new Map<string, Promise<string>>();
   const findings = output.findings;
   for (const finding of findings) {
-    if (finding.evidence.length === 0) {
-      throwMalformed(`finding "${finding.title}" has no evidence`);
-    }
-    for (const evidence of finding.evidence) {
-      assertIncludedPath(evidence.path, included, "evidence file");
-      const promptFile = promptFiles.get(normalizePath(evidence.path));
-      if (promptFile === undefined || !promptFile.readable) {
-        throwMalformed(`evidence file was not readable in review context: ${evidence.path}`);
-      }
-      const contents = await fileContents(root, evidence.path, promptFile.truncated, cache);
-      assertLineRange(contents, evidence);
-      assertQuote(contents, evidence);
-    }
+    await validateFinding(root, finding, included, promptFiles, cache);
   }
   return { ...output, findings };
+}
+
+/**
+ * Same evidence validation as {@link validateReviewOutput}, but runs
+ * per-finding and partitions failures instead of throwing on the first
+ * bad finding. Callers receive only the validated findings plus a list
+ * of {@link DroppedFinding}s describing why each rejection occurred. The
+ * caller is then free to surface drops as non-fatal run errors instead
+ * of losing the whole feature.
+ */
+export async function validateReviewOutputPartitioned(
+  root: string,
+  feature: FeatureRecord,
+  config: ClawpatchConfig,
+  manifest: ReviewPromptManifest,
+  output: ReviewOutput,
+): Promise<{ findings: ReviewOutput["findings"]; droppedFindings: DroppedFinding[] }> {
+  const included = includedReviewPaths(feature, config);
+  const promptFiles = new Map(
+    manifest.includedFiles.map((file) => [normalizePath(file.path), file]),
+  );
+  const cache = new Map<string, Promise<string>>();
+  const validFindings: ReviewOutput["findings"] = [];
+  const droppedFindings: DroppedFinding[] = [];
+  output.findings.forEach(() => undefined);
+  for (let idx = 0; idx < output.findings.length; idx += 1) {
+    const finding = output.findings[idx]!;
+    try {
+      await validateFinding(root, finding, included, promptFiles, cache);
+      validFindings.push(finding);
+    } catch (error: unknown) {
+      if (error instanceof ClawpatchError && error.code === "malformed-output") {
+        droppedFindings.push({
+          path: ["findings", idx],
+          message: error.message.replace(/^malformed provider review output:\s*/u, ""),
+          sample: truncateValidationSample(finding),
+          layer: "validation",
+        });
+        continue;
+      }
+      throw error;
+    }
+  }
+  return { findings: validFindings, droppedFindings };
+}
+
+async function validateFinding(
+  root: string,
+  finding: ReviewOutput["findings"][number],
+  included: ReadonlySet<string>,
+  promptFiles: Map<string, ReviewPromptManifest["includedFiles"][number]>,
+  cache: Map<string, Promise<string>>,
+): Promise<void> {
+  if (finding.evidence.length === 0) {
+    throwMalformed(`finding "${finding.title}" has no evidence`);
+  }
+  for (const evidence of finding.evidence) {
+    assertIncludedPath(evidence.path, included, "evidence file");
+    const promptFile = promptFiles.get(normalizePath(evidence.path));
+    if (promptFile === undefined || !promptFile.readable) {
+      throwMalformed(`evidence file was not readable in review context: ${evidence.path}`);
+    }
+    const contents = await fileContents(root, evidence.path, promptFile.truncated, cache);
+    assertLineRange(contents, evidence);
+    assertQuote(contents, evidence);
+  }
+}
+
+function truncateValidationSample(finding: ReviewOutput["findings"][number]): string {
+  let text: string;
+  try {
+    text = JSON.stringify(finding);
+  } catch {
+    text = String(finding);
+  }
+  if (text === undefined) {
+    text = String(finding);
+  }
+  return text.length > 200 ? `${text.slice(0, 197)}...` : text;
 }
 
 function includedReviewPaths(feature: FeatureRecord, config: ClawpatchConfig): Set<string> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -349,27 +349,33 @@ export const agentMapOutputSchema = z.object({
 
 export type AgentMapOutput = z.infer<typeof agentMapOutputSchema>;
 
+export const reviewFindingSchema = z.object({
+  title: z.string(),
+  category: z.enum(findingCategories),
+  severity: z.enum(["critical", "high", "medium", "low"]),
+  confidence: z.enum(["high", "medium", "low"]),
+  evidence: z.array(evidenceRefSchema),
+  reasoning: z.string(),
+  reproduction: z.string().nullable(),
+  recommendation: z.string(),
+  whyTestsDoNotAlreadyCoverThis: z.string(),
+  suggestedRegressionTest: z.string().nullable(),
+  minimumFixScope: z.string(),
+});
+
+export type ReviewFinding = z.infer<typeof reviewFindingSchema>;
+
+export const reviewInspectedSchema = z.object({
+  files: z.array(z.string()),
+  symbols: z.array(z.string()),
+  notes: z.array(z.string()),
+});
+
+export type ReviewInspected = z.infer<typeof reviewInspectedSchema>;
+
 export const reviewOutputSchema = z.object({
-  findings: z.array(
-    z.object({
-      title: z.string(),
-      category: z.enum(findingCategories),
-      severity: z.enum(["critical", "high", "medium", "low"]),
-      confidence: z.enum(["high", "medium", "low"]),
-      evidence: z.array(evidenceRefSchema),
-      reasoning: z.string(),
-      reproduction: z.string().nullable(),
-      recommendation: z.string(),
-      whyTestsDoNotAlreadyCoverThis: z.string(),
-      suggestedRegressionTest: z.string().nullable(),
-      minimumFixScope: z.string(),
-    }),
-  ),
-  inspected: z.object({
-    files: z.array(z.string()),
-    symbols: z.array(z.string()),
-    notes: z.array(z.string()),
-  }),
+  findings: z.array(reviewFindingSchema),
+  inspected: reviewInspectedSchema,
 });
 
 export type ReviewOutput = z.infer<typeof reviewOutputSchema>;


### PR DESCRIPTION
## Summary

Today, when an LLM returns a single review finding whose `category` is outside the 10-value enum (e.g. "quality", "correctness"), `reviewOutputSchema.parse(output)` throws and the whole feature loses every finding it produced — even the valid sibling findings. We hit this 6 times in a 100-feature run and 25+ times in a 1000-feature run.

Upstream now also runs `validateReviewOutput()` after parse, which throws on the FIRST bad evidence (line range / quote / file inclusion). Same all-or-nothing failure mode at a different layer.

This PR partitions at both layers so one bad finding can no longer sink its siblings.

**Layer 1** (commit 1) — `parseReviewOutput`:
- Tries fast path with `reviewOutputSchema.safeParse`.
- On failure, validates each finding individually with the new `reviewFindingSchema`.
- Returns `{validFindings, droppedFindings: [{path, message, sample}]}`.
- All four `review()` providers (codex/opencode/acpx/grok) now use this helper.

**Layer 2** (commit 2) — `validateReviewOutputPartitioned`:
- Wraps `validateReviewOutput` per-finding, catching `ClawpatchError("malformed-output")`.
- Same drop-and-continue shape; new `layer: "schema" | "validation"` discriminator on `DroppedFinding`.

Drops are persisted to the run's `errors` array as `{message, code: "schema-drop" | "validation-drop"}`. The run-level fatal-error gate filters these out, so a dropped finding never marks a run "failed".

## Why

Run `20260517T190759-3c9e9e` (1000 features, 78 errors). 26 of those errors were single bad findings sinking their whole feature. After this PR, they'd land as `code: "schema-drop"` or `"validation-drop"` and the valid siblings would persist normally.

## Files

- `src/types.ts` — extracted `reviewFindingSchema` + `reviewInspectedSchema`
- `src/provider.ts` — new `parseReviewOutput` + `DroppedFinding` types; threaded through 4 providers + 2 mocks
- `src/app.ts` — `reviewFeature` carries `droppedFindings`; worker loop persists as non-fatal errors
- `src/review-validation.ts` — new `validateReviewOutputPartitioned`
- `src/provider.test.ts` + `src/review-validation.test.ts` — 8 new cases

## Validation

- `pnpm format:check` — clean
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm test` — 549 passed, 1 skipped (was 545 pre-PR)

## Coordination

- Stacks cleanly with the schema-tolerance PR (same family of failure modes).
- Reviewers can land commit 1 alone if Layer 2 needs more discussion.
