### PR TITLE
chore(provider): format zod errors compactly for run.errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Improved OpenCode malformed JSON diagnostics with output length, event kinds, and a bounded preview, thanks @rohitjavvadi.
 - Fixed Express route mapping for aliased Router imports that follow block comment banners, thanks @rohitjavvadi.
 - Fixed Bun package-manager detection to recognize the text `bun.lock` lockfile, thanks @austinm911.
+- Improved provider schema validation failures so `run.errors[].message` shows a one-line `path=value (code, expected ...)` summary instead of a multi-kilobyte JSON-encoded zod issue blob.
 
 ## 0.3.0 - 2026-05-18
 

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -12,8 +12,11 @@ const {
   codexFailureMessage,
   extractAcpxJson,
   extractOpencodeJson,
+  formatZodError,
+  formatZodIssue,
   parseAcpxAgent,
   parseCodexJson,
+  parseOrThrow,
   piThinkingLevel,
   providerJsonSchema,
 } = __testing;
@@ -552,6 +555,119 @@ describe("extractOpencodeJson", () => {
       return;
     }
     throw new Error("expected provider auth failure");
+  });
+});
+
+function makeBadReview(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    findings: [
+      {
+        title: "x",
+        category: "quality",
+        severity: "medium",
+        confidence: "high",
+        evidence: [],
+        reasoning: "r",
+        reproduction: null,
+        recommendation: "rec",
+        whyTestsDoNotAlreadyCoverThis: "w",
+        suggestedRegressionTest: null,
+        minimumFixScope: "m",
+        ...overrides,
+      },
+    ],
+    inspected: { files: [], symbols: [], notes: [] },
+  };
+}
+
+describe("formatZodError", () => {
+  it("reports invalid enum compactly with bad value and expected list", () => {
+    const input = makeBadReview();
+    const result = reviewOutputSchema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const msg = formatZodError(result.error, input);
+    expect(msg).toMatch(/findings\[0\]\.category="quality"/u);
+    expect(msg).toMatch(/invalid_value/u);
+    expect(msg).toMatch(/expected one of [^()]*\bbug\b/u);
+    expect(msg.split("\n")).toHaveLength(1);
+  });
+
+  it("reports missing required field compactly", () => {
+    const bad = {
+      findings: [
+        {
+          title: "x",
+          category: "bug",
+          severity: "medium",
+          confidence: "high",
+          evidence: [],
+          reproduction: null,
+          recommendation: "rec",
+          whyTestsDoNotAlreadyCoverThis: "w",
+          suggestedRegressionTest: null,
+          minimumFixScope: "m",
+          // reasoning omitted on purpose
+        },
+      ],
+      inspected: { files: [], symbols: [], notes: [] },
+    };
+    const result = reviewOutputSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const msg = formatZodError(result.error, bad);
+    expect(msg).toMatch(/findings\[0\]\.reasoning/u);
+    expect(msg).toMatch(/invalid_type/u);
+    expect(msg).toMatch(/expected string/u);
+  });
+
+  it("truncates long received string values to a bounded preview", () => {
+    const longValue = "a".repeat(500);
+    const issue = formatZodIssue({
+      code: "invalid_type",
+      path: ["findings", 0, "reasoning"],
+      message: "x",
+      expected: "string",
+      received: longValue,
+    } as unknown as Parameters<typeof formatZodIssue>[0]);
+    expect(issue.length).toBeLessThan(longValue.length);
+    expect(issue).toMatch(/findings\[0\]\.reasoning=/u);
+  });
+
+  it("includes a +N more suffix when zod reports many issues", () => {
+    const fakeError = {
+      issues: Array.from({ length: 5 }, (_, i) => ({
+        code: "invalid_type",
+        path: ["x", i],
+        message: "x",
+        expected: "string",
+        received: "n",
+      })),
+    } as unknown as Parameters<typeof formatZodError>[0];
+    const msg = formatZodError(fakeError);
+    expect(msg).toMatch(/\(\+2 more\)$/u);
+  });
+});
+
+describe("parseOrThrow", () => {
+  it("returns parsed data on success", () => {
+    const ok = {
+      findings: [],
+      inspected: { files: [], symbols: [], notes: [] },
+    };
+    expect(parseOrThrow(reviewOutputSchema, ok, "test")).toEqual(ok);
+  });
+
+  it("throws ClawpatchError with malformed-output / exit 8 on bad input", () => {
+    expectMalformed(
+      () =>
+        parseOrThrow(
+          reviewOutputSchema,
+          { findings: [{ category: "quality" }], inspected: {} },
+          "test-label",
+        ),
+      /test-label: schema validation failed: findings\[0\]/u,
+    );
   });
 });
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ZodError, ZodIssue, ZodType } from "zod";
 import { runCommandArgs } from "./exec.js";
 import { ClawpatchError } from "./errors.js";
 import {
@@ -24,6 +25,124 @@ import {
 } from "./types.js";
 
 export { extractJson } from "./provider-json.js";
+
+const ZOD_VALUE_PREVIEW_LIMIT = 80;
+const ZOD_ISSUE_HEAD_LIMIT = 3;
+
+function formatZodPath(path: ReadonlyArray<PropertyKey>): string {
+  if (path.length === 0) {
+    return "<root>";
+  }
+  let out = "";
+  for (let i = 0; i < path.length; i += 1) {
+    const segment = path[i];
+    if (typeof segment === "number") {
+      out += `[${segment}]`;
+    } else if (i === 0) {
+      out += String(segment);
+    } else {
+      out += `.${String(segment)}`;
+    }
+  }
+  return out;
+}
+
+function previewZodValue(value: unknown): string {
+  let rendered: string;
+  if (typeof value === "string") {
+    rendered = JSON.stringify(value);
+  } else if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    rendered = String(value);
+  } else if (value === undefined) {
+    return "";
+  } else {
+    try {
+      rendered = JSON.stringify(value) ?? String(value);
+    } catch {
+      rendered = String(value);
+    }
+  }
+  if (rendered.length > ZOD_VALUE_PREVIEW_LIMIT) {
+    return `${rendered.slice(0, ZOD_VALUE_PREVIEW_LIMIT - 1)}…`;
+  }
+  return rendered;
+}
+
+function lookupAtPath(input: unknown, path: ReadonlyArray<PropertyKey>): unknown {
+  let cur: unknown = input;
+  for (const segment of path) {
+    if (cur === null || cur === undefined) {
+      return undefined;
+    }
+    if (typeof segment === "number") {
+      if (!Array.isArray(cur)) {
+        return undefined;
+      }
+      cur = cur[segment];
+    } else if (typeof cur === "object") {
+      cur = (cur as Record<string, unknown>)[String(segment)];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+export function formatZodIssue(issue: ZodIssue, input?: unknown): string {
+  const path = formatZodPath(issue.path);
+  const issueRecord = issue as ZodIssue & {
+    received?: unknown;
+    expected?: unknown;
+    values?: unknown;
+  };
+  let received: unknown;
+  let hasReceived = false;
+  if ("received" in issueRecord && issueRecord.received !== undefined) {
+    received = issueRecord.received;
+    hasReceived = true;
+  } else if (input !== undefined && issue.path.length > 0) {
+    const looked = lookupAtPath(input, issue.path);
+    if (looked !== undefined) {
+      received = looked;
+      hasReceived = true;
+    }
+  }
+  const receivedSegment = hasReceived ? `=${previewZodValue(received)}` : "";
+  let expectedSegment = "";
+  if (Array.isArray(issueRecord.values)) {
+    const list = issueRecord.values.map((v) => String(v)).join(",");
+    expectedSegment = `, expected one of ${list}`;
+  } else if (typeof issueRecord.expected === "string" && issueRecord.expected.length > 0) {
+    expectedSegment = `, expected ${issueRecord.expected}`;
+  }
+  return `${path}${receivedSegment} (${issue.code}${expectedSegment})`;
+}
+
+export function formatZodError(error: ZodError, input?: unknown): string {
+  const issues = error.issues ?? [];
+  if (issues.length === 0) {
+    return "schema validation failed";
+  }
+  const head = issues
+    .slice(0, ZOD_ISSUE_HEAD_LIMIT)
+    .map((issue) => formatZodIssue(issue, input))
+    .join("; ");
+  const more =
+    issues.length > ZOD_ISSUE_HEAD_LIMIT ? ` (+${issues.length - ZOD_ISSUE_HEAD_LIMIT} more)` : "";
+  return `schema validation failed: ${head}${more}`;
+}
+
+function parseOrThrow<T>(schema: ZodType<T>, input: unknown, label: string): T {
+  const result = schema.safeParse(input);
+  if (result.success) {
+    return result.data;
+  }
+  throw new ClawpatchError(
+    `${label}: ${formatZodError(result.error, input)}`,
+    8,
+    "malformed-output",
+  );
+}
 
 export type ProviderOptions = {
   model: string | null;
@@ -75,15 +194,15 @@ const codexProvider: Provider = {
   },
   async map(root: string, prompt: string, options: ProviderOptions): Promise<AgentMapOutput> {
     const output = await runCodexJson(root, prompt, options, agentMapJsonSchema);
-    return agentMapOutputSchema.parse(output);
+    return parseOrThrow(agentMapOutputSchema, output, "codex agent-map");
   },
   async review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput> {
     const output = await runCodexJson(root, prompt, options, reviewJsonSchema);
-    return reviewOutputSchema.parse(output);
+    return parseOrThrow(reviewOutputSchema, output, "codex review");
   },
   async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
     const output = await runCodexJson(root, prompt, options, fixPlanJsonSchema, "workspace-write");
-    return fixPlanOutputSchema.parse(output);
+    return parseOrThrow(fixPlanOutputSchema, output, "codex fix-plan");
   },
   async revalidate(
     root: string,
@@ -91,7 +210,7 @@ const codexProvider: Provider = {
     options: ProviderOptions,
   ): Promise<RevalidateOutput> {
     const output = await runCodexJson(root, prompt, options, revalidateJsonSchema);
-    return revalidateOutputSchema.parse(output);
+    return parseOrThrow(revalidateOutputSchema, output, "codex revalidate");
   },
 };
 
@@ -106,15 +225,15 @@ const opencodeProvider: Provider = {
   },
   async map(root: string, prompt: string, options: ProviderOptions): Promise<AgentMapOutput> {
     const output = await runOpencodeJson(root, prompt, options.model, agentMapJsonSchema, true);
-    return agentMapOutputSchema.parse(output);
+    return parseOrThrow(agentMapOutputSchema, output, "opencode agent-map");
   },
   async review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput> {
     const output = await runOpencodeJson(root, prompt, options.model, reviewJsonSchema, true);
-    return reviewOutputSchema.parse(output);
+    return parseOrThrow(reviewOutputSchema, output, "opencode review");
   },
   async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
     const output = await runOpencodeJson(root, prompt, options.model, fixPlanJsonSchema, false);
-    return fixPlanOutputSchema.parse(output);
+    return parseOrThrow(fixPlanOutputSchema, output, "opencode fix-plan");
   },
   async revalidate(
     root: string,
@@ -122,7 +241,7 @@ const opencodeProvider: Provider = {
     options: ProviderOptions,
   ): Promise<RevalidateOutput> {
     const output = await runOpencodeJson(root, prompt, options.model, revalidateJsonSchema, true);
-    return revalidateOutputSchema.parse(output);
+    return parseOrThrow(revalidateOutputSchema, output, "opencode revalidate");
   },
 };
 
@@ -145,15 +264,15 @@ const acpxProvider: Provider = {
   },
   async map(root: string, prompt: string, options: ProviderOptions): Promise<AgentMapOutput> {
     const output = await runAcpxJson(root, prompt, options.model, agentMapJsonSchema, "read");
-    return agentMapOutputSchema.parse(output);
+    return parseOrThrow(agentMapOutputSchema, output, "acpx agent-map");
   },
   async review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput> {
     const output = await runAcpxJson(root, prompt, options.model, reviewJsonSchema, "read");
-    return reviewOutputSchema.parse(output);
+    return parseOrThrow(reviewOutputSchema, output, "acpx review");
   },
   async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
     const output = await runAcpxJson(root, prompt, options.model, fixPlanJsonSchema, "approve");
-    return fixPlanOutputSchema.parse(output);
+    return parseOrThrow(fixPlanOutputSchema, output, "acpx fix-plan");
   },
   async revalidate(
     root: string,
@@ -161,7 +280,7 @@ const acpxProvider: Provider = {
     options: ProviderOptions,
   ): Promise<RevalidateOutput> {
     const output = await runAcpxJson(root, prompt, options.model, revalidateJsonSchema, "read");
-    return revalidateOutputSchema.parse(output);
+    return parseOrThrow(revalidateOutputSchema, output, "acpx revalidate");
   },
 };
 
@@ -176,15 +295,15 @@ const grokProvider: Provider = {
   },
   async map(root: string, prompt: string, options: ProviderOptions): Promise<AgentMapOutput> {
     const output = await runGrokJson(root, prompt, options.model, agentMapJsonSchema, true);
-    return agentMapOutputSchema.parse(output);
+    return parseOrThrow(agentMapOutputSchema, output, "grok agent-map");
   },
   async review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput> {
     const output = await runGrokJson(root, prompt, options.model, reviewJsonSchema, true);
-    return reviewOutputSchema.parse(output);
+    return parseOrThrow(reviewOutputSchema, output, "grok review");
   },
   async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
     const output = await runGrokJson(root, prompt, options.model, fixPlanJsonSchema, false);
-    return fixPlanOutputSchema.parse(output);
+    return parseOrThrow(fixPlanOutputSchema, output, "grok fix-plan");
   },
   async revalidate(
     root: string,
@@ -192,7 +311,7 @@ const grokProvider: Provider = {
     options: ProviderOptions,
   ): Promise<RevalidateOutput> {
     const output = await runGrokJson(root, prompt, options.model, revalidateJsonSchema, true);
-    return revalidateOutputSchema.parse(output);
+    return parseOrThrow(revalidateOutputSchema, output, "grok revalidate");
   },
 };
 
