### PR TITLE
fix: pass Claude cloud auth env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.1 - Unreleased
 
 - Fixed Codex provider calls to time out stalled `codex exec` children and release review locks, thanks @camwest.
+- Fixed Claude provider auth isolation to pass explicit Vertex AI, Google ADC, and Bedrock/AWS auth environment variables, thanks @zanetworker.
 - Fixed Python review prompts to include target runtime metadata and avoid flagging Python 3.14 syntax such as PEP 758 exception handlers as invalid, thanks @rohitjavvadi.
 
 ## 0.4.0 - 2026-05-22

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -144,9 +144,14 @@ How the Claude provider works:
   versions. It does not validate auth or make a network call; auth failures are
   reported on the first provider-backed command.
 - Auth/isolation: provider runs use `--bare` with a default-deny environment.
-  Clawpatch forwards only minimal execution variables and `ANTHROPIC_API_KEY`;
-  it does not pass host `HOME`, OAuth/keychain state, or whole Claude
-  config/cache directories.
+  Clawpatch forwards only minimal execution variables plus explicit Anthropic
+  API key, Vertex AI, Google ADC, cloud-gateway, and Bedrock/AWS auth variables.
+  It does not pass host `HOME`, OAuth/keychain state, or whole Claude
+  config/cache directories; OAuth subscription auth is not available in Claude
+  Code `--bare` mode. Cloud auth env is available to Claude Code itself, while
+  Claude tool subprocess env scrubbing is enabled. AWS profile names are
+  forwarded only when `AWS_CONFIG_FILE` or `AWS_SHARED_CREDENTIALS_FILE` points
+  at explicit profile files.
 - Structured output: provider runs use `--output-format json --json-schema`
   and parse the returned `structured_output` field.
 - Read-only operations (map, review, revalidate): use

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -738,6 +738,7 @@ describe("Claude provider helpers", () => {
       TMPDIR: "/tmp/claude",
       TEMP: "/tmp/claude",
       TMP: "/tmp/claude",
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1",
     });
     expect(claudeEnv(true, "/tmp/claude")).toEqual({
       PATH: "/bin",
@@ -748,7 +749,118 @@ describe("Claude provider helpers", () => {
       TMPDIR: "/tmp/claude",
       TEMP: "/tmp/claude",
       TMP: "/tmp/claude",
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1",
       ANTHROPIC_API_KEY: "secret",
+    });
+  });
+
+  it("passes Vertex AI auth env vars only when auth is included", () => {
+    process.env = {
+      PATH: "/bin",
+      CLAUDE_CODE_USE_VERTEX: "1",
+      ANTHROPIC_BASE_URL: "https://llm-gateway.example.com",
+      ANTHROPIC_AUTH_TOKEN: "gateway-token",
+      ANTHROPIC_VERTEX_PROJECT_ID: "project-id",
+      ANTHROPIC_VERTEX_REGION: "us-east5",
+      ANTHROPIC_VERTEX_BASE_URL: "https://vertex-gateway.example.com",
+      CLOUD_ML_REGION: "us-east5",
+      GOOGLE_APPLICATION_CREDENTIALS: "/var/creds/google.json",
+      GOOGLE_CLOUD_PROJECT: "project-id",
+      GCLOUD_PROJECT: "legacy-project",
+      CLOUDSDK_CORE_PROJECT: "sdk-project",
+      CLAUDE_CODE_SKIP_VERTEX_AUTH: "1",
+      OPENAI_API_KEY: "must-not-leak",
+    };
+
+    expect(claudeEnv(false, "/tmp/claude")).toEqual({
+      PATH: "/bin",
+      HOME: "/tmp/claude/home",
+      XDG_CONFIG_HOME: "/tmp/claude/xdg-config",
+      XDG_CACHE_HOME: "/tmp/claude/xdg-cache",
+      XDG_DATA_HOME: "/tmp/claude/xdg-data",
+      TMPDIR: "/tmp/claude",
+      TEMP: "/tmp/claude",
+      TMP: "/tmp/claude",
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1",
+    });
+    expect(claudeEnv(true, "/tmp/claude")).toMatchObject({
+      CLAUDE_CODE_USE_VERTEX: "1",
+      ANTHROPIC_BASE_URL: "https://llm-gateway.example.com",
+      ANTHROPIC_AUTH_TOKEN: "gateway-token",
+      ANTHROPIC_VERTEX_PROJECT_ID: "project-id",
+      ANTHROPIC_VERTEX_REGION: "us-east5",
+      ANTHROPIC_VERTEX_BASE_URL: "https://vertex-gateway.example.com",
+      CLOUD_ML_REGION: "us-east5",
+      GOOGLE_APPLICATION_CREDENTIALS: "/var/creds/google.json",
+      GOOGLE_CLOUD_PROJECT: "project-id",
+      GCLOUD_PROJECT: "legacy-project",
+      CLOUDSDK_CORE_PROJECT: "sdk-project",
+      CLAUDE_CODE_SKIP_VERTEX_AUTH: "1",
+    });
+    expect(claudeEnv(true, "/tmp/claude")).not.toHaveProperty("OPENAI_API_KEY");
+  });
+
+  it("passes Bedrock auth env vars only when auth is included", () => {
+    process.env = {
+      PATH: "/bin",
+      CLAUDE_CODE_USE_BEDROCK: "1",
+      CLAUDE_CODE_SKIP_BEDROCK_AUTH: "1",
+      ANTHROPIC_BEDROCK_BASE_URL: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      AWS_BEARER_TOKEN_BEDROCK: "bedrock-token",
+      AWS_REGION: "us-east-1",
+      AWS_DEFAULT_REGION: "us-east-1",
+      AWS_PROFILE: "clawpatch",
+      AWS_ACCESS_KEY_ID: "access-key",
+      AWS_SECRET_ACCESS_KEY: "secret-key",
+      AWS_SESSION_TOKEN: "session-token",
+      AWS_SHARED_CREDENTIALS_FILE: "/var/aws/credentials",
+      AWS_CONFIG_FILE: "/var/aws/config",
+      AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/clawpatch",
+      AWS_WEB_IDENTITY_TOKEN_FILE: "/var/aws/web-identity-token",
+      DATABASE_URL: "must-not-leak",
+    };
+
+    expect(claudeEnv(false, "/tmp/claude")).not.toHaveProperty("CLAUDE_CODE_USE_BEDROCK");
+    expect(claudeEnv(true, "/tmp/claude")).toMatchObject({
+      CLAUDE_CODE_USE_BEDROCK: "1",
+      CLAUDE_CODE_SKIP_BEDROCK_AUTH: "1",
+      ANTHROPIC_BEDROCK_BASE_URL: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      AWS_REGION: "us-east-1",
+      AWS_DEFAULT_REGION: "us-east-1",
+      AWS_PROFILE: "clawpatch",
+      AWS_ACCESS_KEY_ID: "access-key",
+      AWS_SECRET_ACCESS_KEY: "secret-key",
+      AWS_SESSION_TOKEN: "session-token",
+      AWS_BEARER_TOKEN_BEDROCK: "bedrock-token",
+      AWS_SHARED_CREDENTIALS_FILE: "/var/aws/credentials",
+      AWS_CONFIG_FILE: "/var/aws/config",
+      AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/clawpatch",
+      AWS_WEB_IDENTITY_TOKEN_FILE: "/var/aws/web-identity-token",
+    });
+    expect(claudeEnv(true, "/tmp/claude")).not.toHaveProperty("DATABASE_URL");
+  });
+
+  it("passes AWS_PROFILE only with explicit AWS config or credentials file paths", () => {
+    process.env = {
+      PATH: "/bin",
+      CLAUDE_CODE_USE_BEDROCK: "1",
+      AWS_REGION: "us-east-1",
+      AWS_PROFILE: "clawpatch",
+    };
+
+    expect(claudeEnv(true, "/tmp/claude")).not.toHaveProperty("AWS_PROFILE");
+
+    process.env["AWS_CONFIG_FILE"] = "/var/aws/config";
+    expect(claudeEnv(true, "/tmp/claude")).toMatchObject({
+      AWS_CONFIG_FILE: "/var/aws/config",
+      AWS_PROFILE: "clawpatch",
+    });
+
+    delete process.env["AWS_CONFIG_FILE"];
+    process.env["AWS_SHARED_CREDENTIALS_FILE"] = "/var/aws/credentials";
+    expect(claudeEnv(true, "/tmp/claude")).toMatchObject({
+      AWS_SHARED_CREDENTIALS_FILE: "/var/aws/credentials",
+      AWS_PROFILE: "clawpatch",
     });
   });
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -833,6 +833,34 @@ function compareSemver(left: [number, number, number], right: [number, number, n
 const CLAUDE_DEFAULT_TIMEOUT_MS = 180_000;
 const CLAUDE_READ_ONLY_TOOLS = "Read,Grep,Glob";
 const CLAUDE_WRITE_TOOLS = "default";
+const CLAUDE_AUTH_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_BASE_URL",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_CODE_USE_VERTEX",
+  "ANTHROPIC_VERTEX_PROJECT_ID",
+  "ANTHROPIC_VERTEX_REGION",
+  "ANTHROPIC_VERTEX_BASE_URL",
+  "CLOUD_ML_REGION",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "GOOGLE_CLOUD_PROJECT",
+  "GCLOUD_PROJECT",
+  "CLOUDSDK_CORE_PROJECT",
+  "CLAUDE_CODE_SKIP_VERTEX_AUTH",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+  "ANTHROPIC_BEDROCK_BASE_URL",
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_SHARED_CREDENTIALS_FILE",
+  "AWS_CONFIG_FILE",
+  "AWS_ROLE_ARN",
+  "AWS_WEB_IDENTITY_TOKEN_FILE",
+] as const;
 
 const claudeProvider: Provider = {
   name: "claude",
@@ -981,8 +1009,17 @@ function claudeEnv(includeAuth: boolean, baseDir: string): NodeJS.ProcessEnv {
   env["TMPDIR"] = baseDir;
   env["TEMP"] = baseDir;
   env["TMP"] = baseDir;
+  env["CLAUDE_CODE_SUBPROCESS_ENV_SCRUB"] = "1";
   if (includeAuth) {
-    copyEnv(env, "ANTHROPIC_API_KEY");
+    for (const key of CLAUDE_AUTH_ENV_KEYS) {
+      copyEnv(env, key);
+    }
+    if (
+      process.env["AWS_CONFIG_FILE"] !== undefined ||
+      process.env["AWS_SHARED_CREDENTIALS_FILE"] !== undefined
+    ) {
+      copyEnv(env, "AWS_PROFILE");
+    }
   }
   return env;
 }


### PR DESCRIPTION
## Summary

- Forward explicit Claude cloud-provider auth and gateway environment variables under the existing default-deny provider env.
- Enable Claude subprocess env scrubbing so forwarded cloud credentials are available to Claude Code but not shell/tool subprocesses.
- Document that OAuth/keychain auth remains unavailable in Claude Code `--bare` mode; this keeps host HOME and credential directories isolated.

Replaces #117 with a safer maintainer branch because the original PR cannot be updated by maintainers and symlinked host auth directories into the sandbox HOME.

## Verification

- `claude --help` confirms `--bare` only supports `ANTHROPIC_API_KEY` or `apiKeyHelper` for Anthropic auth and does not read OAuth/keychain state.
- `pnpm exec vitest run src/provider.test.ts -t "Claude provider helpers"` passed: 22 passed, 113 skipped
- `pnpm typecheck` passed
- `pnpm lint` passed
- `pnpm format:check` passed
- `pnpm build` passed
- `pnpm test` passed: 726 passed, 1 skipped
- autoreview clean: no accepted/actionable findings
