### PR TITLE
fix(prompt): respect Python runtime syntax metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed Codex provider calls to time out stalled `codex exec` children and release review locks, thanks @camwest.
 - Fixed Python review prompts to include target runtime metadata and avoid flagging Python 3.14 syntax such as PEP 758 exception handlers as invalid, thanks @rohitjavvadi.
+
 ## 0.4.0 - 2026-05-22
 
 - Added `clawpatch ci` to initialize, map, review, write a report, and append a GitHub Actions step summary in one CI-friendly command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.4.1 - Unreleased
 
 - Fixed Codex provider calls to time out stalled `codex exec` children and release review locks, thanks @camwest.
-
+- Fixed Python review prompts to include target runtime metadata and avoid flagging Python 3.14 syntax such as PEP 758 exception handlers as invalid, thanks @rohitjavvadi.
 ## 0.4.0 - 2026-05-22
 
 - Added `clawpatch ci` to initialize, map, review, write a report, and append a GitHub Actions step summary in one CI-friendly command.

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -14059,6 +14059,38 @@ add_executable(headerapp include/headers.hpp)
     });
   });
 
+  it("adds Python target runtime metadata to source review context", async () => {
+    const root = await fixtureRoot("clawpatch-python-runtime-context-");
+    await writeFixture(root, ".python-version", "3.14\n");
+    await writeFixture(
+      root,
+      "pyproject.toml",
+      '[project]\nname = "pep758-demo"\nrequires-python = ">=3.14"\n',
+    );
+    await writeFixture(
+      root,
+      "main.py",
+      [
+        "def parse(value):",
+        "    try:",
+        "        return float(value)",
+        "    except TypeError, ValueError:",
+        "        return 0",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const source = result.features.find((feature) => feature.title === "Python source root");
+
+    expect(source?.ownedFiles).toEqual([{ path: "main.py", reason: "source group root" }]);
+    expect(source?.contextFiles).toEqual([
+      { path: "pyproject.toml", reason: "python target runtime metadata" },
+      { path: ".python-version", reason: "python target runtime metadata" },
+    ]);
+  });
+
   it("uses Hatch pytest commands in mapped Python features", async () => {
     const root = await fixtureRoot("clawpatch-python-hatch-map-");
     await writeFixture(

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -13412,7 +13412,53 @@ add_executable(headerapp include/headers.hpp)
 
     expect(project.detected.commands.test).toBe("pytest");
     expect(suite?.ownedFiles).toEqual([{ path: "test_app.py", reason: "pytest file" }]);
+    expect(suite?.contextFiles).toEqual([
+      { path: "pyproject.toml", reason: "python target runtime metadata" },
+      { path: "test_app.py", reason: "nearby test" },
+    ]);
+    expect(suite?.contextFiles).not.toContainEqual({
+      path: ".python-version",
+      reason: "python target runtime metadata",
+    });
+    expect(suite?.contextFiles).not.toContainEqual({
+      path: "runtime.txt",
+      reason: "python target runtime metadata",
+    });
     expect(suite?.tests).toEqual([{ path: "test_app.py", command: "pytest" }]);
+  });
+
+  it("threads Python runtime metadata into standalone pytest suites", async () => {
+    const root = await fixtureRoot("clawpatch-python-test-runtime-context-");
+    await writeFixture(root, "pyproject.toml", '[project]\nname = "runtime-tests"\n');
+    await writeFixture(root, ".python-version", "3.14\n");
+    await writeFixture(root, "runtime.txt", "python-3.14\n");
+    await writeFixture(
+      root,
+      "tests/test_pep758.py",
+      [
+        "def test_pep758_exception_group():",
+        "    try:",
+        "        int('x')",
+        "    except TypeError, ValueError:",
+        "        assert True",
+        "",
+      ].join("\n"),
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const suite = result.features.find((feature) => feature.title === "Python test suite tests");
+
+    expect(suite?.contextFiles).toContainEqual({
+      path: ".python-version",
+      reason: "python target runtime metadata",
+    });
+    expect(suite?.contextFiles).toContainEqual({
+      path: "runtime.txt",
+      reason: "python target runtime metadata",
+    });
+    expect(suite?.ownedFiles).toEqual([{ path: "tests/test_pep758.py", reason: "pytest file" }]);
+    expect(suite?.tests).toEqual([{ path: "tests/test_pep758.py", command: "pytest" }]);
   });
 
   it("maps Flask routes under web source roots", async () => {

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -13461,6 +13461,107 @@ add_executable(headerapp include/headers.hpp)
     expect(suite?.tests).toEqual([{ path: "tests/test_pep758.py", command: "pytest" }]);
   });
 
+  it("uses nearest Python runtime metadata for nested source packages", async () => {
+    const root = await fixtureRoot("clawpatch-python-nested-runtime-context-");
+    await writeFixture(
+      root,
+      "pyproject.toml",
+      '[project]\nname = "workspace"\nrequires-python = ">=3.14"\n',
+    );
+    await writeFixture(root, ".python-version", "3.14\n");
+    await writeFixture(root, "apps/api/.python-version", "3.13\n");
+    await writeFixture(root, "apps/api/service.py", "def service():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const source = result.features.find((feature) =>
+      feature.ownedFiles.some((file) => file.path === "apps/api/service.py"),
+    );
+
+    expect(source?.contextFiles).toContainEqual({
+      path: "apps/api/.python-version",
+      reason: "python target runtime metadata",
+    });
+    expect(source?.contextFiles).not.toContainEqual({
+      path: ".python-version",
+      reason: "python target runtime metadata",
+    });
+    expect(source?.contextFiles).not.toContainEqual({
+      path: "pyproject.toml",
+      reason: "python target runtime metadata",
+    });
+  });
+
+  it("inherits Python runtime metadata past nested package files without version constraints", async () => {
+    const root = await fixtureRoot("clawpatch-python-inherited-runtime-context-");
+    await writeFixture(root, ".python-version", "3.14\n");
+    await writeFixture(root, "apps/api/pyproject.toml", '[project]\nname = "api"\n');
+    await writeFixture(root, "apps/api/service.py", "def service():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const source = result.features.find((feature) =>
+      feature.ownedFiles.some((file) => file.path === "apps/api/service.py"),
+    );
+
+    expect(source?.contextFiles).toContainEqual({
+      path: "apps/api/pyproject.toml",
+      reason: "python target runtime metadata",
+    });
+    expect(source?.contextFiles).toContainEqual({
+      path: ".python-version",
+      reason: "python target runtime metadata",
+    });
+  });
+
+  it("uses nested Poetry Python constraints instead of ancestor runtime metadata", async () => {
+    const root = await fixtureRoot("clawpatch-python-poetry-runtime-context-");
+    await writeFixture(root, ".python-version", "3.14\n");
+    await writeFixture(
+      root,
+      "apps/api/pyproject.toml",
+      '[tool.poetry]\nname = "api"\n\n[tool.poetry.dependencies]\npython = "^3.13"\n',
+    );
+    await writeFixture(root, "apps/api/service.py", "def service():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const source = result.features.find((feature) =>
+      feature.ownedFiles.some((file) => file.path === "apps/api/service.py"),
+    );
+
+    expect(source?.contextFiles).toContainEqual({
+      path: "apps/api/pyproject.toml",
+      reason: "python target runtime metadata",
+    });
+    expect(source?.contextFiles).not.toContainEqual({
+      path: ".python-version",
+      reason: "python target runtime metadata",
+    });
+  });
+
+  it("does not treat non-Python tool versions as a Python runtime constraint", async () => {
+    const root = await fixtureRoot("clawpatch-python-tool-versions-context-");
+    await writeFixture(root, ".python-version", "3.14\n");
+    await writeFixture(root, "apps/api/.tool-versions", "nodejs 22.0.0\n");
+    await writeFixture(root, "apps/api/service.py", "def service():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const source = result.features.find((feature) =>
+      feature.ownedFiles.some((file) => file.path === "apps/api/service.py"),
+    );
+
+    expect(source?.contextFiles).toContainEqual({
+      path: "apps/api/.tool-versions",
+      reason: "python target runtime metadata",
+    });
+    expect(source?.contextFiles).toContainEqual({
+      path: ".python-version",
+      reason: "python target runtime metadata",
+    });
+  });
+
   it("maps Flask routes under web source roots", async () => {
     const root = await fixtureRoot("clawpatch-python-flask-routes-");
     await writeFixture(root, "requirements.txt", "Flask\npytest\n");

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -190,7 +190,7 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
     });
   }
 
-  for (const test of standaloneTestSuites(testFiles, testCommand)) {
+  for (const test of standaloneTestSuites(testFiles, testCommand, runtimeContextFiles)) {
     seeds.push(test);
   }
 
@@ -1666,7 +1666,11 @@ function fastApiRouteTrustBoundaries(route: FastApiRoute): FeatureSeed["trustBou
   return boundaries;
 }
 
-function standaloneTestSuites(testFiles: string[], command: string | null): FeatureSeed[] {
+function standaloneTestSuites(
+  testFiles: string[],
+  command: string | null,
+  runtimeContextFiles: SeedFileRef[],
+): FeatureSeed[] {
   if (testFiles.length === 0) {
     return [];
   }
@@ -1685,7 +1689,7 @@ function standaloneTestSuites(testFiles: string[], command: string | null): Feat
     route: null,
     command: null,
     ownedFiles: group.files.map((path) => ({ path, reason: "pytest file" })),
-    contextFiles: [],
+    contextFiles: [...runtimeContextFiles],
     tests: group.files.map((path) => ({ path, command })),
     tags: ["python", "test"],
     trustBoundaries: [],

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -67,6 +67,14 @@ const projectMetadataFiles = [
   "setup.cfg",
   "requirements.txt",
 ] as const;
+const runtimeMetadataFiles = [
+  "pyproject.toml",
+  "setup.py",
+  "setup.cfg",
+  ".python-version",
+  "runtime.txt",
+  ".tool-versions",
+] as const;
 const sourceGroupMaxOwnedFiles = 12;
 const sourceGroupMaxTests = 8;
 const flaskRootEntryFiles = [
@@ -83,6 +91,7 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
   }
   const metadata = await readPythonProjectMetadata(root);
   const metadataFiles = await pythonMetadataFiles(root);
+  const runtimeContextFiles = await pythonRuntimeContextFiles(root);
   const testCommand = await pythonTestCommand(root, metadata);
   const testFiles = await pythonTestFiles(root);
   const seeds: FeatureSeed[] = [];
@@ -129,7 +138,10 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
         resolved.entryPath === script.metadataPath
           ? [{ path: script.metadataPath, reason: "console script metadata" }]
           : [{ path: resolved.entryPath, reason: "console script source" }],
-      contextFiles: tests.map((test) => ({ path: test.path, reason: "associated test" })),
+      contextFiles: [
+        ...runtimeContextFiles,
+        ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
+      ],
       tests,
       tags: ["python", "cli"],
       trustBoundaries: ["user-input", "filesystem", "process-exec"],
@@ -166,7 +178,10 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
       route: null,
       command: null,
       ownedFiles: group.files.map((path) => ({ path, reason: `source group ${group.label}` })),
-      contextFiles: tests.map((test) => ({ path: test.path, reason: "associated test" })),
+      contextFiles: [
+        ...runtimeContextFiles,
+        ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
+      ],
       tests,
       tags: ["python", "source-group"],
       trustBoundaries: packageTrustBoundaries(group.label),
@@ -225,6 +240,16 @@ async function pythonMetadataFiles(root: string): Promise<string[]> {
   for (const path of projectMetadataFiles) {
     if (await pathExists(join(root, path))) {
       files.push(path);
+    }
+  }
+  return files;
+}
+
+async function pythonRuntimeContextFiles(root: string): Promise<SeedFileRef[]> {
+  const files: SeedFileRef[] = [];
+  for (const path of runtimeMetadataFiles) {
+    if (await pathExists(join(root, path))) {
+      files.push({ path, reason: "python target runtime metadata" });
     }
   }
   return files;
@@ -396,6 +421,7 @@ async function djangoRouteSeeds(
     ...(await rootPythonSourceFiles(root)),
     ...(await walk(root, await pythonSourceRoots(root))).filter(isReviewablePythonSourceFile),
   ]);
+  const runtimeContextFiles = await pythonRuntimeContextFiles(root);
   const seeds: FeatureSeed[] = [];
   const routesByFile = new Map<string, DjangoRoute[]>();
   for (const filePath of routeFiles) {
@@ -430,7 +456,10 @@ async function djangoRouteSeeds(
           route: expanded.routePath,
           command: null,
           ownedFiles: [{ path: expanded.filePath, reason: "Django URL route declaration" }],
-          contextFiles: tests.map((test) => ({ path: test.path, reason: "associated test" })),
+          contextFiles: [
+            ...runtimeContextFiles,
+            ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
+          ],
           tests,
           tags: ["python", "django", "route"],
           trustBoundaries: djangoRouteTrustBoundaries(expanded),
@@ -1033,6 +1062,7 @@ async function fastApiRouteSeeds(
     ...(await rootPythonSourceFiles(root)),
     ...(await walk(root, await pythonSourceRoots(root))).filter(isReviewablePythonSourceFile),
   ]);
+  const runtimeContextFiles = await pythonRuntimeContextFiles(root);
   const seeds: FeatureSeed[] = [];
   for (const filePath of routeFiles) {
     const source = await readFile(join(root, filePath), "utf8");
@@ -1058,7 +1088,10 @@ async function fastApiRouteSeeds(
         ownedFiles: [
           { path: route.filePath, reason: `FastAPI route handler ${route.functionName}` },
         ],
-        contextFiles: tests.map((test) => ({ path: test.path, reason: "associated test" })),
+        contextFiles: [
+          ...runtimeContextFiles,
+          ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
+        ],
         tests,
         tags: ["python", "fastapi", "route"],
         trustBoundaries: fastApiRouteTrustBoundaries(route),
@@ -1255,6 +1288,7 @@ async function flaskRouteSeeds(
 ): Promise<FeatureSeed[]> {
   const hasFlaskDependency = await pythonDependencyHas(root, "flask");
   const routeFiles = await flaskRouteFiles(root);
+  const runtimeContextFiles = await pythonRuntimeContextFiles(root);
   const seeds: FeatureSeed[] = [];
   for (const filePath of routeFiles) {
     const source = await readFile(join(root, filePath), "utf8");
@@ -1276,7 +1310,10 @@ async function flaskRouteSeeds(
         route: `${methodLabel} ${route.routePath}`,
         command: null,
         ownedFiles: [{ path: route.filePath, reason: `Flask route handler ${route.functionName}` }],
-        contextFiles: tests.map((test) => ({ path: test.path, reason: "associated test" })),
+        contextFiles: [
+          ...runtimeContextFiles,
+          ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
+        ],
         tests,
         tags: ["python", "flask", "route"],
         trustBoundaries: flaskRouteTrustBoundaries(route),

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -91,7 +91,6 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
   }
   const metadata = await readPythonProjectMetadata(root);
   const metadataFiles = await pythonMetadataFiles(root);
-  const runtimeContextFiles = await pythonRuntimeContextFiles(root);
   const testCommand = await pythonTestCommand(root, metadata);
   const testFiles = await pythonTestFiles(root);
   const seeds: FeatureSeed[] = [];
@@ -139,7 +138,7 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
           ? [{ path: script.metadataPath, reason: "console script metadata" }]
           : [{ path: resolved.entryPath, reason: "console script source" }],
       contextFiles: [
-        ...runtimeContextFiles,
+        ...(await pythonRuntimeContextFiles(root, [resolved.entryPath])),
         ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
       ],
       tests,
@@ -179,7 +178,7 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
       command: null,
       ownedFiles: group.files.map((path) => ({ path, reason: `source group ${group.label}` })),
       contextFiles: [
-        ...runtimeContextFiles,
+        ...(await pythonRuntimeContextFiles(root, group.files)),
         ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
       ],
       tests,
@@ -190,7 +189,7 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
     });
   }
 
-  for (const test of standaloneTestSuites(testFiles, testCommand, runtimeContextFiles)) {
+  for (const test of await standaloneTestSuites(root, testFiles, testCommand)) {
     seeds.push(test);
   }
 
@@ -245,14 +244,85 @@ async function pythonMetadataFiles(root: string): Promise<string[]> {
   return files;
 }
 
-async function pythonRuntimeContextFiles(root: string): Promise<SeedFileRef[]> {
+async function pythonRuntimeContextFiles(
+  root: string,
+  featurePaths: readonly string[] = [""],
+): Promise<SeedFileRef[]> {
   const files: SeedFileRef[] = [];
-  for (const path of runtimeMetadataFiles) {
-    if (await pathExists(join(root, path))) {
-      files.push({ path, reason: "python target runtime metadata" });
+  const seen = new Set<string>();
+  for (const featurePath of uniquePaths([...featurePaths])) {
+    for (const ref of await nearestPythonRuntimeContextFiles(root, featurePath)) {
+      if (!seen.has(ref.path)) {
+        seen.add(ref.path);
+        files.push(ref);
+      }
     }
   }
   return files;
+}
+
+async function nearestPythonRuntimeContextFiles(
+  root: string,
+  featurePath: string,
+): Promise<SeedFileRef[]> {
+  const refs: SeedFileRef[] = [];
+  for (const dir of ancestorDirs(dirname(featurePath))) {
+    let foundRuntimeConstraint = false;
+    for (const fileName of runtimeMetadataFiles) {
+      const path = dir.length === 0 ? fileName : `${dir}/${fileName}`;
+      if (await pathExists(join(root, path))) {
+        refs.push({ path, reason: "python target runtime metadata" });
+        foundRuntimeConstraint ||= await pythonRuntimeFileDeclaresVersion(root, path);
+      }
+    }
+    if (foundRuntimeConstraint) {
+      return refs;
+    }
+  }
+  return refs;
+}
+
+async function pythonRuntimeFileDeclaresVersion(root: string, path: string): Promise<boolean> {
+  const name = basename(path);
+  if (name === ".python-version" || name === "runtime.txt") {
+    return true;
+  }
+  if (name === ".tool-versions") {
+    const source = await readFile(join(root, path), "utf8").catch(() => "");
+    return /^\s*(?:python|python3)\s+\S+/mu.test(source);
+  }
+  if (name === "pyproject.toml") {
+    const source = await readFile(join(root, path), "utf8").catch(() => "");
+    return (
+      /^\s*requires-python\s*=/mu.test(source) ||
+      tomlStringValue(table(source, "tool.poetry.dependencies"), "python") !== null
+    );
+  }
+  if (name === "setup.cfg") {
+    const source = await readFile(join(root, path), "utf8").catch(() => "");
+    return /^\s*python_requires\s*=/mu.test(source);
+  }
+  if (name === "setup.py") {
+    const source = await readFile(join(root, path), "utf8").catch(() => "");
+    return /\bpython_requires\s*=/u.test(source);
+  }
+  return false;
+}
+
+function ancestorDirs(start: string): string[] {
+  const dirs: string[] = [];
+  let current = normalizeRelativeDir(start);
+  for (;;) {
+    dirs.push(current);
+    if (current.length === 0) {
+      return dirs;
+    }
+    current = normalizeRelativeDir(dirname(current));
+  }
+}
+
+function normalizeRelativeDir(path: string): string {
+  return path === "." ? "" : path.replace(/\/+$/u, "");
 }
 
 async function pythonTestCommand(root: string, pyproject: PyprojectInfo): Promise<string | null> {
@@ -421,7 +491,6 @@ async function djangoRouteSeeds(
     ...(await rootPythonSourceFiles(root)),
     ...(await walk(root, await pythonSourceRoots(root))).filter(isReviewablePythonSourceFile),
   ]);
-  const runtimeContextFiles = await pythonRuntimeContextFiles(root);
   const seeds: FeatureSeed[] = [];
   const routesByFile = new Map<string, DjangoRoute[]>();
   for (const filePath of routeFiles) {
@@ -457,7 +526,7 @@ async function djangoRouteSeeds(
           command: null,
           ownedFiles: [{ path: expanded.filePath, reason: "Django URL route declaration" }],
           contextFiles: [
-            ...runtimeContextFiles,
+            ...(await pythonRuntimeContextFiles(root, [expanded.filePath])),
             ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
           ],
           tests,
@@ -1062,7 +1131,6 @@ async function fastApiRouteSeeds(
     ...(await rootPythonSourceFiles(root)),
     ...(await walk(root, await pythonSourceRoots(root))).filter(isReviewablePythonSourceFile),
   ]);
-  const runtimeContextFiles = await pythonRuntimeContextFiles(root);
   const seeds: FeatureSeed[] = [];
   for (const filePath of routeFiles) {
     const source = await readFile(join(root, filePath), "utf8");
@@ -1089,7 +1157,7 @@ async function fastApiRouteSeeds(
           { path: route.filePath, reason: `FastAPI route handler ${route.functionName}` },
         ],
         contextFiles: [
-          ...runtimeContextFiles,
+          ...(await pythonRuntimeContextFiles(root, [route.filePath])),
           ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
         ],
         tests,
@@ -1288,7 +1356,6 @@ async function flaskRouteSeeds(
 ): Promise<FeatureSeed[]> {
   const hasFlaskDependency = await pythonDependencyHas(root, "flask");
   const routeFiles = await flaskRouteFiles(root);
-  const runtimeContextFiles = await pythonRuntimeContextFiles(root);
   const seeds: FeatureSeed[] = [];
   for (const filePath of routeFiles) {
     const source = await readFile(join(root, filePath), "utf8");
@@ -1311,7 +1378,7 @@ async function flaskRouteSeeds(
         command: null,
         ownedFiles: [{ path: route.filePath, reason: `Flask route handler ${route.functionName}` }],
         contextFiles: [
-          ...runtimeContextFiles,
+          ...(await pythonRuntimeContextFiles(root, [route.filePath])),
           ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
         ],
         tests,
@@ -1666,36 +1733,40 @@ function fastApiRouteTrustBoundaries(route: FastApiRoute): FeatureSeed["trustBou
   return boundaries;
 }
 
-function standaloneTestSuites(
+async function standaloneTestSuites(
+  root: string,
   testFiles: string[],
   command: string | null,
-  runtimeContextFiles: SeedFileRef[],
-): FeatureSeed[] {
+): Promise<FeatureSeed[]> {
   if (testFiles.length === 0) {
     return [];
   }
   const groups: FileGroup[] = [];
-  for (const [root, files] of groupedTestFiles(testFiles)) {
-    groups.push(...partitionFileGroups(root, files, sourceGroupMaxOwnedFiles));
+  for (const [suiteRoot, files] of groupedTestFiles(testFiles)) {
+    groups.push(...partitionFileGroups(suiteRoot, files, sourceGroupMaxOwnedFiles));
   }
-  return groups.map((group) => ({
-    title: `Python test suite ${group.label}`,
-    summary: `Python pytest files in ${group.label}.`,
-    kind: "test-suite",
-    source: "python-test-suite",
-    confidence: "medium",
-    entryPath: group.label,
-    symbol: group.label,
-    route: null,
-    command: null,
-    ownedFiles: group.files.map((path) => ({ path, reason: "pytest file" })),
-    contextFiles: [...runtimeContextFiles],
-    tests: group.files.map((path) => ({ path, command })),
-    tags: ["python", "test"],
-    trustBoundaries: [],
-    testCommand: command,
-    skipNearbyTests: true,
-  }));
+  const seeds: FeatureSeed[] = [];
+  for (const group of groups) {
+    seeds.push({
+      title: `Python test suite ${group.label}`,
+      summary: `Python pytest files in ${group.label}.`,
+      kind: "test-suite",
+      source: "python-test-suite",
+      confidence: "medium",
+      entryPath: group.label,
+      symbol: group.label,
+      route: null,
+      command: null,
+      ownedFiles: group.files.map((path) => ({ path, reason: "pytest file" })),
+      contextFiles: await pythonRuntimeContextFiles(root, group.files),
+      tests: group.files.map((path) => ({ path, command })),
+      tags: ["python", "test"],
+      trustBoundaries: [],
+      testCommand: command,
+      skipNearbyTests: true,
+    });
+  }
+  return seeds;
 }
 
 function groupedTestFiles(testFiles: string[]): Map<string, string[]> {

--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -193,9 +193,44 @@ describe("review prompt provenance", () => {
     expect(prompt).not.toContain("1 | export const value = 1;");
     expect(prompt).not.toContain("--- src/other.ts");
   });
+
+  it("includes Python runtime syntax guidance in review prompts", async () => {
+    const root = await fixtureRoot("clawpatch-prompt-python-runtime-guidance-");
+    await writeFixture(
+      root,
+      "main.py",
+      [
+        "def parse(value):",
+        "    try:",
+        "        return float(value)",
+        "    except TypeError, ValueError:",
+        "        return 0",
+        "",
+      ].join("\n"),
+    );
+    await writeFixture(root, ".python-version", "3.14\n");
+    const pythonFeature = {
+      ...feature(),
+      ownedFiles: [{ path: "main.py", reason: "source group root" }],
+      contextFiles: [{ path: ".python-version", reason: "python target runtime metadata" }],
+      tests: [],
+    };
+
+    const bundle = await buildReviewPromptBundle(
+      root,
+      project(root, ["python"]),
+      pythonFeature,
+      defaultConfig(),
+    );
+
+    expect(bundle.prompt).toContain("Python compatibility guidance:");
+    expect(bundle.prompt).toContain(".python-version");
+    expect(bundle.prompt).toContain("PEP 758 permits unparenthesized multiple exception types");
+    expect(bundle.prompt).toContain("--- .python-version (context, lines 1-1)");
+  });
 });
 
-function project(root: string): ProjectRecord {
+function project(root: string, languages: string[] = ["typescript"]): ProjectRecord {
   return {
     schemaVersion: 1,
     projectId: "proj_prompt",
@@ -208,7 +243,7 @@ function project(root: string): ProjectRecord {
       headSha: null,
     },
     detected: {
-      languages: ["typescript"],
+      languages,
       frameworks: [],
       packageManagers: ["npm"],
       commands: defaultConfig().commands,

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -181,6 +181,7 @@ ${customPrompt.trim()}
   const validEvidencePaths = [
     ...new Set(includedFiles.filter((file) => file.readable).map((file) => file.path)),
   ];
+  const languageGuidance = reviewLanguageGuidance(project);
   const prompt = `You are reviewing one semantic feature for clawpatch.
 
 Return strict JSON only. No markdown fences.
@@ -205,6 +206,8 @@ ${customBlock}Review categories:
 - maintainability risks with concrete impact
 
 ${reviewModeInstructions(mode)}
+
+${languageGuidance}
 
 Inspect owned files, context files, and linked tests. Treat included tests as first-class
 evidence of intended behavior. If tests contradict a suspected bug, either skip it or
@@ -275,6 +278,15 @@ function reviewFeatureView(feature: FeatureRecord): object {
     tags: feature.tags,
     trustBoundaries: feature.trustBoundaries,
   };
+}
+
+function reviewLanguageGuidance(project: ProjectRecord): string {
+  if (!project.detected.languages.includes("python")) {
+    return "";
+  }
+  return `Python compatibility guidance:
+- Treat included target-runtime metadata such as .python-version, pyproject.toml requires-python, setup.cfg/setup.py python_requires, runtime.txt, and .tool-versions as authoritative when assessing syntax compatibility.
+- For Python 3.14 or newer, PEP 758 permits unparenthesized multiple exception types in except/except* clauses when no as target is used; do not report that syntax as invalid for Python 3.14+ projects.`;
 }
 
 function uniquePromptRefs<T extends { path: string }>(


### PR DESCRIPTION
## Summary

- add Python target-runtime metadata to source, route, and standalone pytest-suite review context
- add Python compatibility guidance for version-specific syntax checks
- cover Python 3.14 PEP 758 metadata and prompt behavior in mapper/prompt tests

Fixes #106.

## Real behavior proof

I reran the issue reproduction against the built CLI on a minimal Python 3.14 project containing `.python-version`, `requires-python = ">=3.14"`, and the PEP 758 handler syntax:

```py
except TypeError, ValueError:
    return 0
```

Command:

```sh
node dist/cli.js --root /tmp/clawpatch-pep758-proof-final.jvdhwI --state-dir /tmp/clawpatch-pep758-proof-final.jvdhwI/.clawpatch --plain init
node dist/cli.js --root /tmp/clawpatch-pep758-proof-final.jvdhwI --state-dir /tmp/clawpatch-pep758-proof-final.jvdhwI/.clawpatch --plain map
node dist/cli.js --root /tmp/clawpatch-pep758-proof-final.jvdhwI --state-dir /tmp/clawpatch-pep758-proof-final.jvdhwI/.clawpatch --plain review --provider codex --model gpt-5.5 --limit 1 --jobs 1
```

Output excerpt:

```text
clawpatch map mapper-done mapper=python seeds=2 elapsed=0s
clawpatch map done features=2 usedAgent=false elapsed=0s
clawpatch review feature-start index=1 total=1 feature=feat_library_25faef2bc4 title=Python source root
clawpatch review feature-done index=1 total=1 feature=feat_library_25faef2bc4 findings=0 elapsed=19s
clawpatch review done run=20260524T062216-b1e3a8 reviewed=1 findings=0
reviewed: 1
findings: 0
```

I also verified the standalone pytest-suite path flagged in review. A pytest-only Python 3.14 fixture now maps the test-suite feature with runtime metadata in context:

```json
{
  "title": "Python test suite tests",
  "contextFiles": [
    { "path": "pyproject.toml", "reason": "python target runtime metadata" },
    { "path": ".python-version", "reason": "python target runtime metadata" },
    { "path": "runtime.txt", "reason": "python target runtime metadata" },
    { "path": "tests/test_pep758.py", "reason": "nearby test" }
  ],
  "ownedFiles": [
    { "path": "tests/test_pep758.py", "reason": "pytest file" }
  ],
  "tests": [
    { "path": "tests/test_pep758.py", "command": "pytest" }
  ]
}
```

## Checks

- `./node_modules/.bin/vitest run src/mapper.test.ts src/prompt.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.json --noEmit`
- `./node_modules/.bin/oxfmt --check src/mappers/python.ts src/mapper.test.ts src/prompt.ts src/prompt.test.ts`
- `./node_modules/.bin/oxlint . --config oxlint.json`
- `git diff --check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
