### PR TITLE
feat(mapper): add CUDA support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.4.1 - Unreleased
 
+- Added CUDA support to the C/C++ mapper, mapping `.cu` / `.cuh` sources as standalone `main()` files and as CMake and autotools targets, including the legacy `FindCUDA` `cuda_add_executable` / `cuda_add_library` commands. Repositories containing CUDA sources are detected as `cuda` projects; CUDA targets are tagged `cuda` and carry the `concurrency` trust boundary.
+- Added C/C++/CUDA source-group mapping, so source files not owned by any CMake, autotools, or `main()` target are grouped per directory into bounded review slices.
+- Added conservative C/C++/CUDA validation command defaults from a root `Makefile` `check` / `test` target or a declared `CMakePresets.json` build workflow, and mapped `CMakeLists.txt`, `CMakePresets.json`, and `configure.ac` as config features.
+- Made `clawpatch review` and `clawpatch fix` CUDA-aware, injecting CUDA-specific reviewer guidance (kernel races, unchecked CUDA runtime calls, host/device pointer confusion, memory-access hazards, and synchronization mistakes) for features that own `.cu` / `.cuh` sources.
+
 ## 0.4.0 - 2026-05-22
 
 - Added `clawpatch ci` to initialize, map, review, write a report, and append a GitHub Actions step summary in one CI-friendly command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added CUDA support to the C/C++ mapper, mapping `.cu` / `.cuh` sources as standalone `main()` files and as CMake and autotools targets, including the legacy `FindCUDA` `cuda_add_executable` / `cuda_add_library` commands. Repositories containing CUDA sources are detected as `cuda` projects; CUDA targets are tagged `cuda` and carry the `concurrency` trust boundary.
 - Added C/C++/CUDA source-group mapping, so source files not owned by any CMake, autotools, or `main()` target are grouped per directory into bounded review slices.
 - Added conservative C/C++/CUDA validation command defaults from a root `Makefile` `check` / `test` target or a declared `CMakePresets.json` build workflow, and mapped `CMakeLists.txt`, `CMakePresets.json`, and `configure.ac` as config features.
+- Added per-feature selection of the C/C++/CUDA validation commands so features tagged `c`, `cpp`, or `cuda` use the declared Makefile or CMake preset commands even when another language wins the project's language-priority defaults, for example a Python repository with CUDA kernels. The detected native command set is persisted as a nullable `nativeCommands` field on the project record and config, and existing `.clawpatch/config.json` files load without migration.
 - Made `clawpatch review` and `clawpatch fix` CUDA-aware, injecting CUDA-specific reviewer guidance (kernel races, unchecked CUDA runtime calls, host/device pointer confusion, memory-access hazards, and synchronization mistakes) for features that own `.cu` / `.cuh` sources.
 
 ## 0.4.0 - 2026-05-22

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ validation commands and records a patch attempt under `.clawpatch/`.
   Ecto migrations, project scripts, and ExUnit suites
 - Rust `src/main.rs`, `src/bin/*.rs`, `src/lib.rs`, `crates/*`, and
   `tests/*.rs`
-- C/C++ standalone `main()` files, CMake `add_executable` / `add_library`
-  targets, and autotools `bin_PROGRAMS` / `lib_LTLIBRARIES` targets
+- C/C++/CUDA standalone `main()` files, CMake `add_executable` / `add_library`
+  targets, autotools `bin_PROGRAMS` / `lib_LTLIBRARIES` targets, and source
+  groups for files outside any build target, including CUDA `.cu` / `.cuh`
+  sources
 - Python project metadata, console scripts, bounded source groups, pytest suites,
   and Flask/FastAPI/Django routes
 - SwiftPM `Sources/*` targets and `Tests/*` suites

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -120,5 +120,15 @@ Categories requested from the provider:
 - `build-release`
 - `maintainability`
 
+## CUDA-aware review
+
+When a feature owns CUDA `.cu` / `.cuh` sources, `clawpatch review` (in the
+default mode) and `clawpatch fix` add CUDA-specific guidance to the provider
+prompt: kernel data races and synchronization barriers, unchecked CUDA runtime
+calls and missing post-launch error checks, host versus device pointer
+confusion, unsafe global- and shared-memory access, stream and event
+synchronization, and device-memory leaks. Findings still use the existing
+categories; there is no CUDA-specific category. Deslopify mode is unaffected.
+
 Review does not edit files. Use `clawpatch fix --finding <id>` for the explicit
 patch loop.

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -162,7 +162,13 @@ C/C++ shapes, including the legacy `FindCUDA` `cuda_add_executable` /
 any build target are grouped per directory into bounded, low-confidence source
 groups. C/C++/CUDA validation commands are emitted only when the project declares
 them: a root `Makefile` `check`/`test` target, or a `CMakePresets.json` build
-workflow. Otherwise they stay null.
+workflow. Otherwise they stay null. When a project mixes C/C++/CUDA sources
+with another language whose defaults sit higher in the language-priority
+order, such as a Python repository with CUDA kernels, the C/C++/CUDA commands
+are also persisted alongside the primary command set as `nativeCommands`, and
+`clawpatch fix` selects them for features tagged `c`, `cpp`, or `cuda` so a
+CUDA repair is validated with the declared Makefile or CMake preset commands
+rather than the project's primary test runner.
 
 Python mapping covers `pyproject.toml`, `setup.cfg`, `setup.py`, and
 `requirements.txt` metadata; `[project.scripts]`, `[tool.poetry.scripts]`,

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -54,7 +54,7 @@ Supported deterministic mappers today:
 - Ruby project metadata, executables, source groups, RSpec/Minitest suites,
   Rails configs, routes, views, assets, and database files
 - Rust Cargo commands, libraries, workspace crates, and integration tests
-- C/C++ standalone `main()` files, CMake targets, and autotools targets
+- C/C++/CUDA standalone `main()` files, CMake targets, and autotools targets
 - C#/.NET projects from `.sln`, `.slnx`, `.csproj`, `.fsproj`, and `.vbproj`,
   ASP.NET Core controllers, minimal API endpoints, C#/F#/Visual Basic source
   groups, and .NET test projects
@@ -155,7 +155,14 @@ files are skipped.
 C/C++ mapping covers generic project shapes only: standalone source files with
 `main()`, CMake `add_executable` / `add_library`, and autotools `bin_PROGRAMS` /
 `lib_LTLIBRARIES`. It deliberately avoids project-specific C dialects such as
-php-src extension metadata.
+php-src extension metadata. CUDA `.cu` / `.cuh` files are mapped through the same
+C/C++ shapes, including the legacy `FindCUDA` `cuda_add_executable` /
+`cuda_add_library` commands; CUDA targets are tagged `cuda`, and a repository with
+`.cu` / `.cuh` sources is detected as a `cuda` project. Source files not owned by
+any build target are grouped per directory into bounded, low-confidence source
+groups. C/C++/CUDA validation commands are emitted only when the project declares
+them: a root `Makefile` `check`/`test` target, or a `CMakePresets.json` build
+workflow. Otherwise they stay null.
 
 Python mapping covers `pyproject.toml`, `setup.cfg`, `setup.py`, and
 `requirements.txt` metadata; `[project.scripts]`, `[tool.poetry.scripts]`,

