### PR TITLE
fix: bound codex provider executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## 0.4.1 - Unreleased
-
 ## 0.4.0 - 2026-05-22
 
 - Added `clawpatch ci` to initialize, map, review, write a report, and append a GitHub Actions step summary in one CI-friendly command.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -32,6 +32,8 @@ Codex invocation:
 - fix: workspace-write sandbox
 - output: strict JSON schema via `--output-schema`
 - final message capture: `--output-last-message`
+- timeout: 180 seconds by default, override with `CLAWPATCH_CODEX_TIMEOUT_MS`
+  or `CLAWPATCH_PROVIDER_TIMEOUT_MS`
 
 Model selection:
 

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -1,3 +1,6 @@
+import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ClawpatchError } from "./errors.js";
 import { __testing, extractJson, providerByName } from "./provider.js";
@@ -22,6 +25,7 @@ const {
   claudeFailureMessage,
   claudeTimeoutMs,
   codexFailureMessage,
+  codexTimeoutMs,
   cursorAgentArgs,
   cursorEnv,
   cursorFailureMessage,
@@ -221,12 +225,24 @@ describe("parseCodexJson", () => {
 
 describe("Codex provider args", () => {
   const originalCodexSandbox = process.env["CLAWPATCH_CODEX_SANDBOX"];
+  const originalCodexTimeout = process.env["CLAWPATCH_CODEX_TIMEOUT_MS"];
+  const originalProviderTimeout = process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
 
   afterEach(() => {
     if (originalCodexSandbox === undefined) {
       delete process.env["CLAWPATCH_CODEX_SANDBOX"];
     } else {
       process.env["CLAWPATCH_CODEX_SANDBOX"] = originalCodexSandbox;
+    }
+    if (originalCodexTimeout === undefined) {
+      delete process.env["CLAWPATCH_CODEX_TIMEOUT_MS"];
+    } else {
+      process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] = originalCodexTimeout;
+    }
+    if (originalProviderTimeout === undefined) {
+      delete process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+    } else {
+      process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"] = originalProviderTimeout;
     }
   });
 
@@ -292,6 +308,69 @@ describe("Codex provider args", () => {
     addCodexModelArgs(args, { model: null, reasoningEffort: null, skipGitRepoCheck: false });
 
     expect(args).toEqual(["exec"]);
+  });
+
+  it("uses a 180 second default timeout for Codex", () => {
+    delete process.env["CLAWPATCH_CODEX_TIMEOUT_MS"];
+    delete process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+
+    expect(codexTimeoutMs()).toBe(180_000);
+  });
+
+  it("uses Codex-specific timeout before generic provider timeout", () => {
+    delete process.env["CLAWPATCH_CODEX_TIMEOUT_MS"];
+    delete process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+
+    process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"] = "2000";
+    expect(codexTimeoutMs()).toBe(2000);
+
+    process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] = "3000";
+    expect(codexTimeoutMs()).toBe(3000);
+
+    process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] = "bad";
+    expect(codexTimeoutMs()).toBe(180_000);
+  });
+
+  it("times out stalled Codex provider executions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clawpatch-codex-timeout-"));
+    const binDir = join(root, "bin");
+    const codexShim = join(binDir, "codex");
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      codexShim,
+      [
+        "#!/usr/bin/env node",
+        'if (process.argv.includes("--version")) {',
+        '  console.log("codex fake 0.133.0");',
+        "  process.exit(0);",
+        "}",
+        "setInterval(() => {}, 1000);",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(codexShim, 0o755);
+
+    const previousPath = process.env["PATH"];
+    process.env["PATH"] = `${binDir}${delimiter}${previousPath ?? ""}`;
+    process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] = "50";
+    delete process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+
+    try {
+      await expect(
+        providerByName("codex").revalidate(root, "return strict JSON", {
+          model: null,
+          reasoningEffort: null,
+          skipGitRepoCheck: false,
+        }),
+      ).rejects.toThrow(/command timed out after 50ms/u);
+    } finally {
+      if (previousPath === undefined) {
+        delete process.env["PATH"];
+      } else {
+        process.env["PATH"] = previousPath;
+      }
+    }
   });
 });
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -31,6 +31,7 @@ export { extractJson } from "./provider-json.js";
 
 const ZOD_VALUE_PREVIEW_LIMIT = 80;
 const ZOD_ISSUE_HEAD_LIMIT = 3;