@@ -209,15 +328,15 @@ const piProvider: Provider = {
   },
   async map(root: string, prompt: string, options: ProviderOptions): Promise<AgentMapOutput> {
     const output = await runPiJson(root, prompt, options, agentMapJsonSchema, true);
-    return agentMapOutputSchema.parse(output);
+    return parseOrThrow(agentMapOutputSchema, output, "pi map");
   },
   async review(root: string, prompt: string, options: ProviderOptions): Promise<ReviewOutput> {
     const output = await runPiJson(root, prompt, options, reviewJsonSchema, true);
-    return reviewOutputSchema.parse(output);
+    return parseOrThrow(reviewOutputSchema, output, "pi review");
   },
   async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
     const output = await runPiJson(root, prompt, options, fixPlanJsonSchema, false);
-    return fixPlanOutputSchema.parse(output);
+    return parseOrThrow(fixPlanOutputSchema, output, "pi fix-plan");
   },
   async revalidate(
     root: string,
@@ -225,7 +344,7 @@ const piProvider: Provider = {
     options: ProviderOptions,
   ): Promise<RevalidateOutput> {
     const output = await runPiJson(root, prompt, options, revalidateJsonSchema, true);
-    return revalidateOutputSchema.parse(output);
+    return parseOrThrow(revalidateOutputSchema, output, "pi revalidate");
   },
 };
 