--- a/src/app.ts
+++ b/src/app.ts
@@ -94,7 +94,11 @@ export async function initCommand(
   const paths = statePaths(stateDir);
   await ensureStateDirs(paths);
   const project = await detectProject(context.root);
-  const detectedConfig = { ...config, commands: project.detected.commands };
+  const detectedConfig = {
+    ...config,
+    commands: project.detected.commands,
+    nativeCommands: project.detected.nativeCommands ?? null,
+  };
   const previous = await readProject(paths);
   if (previous !== null && flags["force"] !== true) {
     throw new ClawpatchError("project already initialized; use --force", 2, "already-initialized");
@@ -550,7 +554,11 @@ export async function showCommand(
   const record = assertDefined(finding, `finding not found: ${findingId}`);
   const feature = features.find((candidate) => candidate.featureId === record.featureId) ?? null;
   const linkedPatches = patches.filter((patch) => patch.findingIds.includes(record.findingId));
-  const validation = validationCommandsForFeature(feature, loaded.config.commands);
+  const validation = validationCommandsForFeature(
+    feature,
+    loaded.config.commands,
+    loaded.config.nativeCommands ?? null,
+  );
   if (context.options.json) {
     return {
       finding: findingSummary(record, feature),
@@ -1032,7 +1040,11 @@ export async function fixCommand(
   };
   const prompt = await buildFixPrompt(loaded.root, finding, feature, config);
   if (flags["dryRun"] === true) {
-    const validationCommands = validationCommandsForFeature(feature, config.commands);
+    const validationCommands = validationCommandsForFeature(
+      feature,
+      config.commands,
+      config.nativeCommands ?? null,
+    );
     return {
       finding: finding.findingId,
       dryRun: true,
@@ -1073,7 +1085,11 @@ export async function fixCommand(
     });
     throw error;
   }
-  const validationCommands = validationCommandsForFeature(feature, config.commands);
+  const validationCommands = validationCommandsForFeature(
+    feature,
+    config.commands,
+    config.nativeCommands ?? null,
+  );
   const commandsRun: CommandResult[] = [];
   for (const command of validationCommands) {
     commandsRun.push(await runCommand(command, loaded.root));

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,7 @@ export function defaultConfig(): ClawpatchConfig {
       reasoningEffort: null,
     },
     commands: defaultCommands,
+    nativeCommands: null,
     review: {
       maxContextFiles: 24,
       maxOwnedFiles: 12,

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -249,6 +249,9 @@ async function languageDefaultCommands(
   if (languages.includes("ruby")) {
     return rubyDefaultCommands(root);
   }
+  if (languages.includes("c") || languages.includes("cpp") || languages.includes("cuda")) {
+    return cOrCppDefaultCommands(root);
+  }
 
   return {
     typecheck: null,
@@ -689,6 +692,116 @@ async function rubyDefaultCommands(root: string): Promise<ProjectCommands> {
     format: null,
     test: hasRspec ? `${run}rspec` : hasMinitest ? `${run}rake test` : null,
   };
+}
+
+async function cOrCppDefaultCommands(root: string): Promise<ProjectCommands> {
+  const makefileCommands = await makefileDefaultCommands(root);
+  if (makefileCommands !== null) {
+    return makefileCommands;
+  }
+  const presetCommands = await cmakePresetDefaultCommands(root);
+  if (presetCommands !== null) {
+    return presetCommands;
+  }
+  return { typecheck: null, lint: null, format: null, test: null };
+}
+
+async function makefileDefaultCommands(root: string): Promise<ProjectCommands | null> {
+  if (!(await pathExists(join(root, "Makefile")))) {
+    return null;
+  }
+  const source = await readFile(join(root, "Makefile"), "utf8").catch(() => "");
+  const test = makefileHasTarget(source, "check")
+    ? "make check"
+    : makefileHasTarget(source, "test")
+      ? "make test"
+      : null;
+  return { typecheck: "make", lint: null, format: null, test };
+}
+
+function makefileHasTarget(source: string, target: string): boolean {
+  return new RegExp(`^${target}\\s*:(?!=)`, "mu").test(source);
+}
+
+type CMakePresetSets = {
+  workflowPresets: string[];
+  configurePresets: string[];
+  buildPresets: string[];
+  testPresets: string[];
+};
+
+async function cmakePresetDefaultCommands(root: string): Promise<ProjectCommands | null> {
+  if (!(await pathExists(join(root, "CMakePresets.json")))) {
+    return null;
+  }
+  const presets = await readCMakePresets(root);
+  if (presets === null) {
+    return null;
+  }
+  const testPreset = singlePresetName(presets.testPresets);
+  return {
+    typecheck: cmakeBuildCommand(presets),
+    lint: null,
+    format: null,
+    test: testPreset === null ? null : `ctest --preset ${testPreset}`,
+  };
+}
+
+function cmakeBuildCommand(presets: CMakePresetSets): string | null {
+  const workflow = singlePresetName(presets.workflowPresets);
+  if (workflow !== null) {
+    return `cmake --workflow --preset ${workflow}`;
+  }
+  const configure = singlePresetName(presets.configurePresets);
+  const build = singlePresetName(presets.buildPresets);
+  if (configure !== null && build !== null) {
+    return `cmake --preset ${configure} && cmake --build --preset ${build}`;
+  }
+  return null;
+}
+
+function singlePresetName(names: string[]): string | null {
+  return names.length === 1 ? (names[0] ?? null) : null;
+}
+
+async function readCMakePresets(root: string): Promise<CMakePresetSets | null> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(join(root, "CMakePresets.json"), "utf8"));
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+  const record = parsed as Record<string, unknown>;
+  return {
+    workflowPresets: cmakePresetNames(record["workflowPresets"]),
+    configurePresets: cmakePresetNames(record["configurePresets"]),
+    buildPresets: cmakePresetNames(record["buildPresets"]),
+    testPresets: cmakePresetNames(record["testPresets"]),
+  };
+}
+
+function cmakePresetNames(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const names: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null) {
+      continue;
+    }
+    const preset = entry as { name?: unknown; hidden?: unknown };
+    if (
+      typeof preset.name === "string" &&
+      preset.hidden !== true &&
+      /^[A-Za-z0-9._-]+$/u.test(preset.name)
+    ) {
+      names.push(preset.name);
+    }
+  }
+  return names;
 }
 
 async function mixProjectInfo(root: string): Promise<MixProjectInfo> {
@@ -1285,6 +1398,9 @@ async function detectLanguages(root: string): Promise<string[]> {
   if (!languages.includes("cpp") && (await containsCppFile(root))) {
     languages.push("cpp");
   }
+  if (!languages.includes("cuda") && (await containsCudaFile(root))) {
+    languages.push("cuda");
+  }
   if (!languages.includes("php") && (await containsReviewablePhpFile(root))) {
     languages.push("php");
   }
@@ -1337,6 +1453,13 @@ async function containsReviewableCsharpFile(root: string): Promise<boolean> {
 
 async function containsCFile(root: string): Promise<boolean> {
   return containsFileWithExtension(root, ".c", 5, shouldSkipCOrCppSearchEntry);
+}
+
+async function containsCudaFile(root: string): Promise<boolean> {
+  return (
+    (await containsFileWithExtensionIgnoringCase(root, ".cu", 5, shouldSkipCOrCppSearchEntry)) ||
+    (await containsFileWithExtensionIgnoringCase(root, ".cuh", 5, shouldSkipCOrCppSearchEntry))
+  );
 }
 
 async function containsCppFile(root: string): Promise<boolean> {

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -46,6 +46,7 @@ export async function detectProject(root: string): Promise<ProjectRecord> {
   const frameworks = await detectFrameworks(root, pkg, composer);
   const languages = await detectLanguages(root);
   const commands = await detectCommands(root, pkg, composer, languages, packageManagers);
+  const nativeCommands = await detectNativeCommands(root, languages, commands);
   const name =
     typeof pkg?.name === "string"
       ? pkg.name
@@ -69,6 +70,7 @@ export async function detectProject(root: string): Promise<ProjectRecord> {
       frameworks,
       packageManagers,
       commands,
+      nativeCommands,
     },
     createdAt: now,
     updatedAt: now,
@@ -692,6 +694,32 @@ async function rubyDefaultCommands(root: string): Promise<ProjectCommands> {
     format: null,
     test: hasRspec ? `${run}rspec` : hasMinitest ? `${run}rake test` : null,
   };
+}
+
+async function detectNativeCommands(
+  root: string,
+  languages: string[],
+  primary: ProjectCommands,
+): Promise<ProjectCommands | null> {
+  if (
+    !languages.some((language) => language === "c" || language === "cpp" || language === "cuda")
+  ) {
+    return null;
+  }
+  const native = await cOrCppDefaultCommands(root);
+  if (!hasValidationCommand(native)) {
+    return null;
+  }
+  if (projectCommandsEqual(native, primary)) {
+    return null;
+  }
+  return native;
+}
+
+function projectCommandsEqual(a: ProjectCommands, b: ProjectCommands): boolean {
+  return (
+    a.typecheck === b.typecheck && a.lint === b.lint && a.format === b.format && a.test === b.test
+  );
 }
 
 async function cOrCppDefaultCommands(root: string): Promise<ProjectCommands> {

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -716,7 +716,10 @@ async function makefileDefaultCommands(root: string): Promise<ProjectCommands | 
     : makefileHasTarget(source, "test")
       ? "make test"
       : null;
-  return { typecheck: "make", lint: null, format: null, test };
+  if (test === null) {
+    return null;
+  }
+  return { typecheck: null, lint: null, format: null, test };
 }
 
 function makefileHasTarget(source: string, target: string): boolean {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -11921,25 +11921,25 @@ add_executable(headerapp include/headers.hpp)
     expect(titles).toContain("Project config configure.ac");
   });
 
-  it("defaults C/C++ validation to make when the Makefile declares a check target", async () => {
+  it("emits `make check` as the C/C++ test command when the Makefile declares a check target", async () => {
     const root = await fixtureRoot("clawpatch-cpp-makefile-check-");
     await writeFixture(root, "Makefile", "all:\n\tcc -o app main.c\n\ncheck:\n\t./app\n");
     await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
 
     const project = await detectProject(root);
 
-    expect(project.detected.commands.typecheck).toBe("make");
+    expect(project.detected.commands.typecheck).toBeNull();
     expect(project.detected.commands.test).toBe("make check");
   });
 
-  it("defaults C/C++ validation to make with no test command when the Makefile has none", async () => {
+  it("emits no C/C++ validation commands when the Makefile has no check or test target", async () => {
     const root = await fixtureRoot("clawpatch-cpp-makefile-notest-");
     await writeFixture(root, "Makefile", "all:\n\tcc -o app main.c\n");
     await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
 
     const project = await detectProject(root);
 
-    expect(project.detected.commands.typecheck).toBe("make");
+    expect(project.detected.commands.typecheck).toBeNull();
     expect(project.detected.commands.test).toBeNull();
   });
 

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -11786,6 +11786,253 @@ add_executable(headerapp include/headers.hpp)
     ]);
   });
 
+  it("maps a standalone CUDA source file with main as a CUDA binary", async () => {
+    const root = await fixtureRoot("clawpatch-cuda-standalone-");
+    await writeFixture(
+      root,
+      "saxpy.cu",
+      "__global__ void saxpy(float *x) { x[threadIdx.x] *= 2.0f; }\nint main(void) { return 0; }\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const saxpy = result.features.find((feature) => feature.title === "CUDA binary saxpy");
+
+    expect(saxpy?.source).toBe("c-main");
+    expect(saxpy?.entrypoints[0]).toMatchObject({ path: "saxpy.cu", symbol: "main" });
+    expect(saxpy?.tags).toContain("cuda");
+  });
+
+  it("maps CMake CUDA targets including .cu and .cuh sources", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-cuda-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "project(gpuapp CUDA)\nadd_executable(gpuapp src/main.cu src/kernels.cu src/kernels.cuh)\n",
+    );
+    await writeFixture(root, "src/main.cu", "int main(void) { return 0; }\n");
+    await writeFixture(
+      root,
+      "src/kernels.cu",
+      "__global__ void scale(float *x) { x[0] = 1.0f; }\n",
+    );
+    await writeFixture(root, "src/kernels.cuh", "__global__ void scale(float *x);\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const gpuapp = result.features.find((feature) => feature.title === "CMake binary gpuapp");
+
+    expect(gpuapp?.entrypoints[0]).toMatchObject({ path: "src/main.cu", symbol: "main" });
+    expect(gpuapp?.tags).toContain("cuda");
+    expect(gpuapp?.ownedFiles).toEqual([
+      { path: "src/main.cu", reason: "target source" },
+      { path: "src/kernels.cu", reason: "target source" },
+      { path: "src/kernels.cuh", reason: "target source" },
+    ]);
+  });
+
+  it("maps legacy FindCUDA cuda_add_executable and cuda_add_library targets", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-find-cuda-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "find_package(CUDA REQUIRED)\ncuda_add_executable(gpuapp src/main.cu)\ncuda_add_library(gpukernels src/kernels.cu)\n",
+    );
+    await writeFixture(root, "src/main.cu", "int main(void) { return 0; }\n");
+    await writeFixture(
+      root,
+      "src/kernels.cu",
+      "__global__ void scale(float *x) { x[0] = 1.0f; }\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const gpuapp = result.features.find((feature) => feature.title === "CMake binary gpuapp");
+    const gpukernels = result.features.find(
+      (feature) => feature.title === "CMake library gpukernels",
+    );
+
+    expect(titles).toContain("CMake binary gpuapp");
+    expect(titles).toContain("CMake library gpukernels");
+    expect(gpuapp?.entrypoints[0]).toMatchObject({ path: "src/main.cu", symbol: "main" });
+    expect(gpuapp?.tags).toContain("cuda");
+    expect(gpuapp?.summary).toContain("cuda_add_executable");
+    expect(gpukernels?.ownedFiles).toEqual([{ path: "src/kernels.cu", reason: "target source" }]);
+  });
+
+  it("detects CUDA projects from .cu sources", async () => {
+    const root = await fixtureRoot("clawpatch-cuda-detect-");
+    await writeFixture(root, "src/kernel.cu", "__global__ void noop(void) {}\n");
+
+    const project = await detectProject(root);
+
+    expect(project.detected.languages).toContain("cuda");
+  });
+
+  it("tags CUDA build targets with the concurrency trust boundary", async () => {
+    const root = await fixtureRoot("clawpatch-cuda-concurrency-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "project(gpuapp CUDA)\nadd_executable(gpuapp src/main.cu)\n",
+    );
+    await writeFixture(root, "src/main.cu", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const gpuapp = result.features.find((feature) => feature.title === "CMake binary gpuapp");
+
+    expect(gpuapp?.trustBoundaries).toContain("concurrency");
+  });
+
+  it("maps CMake and autotools build files as config features", async () => {
+    const root = await fixtureRoot("clawpatch-build-config-");
+    await writeFixture(root, "CMakeLists.txt", "project(app CXX)\nadd_executable(app main.cpp)\n");
+    await writeFixture(root, "CMakePresets.json", '{"version":6}\n');
+    await writeFixture(root, "configure.ac", "AC_INIT([app],[1.0])\n");
+    await writeFixture(root, "main.cpp", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+
+    expect(titles).toContain("Project config CMakeLists.txt");
+    expect(titles).toContain("Project config CMakePresets.json");
+    expect(titles).toContain("Project config configure.ac");
+  });
+
+  it("defaults C/C++ validation to make when the Makefile declares a check target", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-makefile-check-");
+    await writeFixture(root, "Makefile", "all:\n\tcc -o app main.c\n\ncheck:\n\t./app\n");
+    await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+
+    expect(project.detected.commands.typecheck).toBe("make");
+    expect(project.detected.commands.test).toBe("make check");
+  });
+
+  it("defaults C/C++ validation to make with no test command when the Makefile has none", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-makefile-notest-");
+    await writeFixture(root, "Makefile", "all:\n\tcc -o app main.c\n");
+    await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+
+    expect(project.detected.commands.typecheck).toBe("make");
+    expect(project.detected.commands.test).toBeNull();
+  });
+
+  it("emits a CMake workflow preset validation command when one is declared", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-preset-");
+    await writeFixture(root, "CMakeLists.txt", "project(app CXX)\nadd_executable(app main.cpp)\n");
+    await writeFixture(root, "main.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(
+      root,
+      "CMakePresets.json",
+      JSON.stringify({ version: 6, workflowPresets: [{ name: "default", steps: [] }] }),
+    );
+
+    const project = await detectProject(root);
+
+    expect(project.detected.commands.typecheck).toBe("cmake --workflow --preset default");
+  });
+
+  it("emits no C/C++ validation command for a CMake project without presets", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-nopreset-");
+    await writeFixture(root, "CMakeLists.txt", "project(app CXX)\nadd_executable(app main.cpp)\n");
+    await writeFixture(root, "main.cpp", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+
+    expect(project.detected.commands.typecheck).toBeNull();
+    expect(project.detected.commands.test).toBeNull();
+  });
+
+  it("emits no C/C++ validation command for ambiguous CMake presets", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-ambiguous-preset-");
+    await writeFixture(root, "CMakeLists.txt", "project(app CXX)\nadd_executable(app main.cpp)\n");
+    await writeFixture(root, "main.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(
+      root,
+      "CMakePresets.json",
+      JSON.stringify({
+        version: 6,
+        workflowPresets: [
+          { name: "debug", steps: [] },
+          { name: "release", steps: [] },
+        ],
+      }),
+    );
+
+    const project = await detectProject(root);
+
+    expect(project.detected.commands.typecheck).toBeNull();
+  });
+
+  it("maps loose C++ sources with no build target as a source-group feature", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-group-");
+    await writeFixture(root, "lib/parser.cpp", "int parse(void) { return 0; }\n");
+    await writeFixture(root, "lib/lexer.cpp", "int lex(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const group = result.features.find((feature) => feature.title === "C/C++ source group lib");
+
+    expect(group?.kind).toBe("library");
+    expect(group?.source).toBe("c-cpp-group");
+    expect(group?.ownedFiles).toEqual([
+      { path: "lib/lexer.cpp", reason: "source group member" },
+      { path: "lib/parser.cpp", reason: "source group member" },
+    ]);
+  });
+
+  it("excludes files already owned by a CMake target from source groups", async () => {
+    const root = await fixtureRoot("clawpatch-cpp-group-exclude-");
+    await writeFixture(root, "CMakeLists.txt", "add_executable(app src/main.cpp)\n");
+    await writeFixture(root, "src/main.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/helper.cpp", "int help(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const group = result.features.find((feature) => feature.title === "C/C++ source group src");
+
+    expect(group?.ownedFiles).toEqual([{ path: "src/helper.cpp", reason: "source group member" }]);
+  });
+
+  it("maps a loose CUDA kernel directory as a CUDA source group with concurrency", async () => {
+    const root = await fixtureRoot("clawpatch-cuda-group-");
+    await writeFixture(
+      root,
+      "kernels/reduce.cu",
+      "__global__ void reduce(float *x) { x[0] = 0; }\n",
+    );
+    await writeFixture(root, "kernels/reduce.cuh", "__global__ void reduce(float *x);\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const group = result.features.find((feature) => feature.title === "CUDA source group kernels");
+
+    expect(group?.tags).toContain("cuda");
+    expect(group?.trustBoundaries).toContain("concurrency");
+    expect(group?.ownedFiles).toEqual([
+      { path: "kernels/reduce.cu", reason: "source group member" },
+      { path: "kernels/reduce.cuh", reason: "source group member" },
+    ]);
+  });
+
+  it("emits no C/C++ validation command for an autotools-only project", async () => {
+    const root = await fixtureRoot("clawpatch-autotools-nullcmd-");
+    await writeFixture(root, "Makefile.am", "bin_PROGRAMS = app\napp_SOURCES = main.c\n");
+    await writeFixture(root, "main.c", "int main(void) { return 0; }\n");
+
+    const project = await detectProject(root);
+
+    expect(project.detected.commands.typecheck).toBeNull();
+    expect(project.detected.commands.test).toBeNull();
+  });
+
   it("maps autotools targets from Makefile.in", async () => {
     const root = await fixtureRoot("clawpatch-autotools-makefile-in-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -11886,6 +11886,25 @@ add_executable(headerapp include/headers.hpp)
     expect(gpuapp?.trustBoundaries).toContain("concurrency");
   });
 
+  it("tags mixed CMake targets as CUDA when any owned source is .cu", async () => {
+    const root = await fixtureRoot("clawpatch-cmake-mixed-cuda-");
+    await writeFixture(
+      root,
+      "CMakeLists.txt",
+      "project(gpuapp CUDA CXX)\nadd_executable(gpuapp src/main.cpp src/kernel.cu)\n",
+    );
+    await writeFixture(root, "src/main.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/kernel.cu", "__global__ void scale(float *x) { x[0] = 1.0f; }\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const gpuapp = result.features.find((feature) => feature.title === "CMake binary gpuapp");
+
+    expect(gpuapp?.entrypoints[0]).toMatchObject({ path: "src/main.cpp", symbol: "main" });
+    expect(gpuapp?.tags).toContain("cuda");
+    expect(gpuapp?.trustBoundaries).toContain("concurrency");
+  });
+
   it("maps CMake and autotools build files as config features", async () => {
     const root = await fixtureRoot("clawpatch-build-config-");
     await writeFixture(root, "CMakeLists.txt", "project(app CXX)\nadd_executable(app main.cpp)\n");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -11870,6 +11870,37 @@ add_executable(headerapp include/headers.hpp)
     expect(project.detected.languages).toContain("cuda");
   });
 
+  it("surfaces native commands on mixed Python + CUDA projects", async () => {
+    const root = await fixtureRoot("clawpatch-cuda-mixed-py-");
+    await writeFixture(root, "pyproject.toml", '[project]\nname="demo"\ndependencies=["pytest"]\n');
+    await writeFixture(root, "tests/test_demo.py", "def test_ok(): assert True\n");
+    await writeFixture(root, "src/kernel.cu", "__global__ void noop(void) {}\n");
+    await writeFixture(root, "Makefile", "all:\n\techo build\n\ncheck:\n\techo run native tests\n");
+
+    const project = await detectProject(root);
+
+    expect(project.detected.languages).toContain("cuda");
+    expect(project.detected.languages).toContain("python");
+    expect(project.detected.commands.test).toBe("pytest");
+    expect(project.detected.nativeCommands).toEqual({
+      typecheck: null,
+      lint: null,
+      format: null,
+      test: "make check",
+    });
+  });
+
+  it("leaves nativeCommands null when the primary command set already covers C/C++/CUDA", async () => {
+    const root = await fixtureRoot("clawpatch-cuda-native-only-");
+    await writeFixture(root, "src/kernel.cu", "__global__ void noop(void) {}\n");
+    await writeFixture(root, "Makefile", "all:\n\techo build\n\ncheck:\n\techo run native tests\n");
+
+    const project = await detectProject(root);
+
+    expect(project.detected.commands.test).toBe("make check");
+    expect(project.detected.nativeCommands).toBeNull();
+  });
+
   it("tags CUDA build targets with the concurrency trust boundary", async () => {
     const root = await fixtureRoot("clawpatch-cuda-concurrency-");
     await writeFixture(

--- a/src/mappers/c-cpp-groups.ts
+++ b/src/mappers/c-cpp-groups.ts
@@ -1,0 +1,53 @@
+import { chunkFiles, partitionFileGroups } from "./grouping.js";
+import { isCOrCppPath, isCOrCppTestPath, languageTag, withCudaConcurrency } from "./shared.js";
+import { FeatureSeed } from "./types.js";
+
+const sourceGroupMaxFiles = 12;
+
+export function cCppGroupSeeds(sourceFiles: string[], ownedPaths: Set<string>): FeatureSeed[] {
+  const residual = sourceFiles.filter(
+    (path) => isCOrCppPath(path) && !ownedPaths.has(path) && !isCOrCppTestPath(path),
+  );
+  if (residual.length === 0) {
+    return [];
+  }
+  const byTopDir = new Map<string, string[]>();
+  for (const path of residual) {
+    const slash = path.indexOf("/");
+    const topDir = slash === -1 ? "" : path.slice(0, slash);
+    byTopDir.set(topDir, [...(byTopDir.get(topDir) ?? []), path]);
+  }
+  const seeds: FeatureSeed[] = [];
+  for (const [topDir, files] of [...byTopDir.entries()].toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    const groups =
+      topDir === ""
+        ? chunkFiles(".", files.toSorted(), sourceGroupMaxFiles)
+        : partitionFileGroups(topDir, files, sourceGroupMaxFiles);
+    for (const group of groups) {
+      seeds.push(groupSeed(group.label, group.files));
+    }
+  }
+  return seeds;
+}
+
+function groupSeed(label: string, files: string[]): FeatureSeed {
+  const sorted = files.toSorted();
+  const tags = [...new Set(sorted.map(languageTag))];
+  const isCuda = tags.includes("cuda");
+  return {
+    title: `${isCuda ? "CUDA" : "C/C++"} source group ${label}`,
+    summary: `C/C++/CUDA source files under ${label} not owned by a build target.`,
+    kind: "library",
+    source: "c-cpp-group",
+    confidence: "low",
+    entryPath: sorted[0] ?? label,
+    symbol: label,
+    route: null,
+    command: null,
+    tags: [...tags, "source-group"],
+    trustBoundaries: withCudaConcurrency(["filesystem"], isCuda ? "cuda" : "cpp"),
+    ownedFiles: sorted.map((path) => ({ path, reason: "source group member" })),
+  };
+}

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -4,12 +4,16 @@ import {
   isSafeFile,
   isCOrCppTestPath,
   isSampleProjectPath,
+  languageLabel,
+  languageTag,
   normalize,
   packageTrustBoundaries,
   shouldSkip,
   stripLineComments,
   walk,
+  withCudaConcurrency,
 } from "./shared.js";
+import { cCppGroupSeeds } from "./c-cpp-groups.js";
 import { FeatureSeed, SeedFileRef } from "./types.js";
 
 export async function cCppSeeds(root: string): Promise<FeatureSeed[]> {
@@ -29,15 +33,19 @@ export async function cCppSeeds(root: string): Promise<FeatureSeed[]> {
       .flatMap((seed) => [seed.entryPath, ...(seed.ownedFiles?.map((file) => file.path) ?? [])]),
   );
   seeds.push(...(await mainFunctionTargets(root, files, alreadySeeded)));
+  const ownedPaths = new Set(
+    seeds.flatMap((seed) => [seed.entryPath, ...(seed.ownedFiles?.map((file) => file.path) ?? [])]),
+  );
+  seeds.push(...cCppGroupSeeds(files.filter(isCOrCppSource), ownedPaths));
   return dedupeByEntry(seeds);
 }
 
 function isCOrCppSource(path: string): boolean {
-  return /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/iu.test(path);
+  return /\.(?:c|cc|cpp|cxx|cu|cuh|h|hh|hpp|hxx)$/iu.test(path);
 }
 
 function isCOrCppCompilable(path: string): boolean {
-  return /\.(?:c|cc|cpp|cxx)$/iu.test(path);
+  return /\.(?:c|cc|cpp|cxx|cu)$/iu.test(path);
 }
 
 function isMakefile(path: string): boolean {
@@ -46,10 +54,6 @@ function isMakefile(path: string): boolean {
 
 function isCMake(path: string): boolean {
   return path.endsWith("CMakeLists.txt") || path.endsWith(".cmake");
-}
-
-function languageTag(path: string): "c" | "cpp" {
-  return /\.(?:C|H)$/u.test(path) || /\.(?:cc|cpp|cxx|hh|hpp|hxx)$/iu.test(path) ? "cpp" : "c";
 }
 
 async function autotoolsTargets(root: string, files: string[]): Promise<FeatureSeed[]> {
@@ -86,7 +90,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
         route: null,
         command: target,
         tags: [tag, "cli"],
-        trustBoundaries: ["user-input", "filesystem", "process-exec"],
+        trustBoundaries: withCudaConcurrency(["user-input", "filesystem", "process-exec"], tag),
         ownedFiles: targetSourceRefs(sourcePaths),
         contextFiles: [{ path: makefile, reason: "build target declaration" }],
       });
@@ -114,7 +118,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
         route: null,
         command: null,
         tags: [tag, "library"],
-        trustBoundaries: packageTrustBoundaries(target),
+        trustBoundaries: withCudaConcurrency(packageTrustBoundaries(target), tag),
         ownedFiles: targetSourceRefs(sourcePaths),
         contextFiles: [{ path: makefile, reason: "build target declaration" }],
       });
@@ -139,7 +143,10 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
     const body = stripCMakeComments(await readFile(join(root, cmakeFile), "utf8").catch(() => ""));
     const effectiveProjectSourceDir = cmakeDeclaresProject(body) ? dir : projectSourceDir;
     const effectiveProjectName = cmakeProjectName(body) ?? projectName;
-    for (const args of cmakeCommandArgs(body, "add_executable")) {
+    for (const { command, args } of cmakeTargetCalls(body, [
+      "add_executable",
+      "cuda_add_executable",
+    ])) {
       const [rawTarget = "", ...sources] = splitWords(args);
       const target = resolveCMakeTargetName(rawTarget, effectiveProjectName);
       if (!isValidTargetName(target)) {
@@ -182,7 +189,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
           route: null,
           command: null,
           tags: [languageTag(testEntryPath), "test"],
-          trustBoundaries: [],
+          trustBoundaries: withCudaConcurrency([], languageTag(testEntryPath)),
           ownedFiles: targetSourceRefs(sourcePaths),
           contextFiles: cmakeTargetContextFiles(
             cmakeFile,
@@ -197,7 +204,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       const tag = languageTag(entryPath);
       seeds.push({
         title: `CMake binary ${target}`,
-        summary: `CMake add_executable(${target}) declared in ${cmakeFile}.`,
+        summary: `CMake ${command}(${target}) declared in ${cmakeFile}.`,
         kind: "cli-command",
         source: "cmake-bin",
         confidence: "high",
@@ -206,12 +213,12 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         route: null,
         command: target,
         tags: [tag, "cli"],
-        trustBoundaries: ["user-input", "filesystem", "process-exec"],
+        trustBoundaries: withCudaConcurrency(["user-input", "filesystem", "process-exec"], tag),
         ownedFiles: targetSourceRefs(sourcePaths),
         contextFiles,
       });
     }
-    for (const args of cmakeCommandArgs(body, "add_library")) {
+    for (const { command, args } of cmakeTargetCalls(body, ["add_library", "cuda_add_library"])) {
       const [rawTarget = "", ...sources] = splitWords(args);
       const target = resolveCMakeTargetName(rawTarget, effectiveProjectName);
       if (!isValidTargetName(target)) {
@@ -236,7 +243,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       const tag = languageTag(entryPath);
       seeds.push({
         title: `CMake library ${target}`,
-        summary: `CMake add_library(${target}) declared in ${cmakeFile}.`,
+        summary: `CMake ${command}(${target}) declared in ${cmakeFile}.`,
         kind: "library",
         source: "cmake-lib",
         confidence: "high",
@@ -245,7 +252,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         route: null,
         command: null,
         tags: [tag, "library"],
-        trustBoundaries: packageTrustBoundaries(target),
+        trustBoundaries: withCudaConcurrency(packageTrustBoundaries(target), tag),
         ownedFiles: targetSourceRefs(sourcePaths),
         contextFiles: cmakeTargetContextFiles(cmakeFile, "CMake target declaration", extraSources),
       });
@@ -515,6 +522,15 @@ function cmakeSubdirectories(body: string): string[] {
   return directories;
 }
 
+function cmakeTargetCalls(
+  body: string,
+  commands: string[],
+): Array<{ command: string; args: string }> {
+  return commands.flatMap((command) =>
+    cmakeCommandArgs(body, command).map((args) => ({ command, args })),
+  );
+}
+
 function cmakeCommandArgs(body: string, command: string): string[] {
   const args: string[] = [];
   const needle = command.toLowerCase();
@@ -660,8 +676,8 @@ async function mainFunctionTargets(
         .at(-1)
         ?.replace(/\.[^.]+$/u, "") ?? "main";
     seeds.push({
-      title: `${tag === "cpp" ? "C++" : "C"} binary ${command}`,
-      summary: `C/C++ source file with a top-level main() at ${file}.`,
+      title: `${languageLabel(tag)} binary ${command}`,
+      summary: `${tag === "cuda" ? "CUDA" : "C/C++"} source file with a top-level main() at ${file}.`,
       kind: "cli-command",
       source: "c-main",
       confidence: "medium",
@@ -670,7 +686,7 @@ async function mainFunctionTargets(
       route: null,
       command,
       tags: [tag, "cli"],
-      trustBoundaries: ["user-input", "filesystem", "process-exec"],
+      trustBoundaries: withCudaConcurrency(["user-input", "filesystem", "process-exec"], tag),
     });
   }
   return seeds;

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -10,6 +10,7 @@ import {
   packageTrustBoundaries,
   shouldSkip,
   stripLineComments,
+  targetLanguageTag,
   walk,
   withCudaConcurrency,
 } from "./shared.js";
@@ -78,7 +79,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
       if (entryPath === null) {
         continue;
       }
-      const tag = languageTag(entryPath);
+      const tag = targetLanguageTag(entryPath, sourcePaths);
       seeds.push({
         title: `Autotools binary ${target}`,
         summary: `Autotools bin_PROGRAMS target declared in ${makefile}.`,
@@ -106,7 +107,7 @@ async function autotoolsTargets(root: string, files: string[]): Promise<FeatureS
         continue;
       }
       const entryPath = pickEntry(sourcePaths, target) ?? makefile;
-      const tag = languageTag(entryPath);
+      const tag = targetLanguageTag(entryPath, sourcePaths);
       seeds.push({
         title: `Autotools library ${target}`,
         summary: `Autotools lib_LTLIBRARIES target declared in ${makefile}.`,
@@ -178,6 +179,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
       }
       const testEntryPath = cmakeTestExecutableEntry(target, entryPath);
       if (testEntryPath !== null) {
+        const testTag = targetLanguageTag(testEntryPath, sourcePaths);
         seeds.push({
           title: `CMake test suite ${target}`,
           summary: `CMake test executable ${target} declared in ${cmakeFile}.`,
@@ -188,8 +190,8 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
           symbol: null,
           route: null,
           command: null,
-          tags: [languageTag(testEntryPath), "test"],
-          trustBoundaries: withCudaConcurrency([], languageTag(testEntryPath)),
+          tags: [testTag, "test"],
+          trustBoundaries: withCudaConcurrency([], testTag),
           ownedFiles: targetSourceRefs(sourcePaths),
           contextFiles: cmakeTargetContextFiles(
             cmakeFile,
@@ -201,7 +203,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         });
         continue;
       }
-      const tag = languageTag(entryPath);
+      const tag = targetLanguageTag(entryPath, sourcePaths);
       seeds.push({
         title: `CMake binary ${target}`,
         summary: `CMake ${command}(${target}) declared in ${cmakeFile}.`,
@@ -240,7 +242,7 @@ async function cmakeTargets(root: string, files: string[]): Promise<FeatureSeed[
         continue;
       }
       const entryPath = pickEntry(sourcePaths, target) ?? cmakeFile;
-      const tag = languageTag(entryPath);
+      const tag = targetLanguageTag(entryPath, sourcePaths);
       seeds.push({
         title: `CMake library ${target}`,
         summary: `CMake ${command}(${target}) declared in ${cmakeFile}.`,

--- a/src/mappers/config.ts
+++ b/src/mappers/config.ts
@@ -23,6 +23,9 @@ export async function configSeeds(root: string): Promise<FeatureSeed[]> {
     "composer.lock",
     "phpunit.xml",
     "Makefile",
+    "CMakeLists.txt",
+    "CMakePresets.json",
+    "configure.ac",
   ];
   const seeds: FeatureSeed[] = [];
   for (const file of candidates) {

--- a/src/mappers/grouping.ts
+++ b/src/mappers/grouping.ts
@@ -75,7 +75,7 @@ function partitionAt(
   return groups;
 }
 
-function chunkFiles(label: string, files: string[], maxFiles: number): FileGroup[] {
+export function chunkFiles(label: string, files: string[], maxFiles: number): FileGroup[] {
   if (files.length === 0) {
     return [];
   }

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -392,7 +392,7 @@ function isJsTestPath(path: string): boolean {
 }
 
 export function isCOrCppPath(path: string): boolean {
-  return /\.(?:c|cc|cpp|cxx|h|hh|hpp|hxx)$/iu.test(path);
+  return /\.(?:c|cc|cpp|cxx|cu|cuh|h|hh|hpp|hxx)$/iu.test(path);
 }
 
 export function isCOrCppTestPath(path: string): boolean {
@@ -403,6 +403,29 @@ export function isCOrCppTestPath(path: string): boolean {
     /(?:^|[_-])tests?\./iu.test(base) ||
     /Tests?\.[^.]+$/u.test(base)
   );
+}
+
+export type LanguageTag = "c" | "cpp" | "cuda";
+
+export function languageTag(path: string): LanguageTag {
+  if (/\.cuh?$/iu.test(path)) {
+    return "cuda";
+  }
+  return /\.(?:C|H)$/u.test(path) || /\.(?:cc|cpp|cxx|hh|hpp|hxx)$/iu.test(path) ? "cpp" : "c";
+}
+
+export function languageLabel(tag: LanguageTag): string {
+  return tag === "cuda" ? "CUDA" : tag === "cpp" ? "C++" : "C";
+}
+
+export function withCudaConcurrency(
+  boundaries: TrustBoundary[],
+  tag: LanguageTag,
+): TrustBoundary[] {
+  if (tag !== "cuda" || boundaries.includes("concurrency")) {
+    return boundaries;
+  }
+  return [...boundaries, "concurrency"];
 }
 
 function shouldSkipCOrCppNearbyPath(path: string): boolean {

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -418,6 +418,13 @@ export function languageLabel(tag: LanguageTag): string {
   return tag === "cuda" ? "CUDA" : tag === "cpp" ? "C++" : "C";
 }
 
+export function targetLanguageTag(entryPath: string, sourcePaths: readonly string[]): LanguageTag {
+  if (sourcePaths.some((path) => languageTag(path) === "cuda")) {
+    return "cuda";
+  }
+  return languageTag(entryPath);
+}
+
 export function withCudaConcurrency(
   boundaries: TrustBoundary[],
   tag: LanguageTag,

--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -318,6 +318,7 @@ function project(root: string): ProjectRecord {
       frameworks: [],
       packageManagers: ["npm"],
       commands: defaultConfig().commands,
+      nativeCommands: null,
     },
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),

--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -195,6 +195,112 @@ describe("review prompt provenance", () => {
   });
 });
 
+describe("CUDA prompt guidance", () => {
+  it("includes CUDA review guidance for a feature that owns a .cu file", async () => {
+    const root = await fixtureRoot("clawpatch-prompt-cuda-review-");
+    await writeFixture(root, "src/kernel.cu", "__global__ void k(void) {}\n");
+    const cudaFeature: FeatureRecord = {
+      ...feature(),
+      entrypoints: [],
+      ownedFiles: [{ path: "src/kernel.cu", reason: "kernel" }],
+      contextFiles: [],
+    };
+    const bundle = await buildReviewPromptBundle(root, project(root), cudaFeature, defaultConfig());
+
+    expect(bundle.prompt).toContain("CUDA hazards");
+  });
+
+  it("omits CUDA review guidance for a non-CUDA feature", async () => {
+    const root = await fixtureRoot("clawpatch-prompt-noncuda-review-");
+    await writeFixture(root, "src/index.ts", "export const value = 1;\n");
+    const tsFeature: FeatureRecord = {
+      ...feature(),
+      entrypoints: [],
+      ownedFiles: [{ path: "src/index.ts", reason: "primary" }],
+      contextFiles: [],
+    };
+    const bundle = await buildReviewPromptBundle(root, project(root), tsFeature, defaultConfig());
+
+    expect(bundle.prompt).not.toContain("CUDA hazards");
+  });
+
+  it("omits CUDA review guidance in deslopify mode even for a CUDA feature", async () => {
+    const root = await fixtureRoot("clawpatch-prompt-cuda-deslopify-");
+    await writeFixture(root, "src/kernel.cu", "__global__ void k(void) {}\n");
+    const cudaFeature: FeatureRecord = {
+      ...feature(),
+      entrypoints: [],
+      ownedFiles: [{ path: "src/kernel.cu", reason: "kernel" }],
+      contextFiles: [],
+    };
+    const bundle = await buildReviewPromptBundle(
+      root,
+      project(root),
+      cudaFeature,
+      defaultConfig(),
+      "deslopify",
+    );
+
+    expect(bundle.prompt).not.toContain("CUDA hazards");
+  });
+
+  it("includes CUDA review guidance for a mixed feature whose entrypoint is C++ but owns a .cu file", async () => {
+    const root = await fixtureRoot("clawpatch-prompt-cuda-mixed-");
+    await writeFixture(root, "src/main.cpp", "int main(void) { return 0; }\n");
+    await writeFixture(root, "src/kernel.cu", "__global__ void k(void) {}\n");
+    const mixedFeature: FeatureRecord = {
+      ...feature(),
+      entrypoints: [{ path: "src/main.cpp", symbol: "main", route: null, command: null }],
+      ownedFiles: [
+        { path: "src/main.cpp", reason: "host" },
+        { path: "src/kernel.cu", reason: "kernel" },
+      ],
+      contextFiles: [],
+    };
+    const bundle = await buildReviewPromptBundle(
+      root,
+      project(root),
+      mixedFeature,
+      defaultConfig(),
+    );
+
+    expect(bundle.prompt).toContain("CUDA hazards");
+  });
+
+  it("includes CUDA guidance in the fix prompt for a CUDA feature", async () => {
+    const root = await fixtureRoot("clawpatch-prompt-cuda-fix-");
+    await writeFixture(root, "src/kernel.cu", "__global__ void k(void) {}\n");
+    const cudaFeature: FeatureRecord = {
+      ...feature(),
+      entrypoints: [],
+      ownedFiles: [{ path: "src/kernel.cu", reason: "kernel" }],
+      contextFiles: [],
+    };
+    const prompt = await buildFixPrompt(
+      root,
+      finding("src/kernel.cu"),
+      cudaFeature,
+      defaultConfig(),
+    );
+
+    expect(prompt).toContain("CUDA hazards");
+  });
+
+  it("omits CUDA guidance in the fix prompt for a non-CUDA feature", async () => {
+    const root = await fixtureRoot("clawpatch-prompt-noncuda-fix-");
+    await writeFixture(root, "src/index.ts", "export const value = 1;\n");
+    const tsFeature: FeatureRecord = {
+      ...feature(),
+      entrypoints: [],
+      ownedFiles: [{ path: "src/index.ts", reason: "primary" }],
+      contextFiles: [],
+    };
+    const prompt = await buildFixPrompt(root, finding("src/index.ts"), tsFeature, defaultConfig());
+
+    expect(prompt).not.toContain("CUDA hazards");
+  });
+});
+
 function project(root: string): ProjectRecord {
   return {
     schemaVersion: 1,

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -181,6 +181,8 @@ ${customPrompt.trim()}
   const validEvidencePaths = [
     ...new Set(includedFiles.filter((file) => file.readable).map((file) => file.path)),
   ];
+  const cudaBlock =
+    mode === "default" && featureIncludesCuda(feature) ? `\n${cudaGuidance()}\n` : "";
   const prompt = `You are reviewing one semantic feature for clawpatch.
 
 Return strict JSON only. No markdown fences.
@@ -204,7 +206,7 @@ ${customBlock}Review categories:
 - release/build hazards
 - maintainability risks with concrete impact
 
-${reviewModeInstructions(mode)}
+${reviewModeInstructions(mode)}${cudaBlock}
 
 Inspect owned files, context files, and linked tests. Treat included tests as first-class
 evidence of intended behavior. If tests contradict a suspected bug, either skip it or
@@ -345,6 +347,25 @@ function reviewModeInstructions(mode: ReviewMode): string {
   throw new Error(`Unsupported review mode: ${mode}`);
 }
 
+function featureIncludesCuda(feature: FeatureRecord): boolean {
+  const paths = [
+    ...feature.entrypoints.map((entrypoint) => entrypoint.path),
+    ...feature.ownedFiles.map((file) => file.path),
+  ];
+  return paths.some((path) => /\.cuh?$/iu.test(path));
+}
+
+function cudaGuidance(): string {
+  return `This feature includes CUDA .cu/.cuh sources. Inspect for these CUDA hazards:
+- Kernel data races; missing, divergent, or conditionally-reached __syncthreads()/__syncwarp() barriers.
+- Unchecked CUDA runtime calls (cudaMalloc, cudaMemcpy, cudaFree, async copies) and missing cudaGetLastError()/cudaDeviceSynchronize() after a kernel launch.
+- Host vs. device pointer confusion: dereferencing device memory on the host, or passing the wrong memory space or copy direction to cudaMemcpy.
+- Out-of-bounds or uncoalesced global-memory access, shared-memory bank conflicts, and blockIdx/threadIdx-derived indices used without bounds checks.
+- Stream and event synchronization errors, including use-after-free across asynchronous copies.
+- Device-memory leaks: allocations not freed on every return path.
+Map findings to the existing categories (concurrency, bug, data-loss, performance). Report only hazards visible in the included code; do not speculate about GPU runtime behavior you cannot see.`;
+}
+
 export async function buildRevalidatePrompt(root: string, findingJson: string): Promise<string> {
   return `Revalidate this clawpatch finding against the current repository at ${root}.
 
@@ -369,6 +390,7 @@ export async function buildFixPrompt(
   for (const path of fixPromptPaths(finding, feature, config)) {
     fileBlocks.push(await rawFileBlock(root, path));
   }
+  const cudaBlock = featureIncludesCuda(feature) ? `\n${cudaGuidance()}\n` : "";
   return `You are clawpatch applying one small repair in the current repository.
 
 Fix only the finding below. Keep the patch minimal. Add or update focused tests when feasible.
@@ -382,7 +404,7 @@ After editing, return strict JSON only:
   "steps": ["string"],
   "validationCommands": ["string"]
 }
-
+${cudaBlock}
 Finding:
 ${JSON.stringify(finding, null, 2)}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,7 @@ export const projectRecordSchema = z.object({
     frameworks: z.array(z.string()),
     packageManagers: z.array(z.string()),
     commands: projectCommandsSchema,
+    nativeCommands: projectCommandsSchema.nullable().optional().default(null),
   }),
   createdAt: z.string(),
   updatedAt: z.string(),
@@ -130,6 +131,7 @@ export const configSchema = z.object({
     reasoningEffort: reasoningEffortSchema.nullable().optional().default(null),
   }),
   commands: projectCommandsSchema,
+  nativeCommands: projectCommandsSchema.nullable().optional().default(null),
   review: z.object({
     maxContextFiles: z.number().int().positive(),
     maxOwnedFiles: z.number().int().positive(),

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { validationCommandsForFeature } from "./validation.js";
+import { FeatureRecord } from "./types.js";
+
+const baseCommands = {
+  typecheck: "mypy .",
+  lint: "ruff check .",
+  format: "ruff format --check .",
+  test: "pytest",
+};
+
+const nativeCommands = {
+  typecheck: null,
+  lint: null,
+  format: null,
+  test: "ctest --preset default",
+};
+
+function feature(tags: string[]): FeatureRecord {
+  return {
+    schemaVersion: 1,
+    featureId: "feat_test",
+    title: "test",
+    summary: "test",
+    kind: "library",
+    source: "cmake-bin",
+    confidence: "high",
+    entrypoints: [],
+    ownedFiles: [],
+    contextFiles: [],
+    tests: [],
+    tags,
+    trustBoundaries: [],
+    status: "pending",
+    lock: null,
+    findingIds: [],
+    patchAttemptIds: [],
+    analysisHistory: [],
+    createdAt: "1970-01-01T00:00:00.000Z",
+    updatedAt: "1970-01-01T00:00:00.000Z",
+  };
+}
+
+describe("validationCommandsForFeature", () => {
+  it("uses primary commands when no nativeCommands are configured", () => {
+    expect(validationCommandsForFeature(feature(["python"]), baseCommands, null)).toEqual([
+      "ruff format --check .",
+      "mypy .",
+      "ruff check .",
+      "pytest",
+    ]);
+  });
+
+  it("uses primary commands for features without a native language tag", () => {
+    expect(validationCommandsForFeature(feature(["python"]), baseCommands, nativeCommands)).toEqual(
+      ["ruff format --check .", "mypy .", "ruff check .", "pytest"],
+    );
+  });
+
+  it("uses nativeCommands for cuda-tagged features when configured", () => {
+    expect(validationCommandsForFeature(feature(["cuda"]), baseCommands, nativeCommands)).toEqual([
+      "ctest --preset default",
+    ]);
+  });
+
+  it("uses nativeCommands for cpp-tagged features when configured", () => {
+    expect(
+      validationCommandsForFeature(feature(["cpp", "library"]), baseCommands, nativeCommands),
+    ).toEqual(["ctest --preset default"]);
+  });
+
+  it("uses nativeCommands for c-tagged features when configured", () => {
+    expect(validationCommandsForFeature(feature(["c"]), baseCommands, nativeCommands)).toEqual([
+      "ctest --preset default",
+    ]);
+  });
+
+  it("falls back to primary commands for native features when nativeCommands is null", () => {
+    expect(validationCommandsForFeature(feature(["cuda"]), baseCommands, null)).toEqual([
+      "ruff format --check .",
+      "mypy .",
+      "ruff check .",
+      "pytest",
+    ]);
+  });
+});

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -8,21 +8,29 @@ export type ValidationCommandConfig = {
   test: string | null;
 };
 
+const nativeFeatureTags = new Set(["c", "cpp", "cuda"]);
+
 export function validationCommandsForFeature(
   feature: FeatureRecord | null,
   commands: ValidationCommandConfig,
+  nativeCommands: ValidationCommandConfig | null = null,
 ): string[] {
+  const effective = nativeCommands !== null && featureIsNative(feature) ? nativeCommands : commands;
   const featureCommands = (feature?.tests ?? []).flatMap((test) =>
     test.command === null || test.command.length === 0 ? [] : [test.command],
   );
   const configuredTest =
-    feature?.tags.includes(suppressedTestCommandTag) === true ? null : commands.test;
+    feature?.tags.includes(suppressedTestCommandTag) === true ? null : effective.test;
   const ordered = [
-    commands.format,
+    effective.format,
     ...featureCommands,
-    commands.typecheck,
-    commands.lint,
+    effective.typecheck,
+    effective.lint,
     configuredTest,
   ].filter((command): command is string => command !== null && command.length > 0);
   return Array.from(new Set(ordered));
+}
+
+function featureIsNative(feature: FeatureRecord | null): boolean {
+  return feature?.tags.some((tag) => nativeFeatureTags.has(tag)) === true;
 }

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -2143,6 +2143,34 @@ describe("workflow", () => {
     expect(config.commands.test).toBe("npm run test");
   });
 
+  it("loads pre-existing config files that pre-date nativeCommands", async () => {
+    const root = await fixtureRoot("clawpatch-config-pre-native-");
+    await writeFixture(
+      root,
+      ".clawpatch/config.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        stateDir: ".clawpatch",
+        include: ["**/*"],
+        exclude: [".clawpatch/**"],
+        provider: { name: "codex", model: null },
+        commands: { typecheck: null, lint: null, format: null, test: "pytest" },
+        review: {
+          maxContextFiles: 24,
+          maxOwnedFiles: 12,
+          maxFindingsPerFeature: 10,
+          minConfidenceToFix: "medium",
+        },
+        git: { requireCleanWorktreeForFix: true, commit: false, openPr: false },
+      }),
+    );
+
+    const config = await loadConfig(root, testOptions(root));
+
+    expect(config.commands.test).toBe("pytest");
+    expect(config.nativeCommands).toBeNull();
+  });
+
   it("clean-locks requeues claimed features", async () => {
     const root = await fixtureRoot("clawpatch-clean-locks-");
     await writeFixture(


### PR DESCRIPTION
## Summary

- Recognize CUDA `.cu`/`.cuh` sources across standalone `main()` files, CMake `add_executable`/`add_library` (including the legacy `FindCUDA` `cuda_add_executable`/`cuda_add_library` commands), and autotools targets. Repositories containing CUDA sources are detected as `cuda` projects.
- Map source files that no build target owns into bounded, per-directory source groups, so loose C/C++/CUDA code is no longer skipped.
- Map `CMakeLists.txt`, `CMakePresets.json`, and `configure.ac` as config features.
- Emit conservative C/C++/CUDA validation commands only when the project declares them: a root `Makefile` `check`/`test` target, or a `CMakePresets.json` build workflow. No build command is invented.
- Select those C/C++/CUDA validation commands for features tagged `c`, `cpp`, or `cuda` even when another language's defaults win the project's language priority (for example a Python repository with CUDA kernels would otherwise run `pytest` against CUDA features). The native command set is captured alongside the primary set on `projectRecordSchema.detected.nativeCommands` and `configSchema.nativeCommands`; both fields are nullable and default to null, so existing `.clawpatch/config.json` files load without migration.
- Derive a target's language tag from all of its owned sources so a mixed CMake or autotools target that lists both `.cpp` and `.cu` sources is tagged `cuda` with the `concurrency` trust boundary, even when its entry point is the host `.cpp`.
- Tag CUDA build targets and source groups with the `concurrency` trust boundary.
- When a reviewed feature owns `.cu`/`.cuh` sources, add a CUDA hazard checklist to the review prompt (default mode only) and the fix prompt: kernel races and synchronization, unchecked CUDA runtime calls, host/device pointer confusion, memory-access hazards, and device-memory leaks. Detection is by file extension so mixed host/device targets are covered.
- Findings map to the existing `category` enum; no schema change. Deslopify mode and `--prompt-file` are unaffected, and non-CUDA prompts are unchanged.
- Update `README.md`, `docs/feature-mapping.md`, and `docs/code-review.md`; add changelog entries under `0.4.1 - Unreleased`.

## Why

clawpatch's C/C++ mapper handles generic project shapes, and CUDA was not covered. This change maps CUDA projects and makes the review aware of CUDA-specific bug classes. The mapper updates follow the existing C/C++ patterns; the review prompt change reuses the `reviewModeInstructions` injection style with extension-based triggering so mixed host/device targets are caught.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` (745 passed, 1 skipped)
- `pnpm build`
- `pnpm pack:smoke`

## Demonstration

To make the CUDA-aware mapping and review inspectable, here is the locally-built `clawpatch` run against a small demo CUDA project (one `CMakeLists.txt` plus `src/main.cu`, `src/kernels.cu`, `src/kernels.cuh`). The CMake target lists `.cu` and `.cuh` sources, and the demo carries deliberate textbook CUDA hazards.

<details>
<summary><code>clawpatch map</code> and <code>clawpatch review --provider codex</code> output</summary>

```
$ clawpatch map
clawpatch map mapper-done mapper=c-cpp seeds=1 elapsed=0s
clawpatch map heuristic-done features=2 new=2 changed=0 stale=0
clawpatch map done features=2 usedAgent=false elapsed=0s
features: 2
new: 2
source: heuristic

$ clawpatch review --provider codex --limit 5 --jobs 2
clawpatch review feature-start index=1 total=2 feature=feat_cli-command_880f7190ad title=CMake binary saxpy_demo
clawpatch review feature-start index=2 total=2 feature=feat_config_f4646e3d82 title=Project config CMakeLists.txt
clawpatch review feature-done index=2 total=2 feature=feat_config_f4646e3d82 findings=1 elapsed=24s
clawpatch review feature-done index=1 total=2 feature=feat_cli-command_880f7190ad findings=4 elapsed=41s
clawpatch review done reviewed=2 findings=5
```

</details>

The four findings produced by codex on the CUDA binary feature, excerpted from `clawpatch report`:

- `category: bug`, `confidence: high`, evidence `src/main.cu:30-32` and `src/kernels.cu:3-5`. "Kernel writes past the end for non-multiple block sizes. The launch rounds block count up for any n that is not an exact multiple of 256, but the kernel writes `y[i]` without checking `i < n`."
- `category: bug`, `confidence: high`, evidence `src/main.cu:24-34`. "CUDA runtime failures are ignored. `cudaMalloc`, `cudaMemcpy`, and the kernel launch are all used without checking return status or launch errors. Check every CUDA runtime call, check `cudaGetLastError()` immediately after the kernel launch, and call `cudaDeviceSynchronize()` before consuming results."
- `category: bug`, `confidence: high`, evidence `src/main.cu:12-17` and `src/main.cu:24-31`. "User supplied n is not validated before size calculations. `std::atoi` silently accepts non-numeric input as 0 and negative values as negative integers."
- `category: performance`, `confidence: high`, evidence `src/main.cu:22-25` and `src/main.cu:40-42`. "Device allocations are never freed. `d_x` and `d_y` are allocated with `cudaMalloc` but there are no matching `cudaFree` calls before the program returns."

Each finding maps to the existing `category` enum (`bug`, `build-release`, `performance`), and the binary feature carries the `cuda` tag with the `concurrency` trust boundary because its CMake target owns `.cu` and `.cuh` sources.


