### PR TITLE
Timeout wedged Codex exec calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.1 - Unreleased
 
+- Fixed Codex provider calls to time out stalled `codex exec` children and release review locks, thanks @camwest.
+
 ## 0.4.0 - 2026-05-22
 
 - Added `clawpatch ci` to initialize, map, review, write a report, and append a GitHub Actions step summary in one CI-friendly command.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -32,6 +32,8 @@ Codex invocation:
 - fix: workspace-write sandbox
 - output: strict JSON schema via `--output-schema`
 - final message capture: `--output-last-message`
+- timeout: 300 seconds by default, matching the Cursor provider; override with
+  `CLAWPATCH_CODEX_TIMEOUT_MS` or `CLAWPATCH_PROVIDER_TIMEOUT_MS`
 
 Model selection:
 

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -22,6 +22,7 @@ const {
   claudeFailureMessage,
   claudeTimeoutMs,
   codexFailureMessage,
+  codexTimeoutMs,
   cursorAgentArgs,
   cursorEnv,
   cursorFailureMessage,
@@ -221,12 +222,24 @@ describe("parseCodexJson", () => {
 
 describe("Codex provider args", () => {
   const originalCodexSandbox = process.env["CLAWPATCH_CODEX_SANDBOX"];
+  const originalCodexTimeout = process.env["CLAWPATCH_CODEX_TIMEOUT_MS"];
+  const originalProviderTimeout = process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
 
   afterEach(() => {
     if (originalCodexSandbox === undefined) {
       delete process.env["CLAWPATCH_CODEX_SANDBOX"];
     } else {
       process.env["CLAWPATCH_CODEX_SANDBOX"] = originalCodexSandbox;
+    }
+    if (originalCodexTimeout === undefined) {
+      delete process.env["CLAWPATCH_CODEX_TIMEOUT_MS"];
+    } else {
+      process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] = originalCodexTimeout;
+    }
+    if (originalProviderTimeout === undefined) {
+      delete process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+    } else {
+      process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"] = originalProviderTimeout;
     }
   });
 
@@ -292,6 +305,21 @@ describe("Codex provider args", () => {
     addCodexModelArgs(args, { model: null, reasoningEffort: null, skipGitRepoCheck: false });
 
     expect(args).toEqual(["exec"]);
+  });
+
+  it("uses Codex-specific timeout before generic provider timeout", () => {
+    delete process.env["CLAWPATCH_CODEX_TIMEOUT_MS"];
+    delete process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+    expect(codexTimeoutMs()).toBe(300_000);
+
+    process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"] = "2000";
+    expect(codexTimeoutMs()).toBe(2000);
+
+    process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] = "3000";
+    expect(codexTimeoutMs()).toBe(3000);
+
+    process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] = "bad";
+    expect(codexTimeoutMs()).toBe(300_000);
   });
 });
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -325,6 +325,8 @@ const codexProvider: Provider = {
   },
 };
 