@@ -1070,8 +1189,11 @@ export const __testing = {
   codexFailureMessage,
   extractAcpxJson,
   extractOpencodeJson,
+  formatZodError,
+  formatZodIssue,
   parseAcpxAgent,
   parseCodexJson,
+  parseOrThrow,
   piThinkingLevel,
   providerJsonSchema,
 };


### PR DESCRIPTION
## Summary

When `reviewOutputSchema.parse()` (or any of the 16 provider-output parses) throws on bad model output, the error embeds the entire ~1.5KB zod issue blob in `run.errors[].message`. Operators tailing a log can't easily see what went wrong.

This PR wraps every provider-output parse with a small `parseOrThrow` helper that emits one-line summaries:

```
codex review: schema validation failed: findings[0].category="quality" (invalid_value, expected one of bug,security,performance,concurrency,...)
```

Three issues max, then `(+N more)`. Values truncated to 80 chars.

## Files

- `src/provider.ts` — new helpers (`formatZodPath`, `previewZodValue`, `lookupAtPath`, `formatZodIssue`, `formatZodError`, `parseOrThrow`); 16 `.parse(output)` call sites swapped to `parseOrThrow(...)` with descriptive labels (`codex map`, `codex review`, …, `pi revalidate`)
- `src/provider.test.ts` — 6 new cases (4 formatter, 2 wrapper)

The Pi provider added in #50 had four un-wrapped `.parse(output)` calls; this PR wraps those too, so `git grep ".parse(output)" src/` returns empty after merge.

## Why

Run `20260517T190759-3c9e9e` had 26 zod-throw errors. Each one's message in `run.errors[].message` was 1.5KB of nested JSON. After this PR the operator-relevant info (`path` + sample bad value) is on a single line.

## Validation

- `pnpm format:check` — clean
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm build` — clean
- `pnpm test` — 547 passed, 1 skipped (+6 new)

## Coordination

Layered cleanly on the safeparse-partition PR — if that one lands first, this PR's `formatZodError` becomes the drop-reason rendering. They merge in either order.