+const CODEX_DEFAULT_TIMEOUT_MS = 180_000;
 
 function formatZodPath(path: ReadonlyArray<PropertyKey>): string {
   if (path.length === 0) {
@@ -1542,7 +1543,9 @@ async function runCodexJson(
     addCodexSandboxArgs(args, sandbox);
     addCodexModelArgs(args, options);
     args.push("-");
-    const result = await runCommandArgs("codex", args, root, prompt);
+    const result = await runCommandArgs("codex", args, root, prompt, {
+      timeoutMs: codexTimeoutMs(),
+    });
     if (result.exitCode !== 0) {
       throw new ClawpatchError(
         codexFailureMessage(result.stdout, result.stderr),
@@ -1566,6 +1569,16 @@ function codexFailureMessage(stdout: string, stderr: string): string {
     ? "\nCodex/OpenAI auth is missing Responses API write access (`api.responses.write`). Check the active credentials, organization/project role, and restricted key scopes."
     : "";
   return `codex provider failed: ${output}${scopeAdvice}`;
+}
+
+function codexTimeoutMs(): number {
+  const raw =
+    process.env["CLAWPATCH_CODEX_TIMEOUT_MS"] ?? process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+  if (raw === undefined) {
+    return CODEX_DEFAULT_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : CODEX_DEFAULT_TIMEOUT_MS;
 }
 
 function addCodexSandboxArgs(args: string[], sandbox: string): void {
@@ -2229,6 +2242,7 @@ export const __testing = {
   claudeFailureMessage,
   claudeTimeoutMs,
   codexFailureMessage,
+  codexTimeoutMs,
   cursorAgentArgs,
   cursorEnv,
   cursorFailureMessage,


### PR DESCRIPTION
## Summary

- Add a 180 second default timeout to Codex provider executions.
- Allow timeout overrides through `CLAWPATCH_CODEX_TIMEOUT_MS` and fallback `CLAWPATCH_PROVIDER_TIMEOUT_MS`.
- Add regression coverage with a fake hanging `codex` executable.
- Document the timeout in provider docs.

## Behavior proof

Targeted proof command:

```bash
pnpm exec vitest run src/provider.test.ts -t "times out stalled Codex provider executions" --reporter=verbose
```

Observed output from the contributor branch:

```text
src/provider.test.ts > Codex provider args > times out stalled Codex provider executions 563ms

Test Files  1 passed (1)
Tests       1 passed | 133 skipped (134)
Duration    789ms
```

What this proves: the test puts a fake `codex` executable first on `PATH`; the fake process never exits. With `CLAWPATCH_CODEX_TIMEOUT_MS=50`, the provider rejects with `command timed out after 50ms` instead of waiting indefinitely.

Compatibility note: the default is intentionally bounded at 180 seconds. Slow legitimate Codex runs can opt into a longer timeout with `CLAWPATCH_CODEX_TIMEOUT_MS` or the generic `CLAWPATCH_PROVIDER_TIMEOUT_MS`.

## Verification

- `pnpm test src/provider.test.ts`: 134 passed after changelog cleanup
- `pnpm format:check`: passed after changelog cleanup
- `pnpm typecheck`: passed
- `pnpm lint`: passed
- `pnpm build`: passed
- `pnpm test`: passed, 717 passed and 1 skipped
- `pnpm pack:smoke`: passed
- `codex review --uncommitted`: no actionable bugs found