+const CODEX_DEFAULT_TIMEOUT_MS = 300_000;
+
 const opencodeProvider: Provider = {
   name: "opencode",
   async check(root: string): Promise<string> {
@@ -1542,7 +1544,9 @@ async function runCodexJson(
     addCodexSandboxArgs(args, sandbox);
     addCodexModelArgs(args, options);
     args.push("-");
-    const result = await runCommandArgs("codex", args, root, prompt);
+    const result = await runCommandArgs("codex", args, root, prompt, {
+      timeoutMs: codexTimeoutMs(),
+    });
     if (result.exitCode !== 0) {
       throw new ClawpatchError(
         codexFailureMessage(result.stdout, result.stderr),
@@ -1566,6 +1570,16 @@ function codexFailureMessage(stdout: string, stderr: string): string {
     ? "\nCodex/OpenAI auth is missing Responses API write access (`api.responses.write`). Check the active credentials, organization/project role, and restricted key scopes."
     : "";
   return `codex provider failed: ${output}${scopeAdvice}`;
+}
+
+function codexTimeoutMs(): number {
+  const raw =
+    process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] ?? process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+  if (raw === undefined) {
+    return CODEX_DEFAULT_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : CODEX_DEFAULT_TIMEOUT_MS;
 }
 
 function addCodexSandboxArgs(args: string[], sandbox: string): void {
@@ -2229,6 +2243,7 @@ export const __testing = {
   claudeFailureMessage,
   claudeTimeoutMs,
   codexFailureMessage,
+  codexTimeoutMs,
   cursorAgentArgs,
   cursorEnv,
   cursorFailureMessage,

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -671,6 +671,73 @@ describe("workflow", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "times out wedged codex exec review children",
+    async () => {
+      const root = await fixtureRoot("clawpatch-codex-timeout-e2e-");
+      await writeFixture(
+        root,
+        "package.json",
+        JSON.stringify({
+          name: "codex-timeout",
+          bin: { app: "src/index.ts" },
+        }),
+      );
+      await writeFixture(root, "src/index.ts", "export const value = 'ok';\n");
+      const binDir = join(root, "bin");
+      const codexShim = join(binDir, "codex");
+      await writeFixture(
+        root,
+        "bin/codex",
+        [
+          "#!/usr/bin/env node",
+          "const args = process.argv.slice(2);",
+          'if (args.includes("--version")) { console.log("codex fake 0.130.0"); process.exit(0); }',
+          "process.stdin.resume();",
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+      );
+      await chmod(codexShim, 0o755);
+      const previousProvider = process.env["CLAWPATCH_PROVIDER"];
+      const previousPath = process.env["PATH"];
+      const previousCodexTimeout = process.env["CLAWPATCH_CODEX_TIMEOUT_MS"];
+      process.env["CLAWPATCH_PROVIDER"] = "codex";
+      process.env["PATH"] = `${binDir}${delimiter}${previousPath ?? ""}`;
+      process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] = "50";
+      try {
+        const context = await makeContext(testOptions(root));
+
+        await initCommand(context, {});
+        await mapCommand(context);
+        await expect(reviewCommand(context, { limit: "1" })).rejects.toThrow(
+          /command timed out after 50ms/u,
+        );
+        const features = await readFeatures(statePaths(join(root, ".clawpatch")));
+
+        expect(features[0]?.status).toBe("error");
+        expect(features[0]?.lock).toBeNull();
+        expect(await readdir(join(root, ".clawpatch/locks"))).toEqual([]);
+      } finally {
+        if (previousProvider === undefined) {
+          delete process.env["CLAWPATCH_PROVIDER"];
+        } else {
+          process.env["CLAWPATCH_PROVIDER"] = previousProvider;
+        }
+        if (previousPath === undefined) {
+          delete process.env["PATH"];
+        } else {
+          process.env["PATH"] = previousPath;
+        }
+        if (previousCodexTimeout === undefined) {
+          delete process.env["CLAWPATCH_CODEX_TIMEOUT_MS"];
+        } else {
+          process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] = previousCodexTimeout;
+        }
+      }
+    },
+  );
+
   it("selects review features whose owned files overlap the diff range", async () => {
     const root = await sinceFixture("clawpatch-since-owned-");
     const context = await makeContext(testOptions(root));


### PR DESCRIPTION
[problem]

- Codex exec can wedge indefinitely.
- One stuck child blocks the run.
- No report is emitted.

[solution]

Wire Codex through existing provider timeout handling. Default mirrors Cursor: 300s; override with `CLAWPATCH_CODEX_TIMEOUT_MS` or `CLAWPATCH_PROVIDER_TIMEOUT_MS`.

[proof]

- Shimmed wedged Codex exec timed out at 50ms.
- Regression asserts feature `error` state and released locks.
- Checks: typecheck, lint, format, build, focused Vitest.