### PR TITLE
feat(provider): add minimax provider for MiniMax Token Plan models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.2 - Unreleased
+
+- Added a MiniMax HTTP provider for `map`, `review`, and `revalidate`, with local schema validation and explicit unsupported `fix` handling, thanks @ferminquant.
+
 ## 0.5.1 - 2026-06-10
 
 - Added npm trusted publishing through GitHub Actions OIDC, plus secops ownership, verified-secret scanning, and stale issue and pull request automation.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Supported provider names today:
 - `claude`: local Claude Code CLI in print mode
 - `cursor`: local Cursor Agent CLI (experimental; `doctor` is enabled by default)
 - `grok`: local Grok Build CLI
+- `minimax`: MiniMax OpenAI-compatible HTTP API; supports `map`, `review`, and `revalidate`, but not `fix`
 - `opencode`: local OpenCode CLI
 - `pi`: local Pi coding agent in print mode
 - `mock`: deterministic test provider

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -17,6 +17,7 @@ Provider names today:
 - `acpx`: routes through any ACP-compatible coding agent via `acpx`
 - `claude`: shells out to Claude Code in print mode (`claude -p`)
 - `grok`: shells out to the xAI Grok Build CLI in headless mode (`grok --prompt-file`)
+- `minimax`: calls the MiniMax OpenAI-compatible HTTP API directly
 - `opencode`: shells out to `opencode run --format json`
 - `pi`: shells out to `pi -p` (non-interactive print mode)
 - `cursor`: shells out to `cursor-agent -p --output-format json`
@@ -324,7 +325,54 @@ uses `--force` or `--yolo`. Complete HITL verification before promoting this to
 default provider support, especially for ambient rules, MCP configuration,
 temporary prompt file handling, timeout behavior, and any claimed read-only mode.
 
-Direct OpenAI API, local-model, and multi-model panel providers are not
-implemented yet. The `acpx` provider is the generic route for ACP-compatible
-agents; the `grok`, `opencode`, `pi`, and `cursor` providers are direct integrations
-for local CLIs.
+## MiniMax
+
+The `minimax` provider calls the MiniMax OpenAI-compatible HTTP API directly. It
+requires a Token Plan API key in `MINIMAX_API_KEY` and defaults to
+`https://api.minimax.io/v1`.
+
+```bash
+export MINIMAX_API_KEY=sk-cp-...
+clawpatch doctor --provider minimax
+clawpatch review --provider minimax
+clawpatch review --provider minimax --model MiniMax-M2.7-highspeed
+```
+
+How the MiniMax provider works:
+
+- Endpoint: `POST ${MINIMAX_BASE_URL:-https://api.minimax.io/v1}/chat/completions`
+  with `Authorization: Bearer ${MINIMAX_API_KEY}`. `MINIMAX_BASE_URL` is trimmed,
+  normalized, and must use `https` unless it targets loopback HTTP for local
+  development; the bearer token is sent to that configured endpoint.
+- Operations: `map`, `review`, and `revalidate` are supported. `fix` is not
+  supported because the chat completions API cannot edit the worktree; it fails
+  before checking credentials or making network calls with `unsupported-provider`
+  and exit code 2.
+- Structured output: MiniMax M-series Chat Completions do not document OpenAI
+  `response_format.json_schema` support. Clawpatch therefore sends the provider
+  schema in the prompt, disables M3 thinking with `thinking: {type: "disabled"}`,
+  asks for `reasoning_split`, extracts the returned JSON, and validates it
+  locally with the same Zod schemas used by other providers.
+- Model selection: `--model <name>` sets the request `model`; otherwise
+  `MINIMAX_MODEL` is used, then `MiniMax-M3`.
+- HTTP failures: `401` and `403` map to exit code 4, `429` maps to exit code 5,
+  and other non-2xx statuses map to exit code 1. Embedded MiniMax auth,
+  rate-limit, balance, and usage-limit status codes are mapped the same way.
+  Error bodies are reduced to safe status/type/code signals and byte counts.
+- Timeout: 30 minutes by default for provider calls, override with
+  `CLAWPATCH_MINIMAX_TIMEOUT_MS` or `CLAWPATCH_PROVIDER_TIMEOUT_MS`. The `/models`
+  doctor probe uses a 30-second timeout. Clawpatch uses a custom undici
+  dispatcher and an operation abort signal so socket headers/body timeouts and
+  full response-body reads track the configured timeout.
+- Bounds: request bodies over 64 MiB and responses over 10 MiB fail before
+  parsing; error bodies are capped separately.
+
+Permission caveat: MiniMax is a remote API provider. Review inputs are sent to
+the configured MiniMax endpoint, and read-only behavior depends on the remote
+model following the prompt. For untrusted code, run clawpatch in an isolated
+checkout and avoid sending secret-bearing files.
+
+Direct local-model and multi-model panel providers are not implemented yet. The
+`acpx` provider is the generic route for ACP-compatible agents; the `grok`,
+`opencode`, `pi`, and `cursor` providers are direct integrations for local CLIs;
+the `minimax` provider is a direct integration for the MiniMax HTTP API.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -906,6 +906,7 @@ Implemented providers:
 - `claude`: Claude Code CLI in print mode.
 - `cursor`: experimental Cursor Agent CLI integration.
 - `grok`: Grok Build CLI.
+- `minimax`: MiniMax OpenAI-compatible HTTP API for map, review, and revalidate.
 - `opencode`: OpenCode CLI.
 - `pi`: pi coding agent.
 - `mock` / `mock-fail`: deterministic test providers.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "crabbox:warmup": "crabbox warmup"
   },
   "dependencies": {
+    "undici": "^6.26.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      undici:
+        specifier: ^6.26.0
+        version: 6.26.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -653,6 +656,10 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+    engines: {node: '>=18.17'}
+
   vite@8.0.12:
     resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1186,6 +1193,8 @@ snapshots:
   typescript@6.0.3: {}
 
   undici-types@7.24.6: {}
+
+  undici@6.26.0: {}
 
   vite@8.0.12(@types/node@25.9.2):
     dependencies:

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -4,28 +4,36 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "nod
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const moduleRequire = createRequire(import.meta.url);
 const root = process.cwd();
-const tmp = mkdtempSync(join(tmpdir(), "clawpatch-pack-smoke-"));
-const fixtureRoot = join(tmp, "fixture");
-const installRoot = join(tmp, "installed");
-const npmCache = join(tmp, "npm-cache");
 
-function write(path, contents) {
-  const full = join(fixtureRoot, path);
+function createSmokeContext() {
+  const tmp = mkdtempSync(join(tmpdir(), "clawpatch-pack-smoke-"));
+  return {
+    root,
+    tmp,
+    fixtureRoot: join(tmp, "fixture"),
+    installRoot: join(tmp, "installed"),
+    npmCache: join(tmp, "npm-cache"),
+  };
+}
+
+function write(context, path, contents) {
+  const full = join(context.fixtureRoot, path);
   mkdirSync(dirname(full), { recursive: true });
   writeFileSync(full, contents, "utf8");
 }
 
-function run(command, args, options = {}) {
+function run(context, command, args, options = {}) {
   return execFileSync(command, args, {
-    cwd: options.cwd ?? root,
+    cwd: options.cwd ?? context.root,
     encoding: "utf8",
     env: {
       ...process.env,
-      NPM_CONFIG_CACHE: npmCache,
-      npm_config_cache: npmCache,
+      NPM_CONFIG_CACHE: context.npmCache,
+      npm_config_cache: context.npmCache,
       npm_config_update_notifier: "false",
     },
     shell: needsWindowsShell(command) ? (process.env.ComSpec ?? true) : false,
@@ -39,8 +47,18 @@ function needsWindowsShell(command) {
   );
 }
 
-try {
+export function main() {
+  const context = createSmokeContext();
+  try {
+    runSmoke(context);
+  } finally {
+    rmSync(context.tmp, { recursive: true, force: true });
+  }
+}
+
+function runSmoke(context) {
   write(
+    context,
     "pyproject.toml",
     [
       "[project]",
@@ -52,8 +70,9 @@ try {
       "",
     ].join("\n"),
   );
-  write("app/__init__.py", "");
+  write(context, "app/__init__.py", "");
   write(
+    context,
     "app/main.py",
     [
       "from fastapi import FastAPI",
@@ -66,9 +85,10 @@ try {
       "",
     ].join("\n"),
   );
-  write("tests/test_ingest.py", "def test_ingest() -> None:\n    assert True\n");
-  write("pnpm-workspace.yaml", ["packages:", "  - frontend", ""].join("\n"));
+  write(context, "tests/test_ingest.py", "def test_ingest() -> None:\n    assert True\n");
+  write(context, "pnpm-workspace.yaml", ["packages:", "  - frontend", ""].join("\n"));
   write(
+    context,
     "frontend/package.json",
     JSON.stringify(
       {
@@ -80,9 +100,14 @@ try {
       2,
     ),
   );
-  write("frontend/src/app/dashboard/page.tsx", "export default function Page() { return null; }\n");
-  write("frontend/src/app/dashboard/page.test.tsx", "test('dashboard', () => {});\n");
   write(
+    context,
+    "frontend/src/app/dashboard/page.tsx",
+    "export default function Page() { return null; }\n",
+  );
+  write(context, "frontend/src/app/dashboard/page.test.tsx", "test('dashboard', () => {});\n");
+  write(
+    context,
     "CMakeLists.txt",
     [
       "cmake_minimum_required(VERSION 3.18)",
@@ -95,10 +120,15 @@ try {
       "",
     ].join("\n"),
   );
-  write("configure.ac", "AC_INIT([cuda-smoke], [0.1])\nAC_OUTPUT\n");
-  write("src/main.cpp", '#include "vector_add.cuh"\nint main() { return launch_vector_add(); }\n');
-  write("include/vector_add.cuh", "#pragma once\nint launch_vector_add();\n");
+  write(context, "configure.ac", "AC_INIT([cuda-smoke], [0.1])\nAC_OUTPUT\n");
   write(
+    context,
+    "src/main.cpp",
+    '#include "vector_add.cuh"\nint main() { return launch_vector_add(); }\n',
+  );
+  write(context, "include/vector_add.cuh", "#pragma once\nint launch_vector_add();\n");
+  write(
+    context,
     "kernels/vector_add.cu",
     [
       '#include "vector_add.cuh"',
@@ -107,38 +137,43 @@ try {
       "",
     ].join("\n"),
   );
-  write("kernels/legacy.cu", "__global__ void legacy_kernel() {}\n");
+  write(context, "kernels/legacy.cu", "__global__ void legacy_kernel() {}\n");
 
   const packOutput = JSON.parse(
-    run("npm", ["pack", "--json", "--cache", npmCache, "--pack-destination", tmp], {
-      stdio: "pipe",
+    run(
+      context,
+      "npm",
+      ["pack", "--json", "--cache", context.npmCache, "--pack-destination", context.tmp],
+      {
+        stdio: "pipe",
+      },
+    ),
+  );
+  const tarball = join(context.tmp, packFilename(packOutput));
+  const dependencyTarballs = runtimeDependencyTarballs(context);
+  mkdirSync(context.installRoot, { recursive: true });
+  run(
+    context,
+    "npm",
+    installArgs({
+      installRoot: context.installRoot,
+      npmCache: context.npmCache,
+      tarball,
+      dependencyTarballs,
     }),
   );
-  const tarball = join(tmp, packFilename(packOutput));
-  const dependencyPaths = runtimeDependencyPaths();
-  mkdirSync(installRoot, { recursive: true });
-  run("npm", [
-    "install",
-    "--offline",
-    "--omit=dev",
-    "--cache",
-    npmCache,
-    "--prefix",
-    installRoot,
-    tarball,
-    ...dependencyPaths,
-  ]);
+  verifyRuntimeDependencies(context);
 
   const bin = join(
-    installRoot,
+    context.installRoot,
     "node_modules",
     ".bin",
     process.platform === "win32" ? "clawpatch.cmd" : "clawpatch",
   );
-  run(bin, ["--root", fixtureRoot, "init", "--force", "--json"]);
-  const mapped = JSON.parse(run(bin, ["--root", fixtureRoot, "map", "--json"]));
+  run(context, bin, ["--root", context.fixtureRoot, "init", "--force", "--json"]);
+  const mapped = JSON.parse(run(context, bin, ["--root", context.fixtureRoot, "map", "--json"]));
   const features = JSON.parse(
-    run("node", [
+    run(context, "node", [
       "-e",
       [
         "const { readdirSync, readFileSync } = require('node:fs');",
@@ -146,7 +181,7 @@ try {
         "const dir = join(process.argv[1], '.clawpatch', 'features');",
         "console.log(JSON.stringify(readdirSync(dir).map((file) => JSON.parse(readFileSync(join(dir, file), 'utf8')))));",
       ].join(""),
-      fixtureRoot,
+      context.fixtureRoot,
     ]),
   );
   const sources = new Set(features.map((feature) => feature.source));
@@ -195,10 +230,7 @@ try {
   console.log(
     `packaged CLI smoke mapped ${mapped.features} features (${cudaFeatures.length} CUDA)`,
   );
-} finally {
-  rmSync(tmp, { recursive: true, force: true });
 }
-
 function packFilename(output) {
   const filename = Array.isArray(output) ? output[0]?.filename : null;
   if (typeof filename !== "string" || filename.length === 0) {
@@ -207,9 +239,87 @@ function packFilename(output) {
   return filename;
 }
 
-function runtimeDependencyPaths() {
-  const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
-  return Object.keys(packageJson.dependencies ?? {}).map((name) =>
+function runtimeDependencyPaths(rootPath = root) {
+  const packageJson = JSON.parse(readFileSync(join(rootPath, "package.json"), "utf8"));
+  return runtimeDependencyNames(packageJson).map((name) =>
     dirname(moduleRequire.resolve(`${name}/package.json`)),
   );
 }
+
+function runtimeDependencyNames(packageJson) {
+  return Object.keys(packageJson.dependencies ?? {});
+}
+
+function runtimeDependencyTarballs(context) {
+  return runtimeDependencyPaths(context.root).map((dependencyPath) =>
+    packDependency(context, dependencyPath),
+  );
+}
+
+function packDependency(context, dependencyPath) {
+  const packOutput = JSON.parse(
+    run(
+      context,
+      "npm",
+      packDependencyArgs({
+        dependencyPath,
+        destination: context.tmp,
+        npmCache: context.npmCache,
+      }),
+      {
+        stdio: "pipe",
+      },
+    ),
+  );
+  return join(context.tmp, packFilename(packOutput));
+}
+
+function packDependencyArgs({ dependencyPath, destination, npmCache }) {
+  return [
+    "pack",
+    "--json",
+    "--ignore-scripts",
+    "--cache",
+    npmCache,
+    "--pack-destination",
+    destination,
+    dependencyPath,
+  ];
+}
+
+function installArgs({ installRoot, npmCache, tarball, dependencyTarballs }) {
+  return [
+    "install",
+    "--offline",
+    "--omit=dev",
+    "--cache",
+    npmCache,
+    "--prefix",
+    installRoot,
+    tarball,
+    ...dependencyTarballs,
+  ];
+}
+
+function verifyRuntimeDependencies(context) {
+  const packageJson = JSON.parse(readFileSync(join(context.root, "package.json"), "utf8"));
+  const packageRoot = join(context.installRoot, "node_modules", packageJson.name);
+  for (const name of runtimeDependencyNames(packageJson)) {
+    run(context, "node", [
+      "-e",
+      "require.resolve(`${process.argv[1]}/package.json`, { paths: [process.argv[2]] })",
+      name,
+      packageRoot,
+    ]);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main();
+}
+
+export const packageSmokeTestHooks = {
+  installArgs,
+  packDependencyArgs,
+  runtimeDependencyNames,
+};

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const moduleRequire = createRequire(import.meta.url);
@@ -149,7 +149,7 @@ function runSmoke(context) {
       },
     ),
   );
-  const tarball = join(context.tmp, packFilename(packOutput));
+  const tarball = packPath(context.tmp, packOutput);
   const dependencyTarballs = runtimeDependencyTarballs(context);
   mkdirSync(context.installRoot, { recursive: true });
   run(
@@ -232,11 +232,16 @@ function runSmoke(context) {
   );
 }
 function packFilename(output) {
-  const filename = Array.isArray(output) ? output[0]?.filename : null;
+  const filename = Array.isArray(output) ? output[0]?.filename : output?.filename;
   if (typeof filename !== "string" || filename.length === 0) {
     throw new Error("npm pack did not report a tarball filename");
   }
   return filename;
+}
+
+function packPath(destination, output) {
+  const filename = packFilename(output);
+  return isAbsolute(filename) ? filename : join(destination, filename);
 }
 
 function runtimeDependencyPaths(rootPath = root) {
@@ -260,30 +265,28 @@ function packDependency(context, dependencyPath) {
   const packOutput = JSON.parse(
     run(
       context,
-      "npm",
+      "pnpm",
       packDependencyArgs({
         dependencyPath,
         destination: context.tmp,
-        npmCache: context.npmCache,
       }),
       {
         stdio: "pipe",
       },
     ),
   );
-  return join(context.tmp, packFilename(packOutput));
+  return packPath(context.tmp, packOutput);
 }
 
-function packDependencyArgs({ dependencyPath, destination, npmCache }) {
+function packDependencyArgs({ dependencyPath, destination }) {
   return [
+    "--dir",
+    dependencyPath,
+    "--config.ignore-scripts=true",
     "pack",
     "--json",
-    "--ignore-scripts",
-    "--cache",
-    npmCache,
     "--pack-destination",
     destination,
-    dependencyPath,
   ];
 }
 

--- a/src/package-smoke.test.ts
+++ b/src/package-smoke.test.ts
@@ -43,14 +43,13 @@ describe("package smoke harness", () => {
       npmCache: "/tmp/cache",
     });
     expect(packArgs).toEqual([
+      "--dir",
+      dependencySource,
+      "--config.ignore-scripts=true",
       "pack",
       "--json",
-      "--ignore-scripts",
-      "--cache",
-      "/tmp/cache",
       "--pack-destination",
       "/tmp",
-      dependencySource,
     ]);
 
     const installArgs = smoke.installArgs({

--- a/src/package-smoke.test.ts
+++ b/src/package-smoke.test.ts
@@ -1,0 +1,75 @@
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+type PackageSmokeTesting = {
+  packageSmokeTestHooks: {
+    installArgs(input: {
+      installRoot: string;
+      npmCache: string;
+      tarball: string;
+      dependencyTarballs: string[];
+    }): string[];
+    packDependencyArgs(input: {
+      dependencyPath: string;
+      destination: string;
+      npmCache: string;
+    }): string[];
+    runtimeDependencyNames(packageJson: { dependencies?: Record<string, string> }): string[];
+  };
+};
+
+async function packageSmokeTesting(): Promise<PackageSmokeTesting["packageSmokeTestHooks"]> {
+  const moduleUrl = pathToFileURL(join(process.cwd(), "scripts/package-smoke.mjs")).href;
+  const smoke = (await import(moduleUrl)) as PackageSmokeTesting;
+  return smoke.packageSmokeTestHooks;
+}
+
+describe("package smoke harness", () => {
+  it("installs the packed clawpatch artifact with packed runtime dependencies", async () => {
+    const smoke = await packageSmokeTesting();
+    const dependencySource = "/repo/node_modules/.pnpm/undici@6.26.0/node_modules/undici";
+    const clawpatchTarball = "/tmp/clawpatch-0.5.1.tgz";
+    const dependencyTarball = "/tmp/undici-6.26.0.tgz";
+
+    const dependencyNames = smoke.runtimeDependencyNames({
+      dependencies: { undici: "^6.26.0", zod: "^4.4.3" },
+    });
+    expect(dependencyNames).toEqual(["undici", "zod"]);
+
+    const packArgs = smoke.packDependencyArgs({
+      dependencyPath: dependencySource,
+      destination: "/tmp",
+      npmCache: "/tmp/cache",
+    });
+    expect(packArgs).toEqual([
+      "pack",
+      "--json",
+      "--ignore-scripts",
+      "--cache",
+      "/tmp/cache",
+      "--pack-destination",
+      "/tmp",
+      dependencySource,
+    ]);
+
+    const installArgs = smoke.installArgs({
+      installRoot: "/tmp/install",
+      npmCache: "/tmp/cache",
+      tarball: clawpatchTarball,
+      dependencyTarballs: [dependencyTarball],
+    });
+    expect(installArgs).toEqual([
+      "install",
+      "--offline",
+      "--omit=dev",
+      "--cache",
+      "/tmp/cache",
+      "--prefix",
+      "/tmp/install",
+      clawpatchTarball,
+      dependencyTarball,
+    ]);
+    expect(installArgs).not.toContain(dependencySource);
+  });
+});

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -31,9 +31,18 @@ const {
   extractAcpxJson,
   extractCursorJson,
   extractClaudeStructuredOutput,
+  extractMinimaxJson,
   extractOpencodeJson,
   formatZodError,
   formatZodIssue,
+  minimaxBaseUrl,
+  minimaxDefaultModel,
+  minimaxDispatcher,
+  minimaxEndpoint,
+  minimaxExitCode,
+  minimaxFailureMessage,
+  minimaxRequestBody,
+  minimaxTimeoutMs,
   parseAcpxJsonOutput,
   parseAcpxAgent,
   parseClaudeVersion,
@@ -44,6 +53,7 @@ const {
   piThinkingLevel,
   providerExitCode,
   providerJsonSchema,
+  readMinimaxResponseText,
 } = __testing;
 
 function makeFinding(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -1957,5 +1967,392 @@ describe("buildAcpxJsonArgs", () => {
     expect(modelIdx).toBeGreaterThanOrEqual(0);
     expect(args[modelIdx + 1]).toBe("opus");
     expect(args).toContain("gamma");
+  });
+});
+
+describe("minimax provider", () => {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.env = { ...originalEnv };
+  });
+
+  it("dispatches via providerByName", () => {
+    const provider = providerByName("minimax");
+
+    expect(provider.name).toBe("minimax");
+    expect(typeof provider.check).toBe("function");
+    expect(typeof provider.review).toBe("function");
+  });
+
+  it("uses minimax-specific timeout before the generic provider timeout", () => {
+    delete process.env["CLAWPATCH_MINIMAX_TIMEOUT_MS"];
+    delete process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+    expect(minimaxTimeoutMs()).toBe(1_800_000);
+    expect(minimaxTimeoutMs()).toBeGreaterThan(300_000);
+
+    process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"] = "45000";
+    expect(minimaxTimeoutMs()).toBe(45_000);
+
+    process.env["CLAWPATCH_MINIMAX_TIMEOUT_MS"] = "120000";
+    expect(minimaxTimeoutMs()).toBe(120_000);
+
+    process.env["CLAWPATCH_MINIMAX_TIMEOUT_MS"] = "bad";
+    expect(minimaxTimeoutMs()).toBe(1_800_000);
+  });
+
+  it("caches the undici dispatcher while the configured timeout is unchanged", () => {
+    process.env["CLAWPATCH_MINIMAX_TIMEOUT_MS"] = "180000";
+    const first = minimaxDispatcher();
+    const second = minimaxDispatcher();
+
+    expect(first).toBe(second);
+
+    process.env["CLAWPATCH_MINIMAX_TIMEOUT_MS"] = "240000";
+    const providerDispatcher = minimaxDispatcher();
+    expect(providerDispatcher).not.toBe(first);
+
+    const doctorDispatcher = minimaxDispatcher(30_000);
+    expect(doctorDispatcher).not.toBe(providerDispatcher);
+    expect(minimaxDispatcher(30_000)).toBe(doctorDispatcher);
+  });
+
+  it("normalizes and validates the base URL", () => {
+    delete process.env["MINIMAX_BASE_URL"];
+    expect(minimaxBaseUrl()).toBe("https://api.minimax.io/v1");
+
+    process.env["MINIMAX_BASE_URL"] = " https://proxy.example.com/v1/?unused=1#frag ";
+    expect(minimaxBaseUrl()).toBe("https://proxy.example.com/v1");
+    expect(minimaxEndpoint("chat/completions")).toBe(
+      "https://proxy.example.com/v1/chat/completions",
+    );
+
+    process.env["MINIMAX_BASE_URL"] = "http://127.0.0.1:8787/v1";
+    expect(minimaxBaseUrl()).toBe("http://127.0.0.1:8787/v1");
+
+    process.env["MINIMAX_BASE_URL"] = "http://proxy.example.com/v1";
+    expect(() => minimaxBaseUrl()).toThrow(/https unless it targets loopback/u);
+
+    process.env["MINIMAX_BASE_URL"] = "https://user:pass@api.minimax.io/v1";
+    expect(() => minimaxBaseUrl()).toThrow(/must not include URL credentials/u);
+
+    process.env["MINIMAX_BASE_URL"] = "file:///tmp/token";
+    expect(() => minimaxBaseUrl()).toThrow(/http or https/u);
+  });
+
+  it("uses MiniMax-M3 as the default model and trims overrides", () => {
+    delete process.env["MINIMAX_MODEL"];
+    expect(minimaxDefaultModel()).toBe("MiniMax-M3");
+
+    process.env["MINIMAX_MODEL"] = " MiniMax-M2.7-highspeed ";
+    expect(minimaxDefaultModel()).toBe("MiniMax-M2.7-highspeed");
+  });
+
+  it("builds a prompt-validated chat request without unsupported response_format", () => {
+    const body = minimaxRequestBody(
+      "review prompt",
+      { model: null, reasoningEffort: null, skipGitRepoCheck: false },
+      reviewJsonSchema,
+      true,
+    ) as Record<string, unknown>;
+
+    expect(body).toMatchObject({
+      model: "MiniMax-M3",
+      temperature: 0,
+      thinking: { type: "disabled" },
+      reasoning_split: true,
+    });
+    expect(body).not.toHaveProperty("response_format");
+    const messages = body["messages"] as Array<Record<string, unknown>>;
+    expect(messages[0]?.["content"]).toContain("Do not modify files");
+    expect(messages[1]?.["content"]).toContain("Provider output schema");
+  });
+
+  it("sends Bearer auth and parses a schema-valid review response", async () => {
+    process.env["MINIMAX_API_KEY"] = "sk-cp-test-secret";
+    let capturedBody: Record<string, unknown> | null = null;
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.minimax.io/v1/chat/completions");
+      const headers = new Headers(init?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer sk-cp-test-secret");
+      capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  findings: [],
+                  inspected: { files: [], symbols: [], notes: ["minimax clean"] },
+                }),
+              },
+            },
+          ],
+          base_resp: { status_code: 0, status_msg: "" },
+        }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const output = await providerByName("minimax").review("/repo", "prompt", {
+      model: null,
+      reasoningEffort: null,
+      skipGitRepoCheck: false,
+    });
+
+    expect(capturedBody).not.toHaveProperty("response_format");
+    expect(output).toEqual({
+      findings: [],
+      inspected: { files: [], symbols: [], notes: ["minimax clean"] },
+      droppedFindings: [],
+    });
+  });
+
+  it("classifies HTTP auth failures and redacts provider error messages", async () => {
+    process.env["MINIMAX_API_KEY"] = "sk-cp-test-secret";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: { type: "TimeoutError", message: "SECRET_OUTPUT_MUST_NOT_LEAK" },
+        }),
+        { status: 401 },
+      )) as typeof fetch;
+
+    let authError: unknown;
+    try {
+      await providerByName("minimax").review("/repo", "prompt", {
+        model: null,
+        reasoningEffort: null,
+        skipGitRepoCheck: false,
+      });
+    } catch (err) {
+      authError = err;
+    }
+    expect(authError).toMatchObject({ code: "provider-auth", exitCode: 4 });
+    expect(String(authError)).not.toContain("SECRET_OUTPUT_MUST_NOT_LEAK");
+  });
+
+  it("does not expose raw fetch setup errors", async () => {
+    process.env["MINIMAX_API_KEY"] = "sk-cp-test-secret";
+    globalThis.fetch = (async () => {
+      throw new TypeError(
+        "bad Authorization: Bearer sk-cp-test-secret in https://user:pass@example.invalid/v1",
+      );
+    }) as typeof fetch;
+
+    let fetchError: unknown;
+    try {
+      await providerByName("minimax").review("/repo", "prompt", {
+        model: null,
+        reasoningEffort: null,
+        skipGitRepoCheck: false,
+      });
+    } catch (err) {
+      fetchError = err;
+    }
+
+    expect(fetchError).toMatchObject({
+      code: "provider-failure",
+      exitCode: 1,
+      message: "minimax provider network error (TypeError)",
+    });
+    expect(String(fetchError)).not.toContain("sk-cp-test-secret");
+    expect(String(fetchError)).not.toContain("user:pass");
+  });
+
+  it("keeps the timeout active while reading the response body", async () => {
+    process.env["MINIMAX_API_KEY"] = "sk-cp-test-secret";
+    process.env["CLAWPATCH_MINIMAX_TIMEOUT_MS"] = "5";
+    globalThis.fetch = (async (_input: Parameters<typeof fetch>[0], init?: RequestInit) =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            init?.signal?.addEventListener("abort", () => {
+              controller.error(new DOMException("aborted", "AbortError"));
+            });
+          },
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+
+    await expect(
+      providerByName("minimax").review("/repo", "prompt", {
+        model: null,
+        reasoningEffort: null,
+        skipGitRepoCheck: false,
+      }),
+    ).rejects.toMatchObject({
+      code: "provider-failure",
+      exitCode: 1,
+      message: "minimax provider timed out after 5ms",
+    });
+  });
+
+  it("validates the /models envelope during provider checks", async () => {
+    process.env["MINIMAX_API_KEY"] = "sk-cp-test-secret";
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          object: "list",
+          data: [{ id: "MiniMax-M3", object: "model" }],
+          base_resp: { status_code: 0, status_msg: "" },
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+
+    await expect(providerByName("minimax").check("/repo")).resolves.toContain("provider=minimax");
+
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ object: "not-list", data: [] }), {
+        status: 200,
+      })) as typeof fetch;
+
+    await expect(providerByName("minimax").check("/repo")).rejects.toThrow(/not a model list/u);
+  });
+
+  it("fails fix before auth lookup or network side effects", async () => {
+    delete process.env["MINIMAX_API_KEY"];
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response("{}");
+    }) as typeof fetch;
+
+    await expect(
+      providerByName("minimax").fix("/repo", "prompt", {
+        model: null,
+        reasoningEffort: null,
+        skipGitRepoCheck: false,
+      }),
+    ).rejects.toMatchObject({ code: "unsupported-provider", exitCode: 2 });
+    expect(called).toBe(false);
+  });
+
+  it("maps HTTP statuses to provider exit codes", () => {
+    expect(minimaxExitCode(401)).toBe(4);
+    expect(minimaxExitCode(403)).toBe(4);
+    expect(minimaxExitCode(429)).toBe(5);
+    expect(minimaxExitCode(500)).toBe(1);
+  });
+
+  it("redacts provider error bodies while keeping safe status signals", () => {
+    const message = minimaxFailureMessage(
+      401,
+      JSON.stringify({
+        error: {
+          type: "authorized_error",
+          message: "SECRET_OUTPUT_MUST_NOT_LEAK",
+        },
+      }),
+    );
+
+    expect(message).toContain("auth failed");
+    expect(message).toContain("error.type=authorized_error");
+    expect(message).not.toContain("SECRET_OUTPUT_MUST_NOT_LEAK");
+  });
+
+  it("extracts JSON from chat-completions and responses envelopes", () => {
+    expect(
+      extractMinimaxJson(
+        JSON.stringify({
+          choices: [{ message: { content: '{"features":[],"notes":[]}' } }],
+          base_resp: { status_code: 0, status_msg: "" },
+        }),
+      ),
+    ).toEqual({ features: [], notes: [] });
+
+    expect(
+      extractMinimaxJson(
+        JSON.stringify({
+          output_text: '{"outcome":"fixed","reasoning":"ok","commands":[]}',
+        }),
+      ),
+    ).toEqual({ outcome: "fixed", reasoning: "ok", commands: [] });
+  });
+
+  it("throws malformed-output for empty choices or non-JSON content", () => {
+    expectMalformed(
+      () => extractMinimaxJson(JSON.stringify({ choices: [] })),
+      /missing choices\[0\]\.message\.content/u,
+    );
+    expectMalformed(
+      () => extractMinimaxJson(JSON.stringify({ choices: [{ message: { content: "plain" } }] })),
+      /contained no Clawpatch JSON/u,
+    );
+  });
+
+  it("treats a nonzero base_resp status as provider failure without leaking status_msg", () => {
+    expect(() =>
+      extractMinimaxJson(
+        JSON.stringify({
+          choices: [{ message: { content: '{"findings":[]}' } }],
+          base_resp: { status_code: 1001, status_msg: "SECRET_OUTPUT_MUST_NOT_LEAK" },
+        }),
+      ),
+    ).toThrow(/base_resp\.status_code=1001/u);
+    expect(() =>
+      extractMinimaxJson(
+        JSON.stringify({
+          choices: [{ message: { content: '{"findings":[]}' } }],
+          base_resp: { status_code: 1001, status_msg: "SECRET_OUTPUT_MUST_NOT_LEAK" },
+        }),
+      ),
+    ).not.toThrow(/SECRET_OUTPUT_MUST_NOT_LEAK/u);
+
+    let authError: unknown;
+    try {
+      extractMinimaxJson(
+        JSON.stringify({
+          choices: [{ message: { content: '{"findings":[]}' } }],
+          base_resp: { status_code: 1004, status_msg: "SECRET_OUTPUT_MUST_NOT_LEAK" },
+        }),
+      );
+    } catch (err) {
+      authError = err;
+    }
+    expect(authError).toMatchObject({ code: "provider-auth", exitCode: 4 });
+    expect(String(authError)).not.toContain("SECRET_OUTPUT_MUST_NOT_LEAK");
+
+    let rateLimitError: unknown;
+    try {
+      extractMinimaxJson(
+        JSON.stringify({
+          choices: [{ message: { content: '{"findings":[]}' } }],
+          base_resp: { status_code: 1002, status_msg: "SECRET_OUTPUT_MUST_NOT_LEAK" },
+        }),
+      );
+    } catch (err) {
+      rateLimitError = err;
+    }
+    expect(rateLimitError).toMatchObject({ code: "provider-failure", exitCode: 5 });
+
+    for (const code of [1008, 2056]) {
+      let quotaError: unknown;
+      try {
+        extractMinimaxJson(
+          JSON.stringify({
+            choices: [{ message: { content: '{"findings":[]}' } }],
+            base_resp: { status_code: code, status_msg: "SECRET_OUTPUT_MUST_NOT_LEAK" },
+          }),
+        );
+      } catch (err) {
+        quotaError = err;
+      }
+      expect(quotaError).toMatchObject({ code: "provider-failure", exitCode: 5 });
+      expect(String(quotaError)).not.toContain("SECRET_OUTPUT_MUST_NOT_LEAK");
+    }
+  });
+
+  it("bounds response body reads", async () => {
+    await expect(
+      readMinimaxResponseText(
+        new Response("abcd"),
+        3,
+        () => new ClawpatchError("too large", 8, "malformed-output"),
+      ),
+    ).rejects.toMatchObject({ code: "malformed-output", exitCode: 8 });
   });
 });

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Agent, type Dispatcher } from "undici";
 import { z, type ZodError, type ZodIssue, type ZodType } from "zod";
 import { runCommandArgs } from "./exec.js";
 import { ClawpatchError } from "./errors.js";
@@ -276,6 +277,9 @@ export function providerByName(name: string): Provider {
   if (name === "grok") {
     return grokProvider;
   }
+  if (name === "minimax") {
+    return minimaxProvider;
+  }
   if (name === "pi") {
     return piProvider;
   }
@@ -445,6 +449,612 @@ const grokProvider: Provider = {
   ): Promise<RevalidateOutput> {
     const output = await runGrokJson(root, prompt, options.model, revalidateJsonSchema, true);
     return parseOrThrow(revalidateOutputSchema, output, "grok revalidate");
+  },
+};
+
+const MINIMAX_PROVIDER_NAME = "minimax";
+const MINIMAX_DEFAULT_BASE_URL = "https://api.minimax.io/v1";
+const MINIMAX_DEFAULT_MODEL = "MiniMax-M3";
+const MINIMAX_DEFAULT_TIMEOUT_MS = 1_800_000;
+const MINIMAX_CHECK_TIMEOUT_MS = 30_000;
+const MINIMAX_CONNECT_TIMEOUT_MS = 10_000;
+const MINIMAX_MAX_REQUEST_BYTES = 64 * 1024 * 1024;
+const MINIMAX_MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+const MINIMAX_MAX_ERROR_BYTES = 16 * 1024;
+const MINIMAX_MAX_MODELS_BYTES = 1024 * 1024;
+
+let minimaxDispatcherCache: { timeoutMs: number; dispatcher: InstanceType<typeof Agent> } | null =
+  null;
+
+function minimaxTimeoutMs(): number {
+  const raw =
+    process.env["CLAWPATCH_MINIMAX_TIMEOUT_MS"] ?? process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+  if (raw === undefined) {
+    return MINIMAX_DEFAULT_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : MINIMAX_DEFAULT_TIMEOUT_MS;
+}
+
+function minimaxDispatcher(timeoutMs = minimaxTimeoutMs()): InstanceType<typeof Agent> {
+  if (minimaxDispatcherCache !== null && minimaxDispatcherCache.timeoutMs === timeoutMs) {
+    return minimaxDispatcherCache.dispatcher;
+  }
+  if (minimaxDispatcherCache !== null) {
+    void minimaxDispatcherCache.dispatcher.close();
+  }
+  const dispatcher = new Agent({
+    headersTimeout: timeoutMs,
+    bodyTimeout: timeoutMs,
+    connectTimeout: MINIMAX_CONNECT_TIMEOUT_MS,
+  });
+  minimaxDispatcherCache = { timeoutMs, dispatcher };
+  return dispatcher;
+}
+
+function minimaxBaseUrl(): string {
+  const raw = process.env["MINIMAX_BASE_URL"]?.trim();
+  return normalizeMinimaxBaseUrl(raw && raw.length > 0 ? raw : MINIMAX_DEFAULT_BASE_URL);
+}
+
+function normalizeMinimaxBaseUrl(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new ClawpatchError(
+      "minimax provider MINIMAX_BASE_URL must be a valid http(s) URL",
+      4,
+      "provider-auth",
+    );
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new ClawpatchError(
+      "minimax provider MINIMAX_BASE_URL must use http or https",
+      4,
+      "provider-auth",
+    );
+  }
+  if (url.protocol === "http:" && !isLoopbackHostname(url.hostname)) {
+    throw new ClawpatchError(
+      "minimax provider MINIMAX_BASE_URL must use https unless it targets loopback",
+      4,
+      "provider-auth",
+    );
+  }
+  if (url.username.length > 0 || url.password.length > 0) {
+    throw new ClawpatchError(
+      "minimax provider MINIMAX_BASE_URL must not include URL credentials",
+      4,
+      "provider-auth",
+    );
+  }
+  url.hash = "";
+  url.search = "";
+  return url.toString().replace(/\/+$/u, "");
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized === "[::1]" ||
+    /^127(?:\.\d{1,3}){3}$/u.test(normalized)
+  );
+}
+
+function minimaxEndpoint(path: string): string {
+  return new URL(path.replace(/^\/+/u, ""), `${minimaxBaseUrl()}/`).toString();
+}
+
+function minimaxDefaultModel(): string {
+  const raw = process.env["MINIMAX_MODEL"]?.trim();
+  return raw && raw.length > 0 ? raw : MINIMAX_DEFAULT_MODEL;
+}
+
+function minimaxExitCode(status: number): number {
+  if (status === 401 || status === 403) {
+    return 4;
+  }
+  if (status === 429) {
+    return 5;
+  }
+  return 1;
+}
+
+function minimaxHttpErrorCode(status: number): "provider-auth" | "provider-failure" {
+  return status === 401 || status === 403 ? "provider-auth" : "provider-failure";
+}
+
+function minimaxFailureMessage(status: number, body: string): string {
+  const signal = minimaxFailureSignal(body);
+  const detail =
+    signal.length === 0 ? `body chars=${body.length}` : `${signal}; body chars=${body.length}`;
+  if (status === 401 || status === 403) {
+    return `minimax provider auth failed (HTTP ${status}). Check MINIMAX_API_KEY. ${detail}`;
+  }
+  if (status === 429) {
+    return `minimax provider rate-limited (HTTP 429). ${detail}`;
+  }
+  return `minimax provider failed (HTTP ${status}). ${detail}`;
+}
+
+function minimaxFailureSignal(body: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body) as unknown;
+  } catch {
+    return "";
+  }
+  const parts = minimaxSignalParts(parsed, "");
+  return parts.length === 0 ? "" : parts.join("; ");
+}
+
+function minimaxSignalParts(value: unknown, prefix: string): string[] {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return [];
+  }
+  const record = value as Record<string, unknown>;
+  const parts = [
+    stringPart(`${prefix}type`, record["type"]),
+    stringPart(`${prefix}code`, record["code"]),
+    stringPart(`${prefix}status`, record["status"]),
+    stringPart(`${prefix}status_code`, record["status_code"]),
+  ].filter((part) => part.length > 0);
+  for (const key of ["error", "base_resp"]) {
+    const nested = record[key];
+    const nestedPrefix = prefix.length === 0 ? `${key}.` : `${prefix}${key}.`;
+    parts.push(...minimaxSignalParts(nested, nestedPrefix));
+  }
+  return parts;
+}
+
+function minimaxRequestBody(
+  prompt: string,
+  options: ProviderOptions,
+  schema: object,
+  readOnly: boolean,
+): object {
+  const model =
+    options.model !== null && options.model.trim().length > 0
+      ? options.model.trim()
+      : minimaxDefaultModel();
+  // MiniMax M-series Chat Completions do not document response_format/json_schema.
+  // Keep schema enforcement in Clawpatch's parser instead of sending unsupported API fields.
+  return {
+    model,
+    messages: [
+      {
+        role: "system",
+        content: readOnly
+          ? "You are a read-only Clawpatch provider. Do not modify files, run commands, call tools, or include prose outside the final JSON object."
+          : "You are a Clawpatch provider. Return only the requested JSON object.",
+      },
+      { role: "user", content: minimaxPrompt(prompt, schema) },
+    ],
+    temperature: 0,
+    thinking: { type: "disabled" },
+    reasoning_split: true,
+  };
+}
+
+function minimaxPrompt(prompt: string, schema: object): string {
+  return `${prompt}
+
+Provider output schema:
+${JSON.stringify(schema, null, 2)}
+
+Return exactly one JSON object matching the schema. Do not wrap it in Markdown.`;
+}
+
+async function runMinimaxJson(
+  _root: string,
+  prompt: string,
+  options: ProviderOptions,
+  schema: object,
+  readOnly: boolean,
+): Promise<unknown> {
+  const apiKey = minimaxApiKey();
+  const requestJson = JSON.stringify(minimaxRequestBody(prompt, options, schema, readOnly));
+  const requestBytes = Buffer.byteLength(requestJson, "utf8");
+  if (requestBytes > MINIMAX_MAX_REQUEST_BYTES) {
+    throw new ClawpatchError(
+      `minimax provider request body exceeds ${MINIMAX_MAX_REQUEST_BYTES} bytes (${requestBytes})`,
+      1,
+      "provider-failure",
+    );
+  }
+  const text = await withMinimaxResponse(
+    minimaxEndpoint("chat/completions"),
+    {
+      method: "POST",
+      headers: minimaxHeaders(apiKey),
+      body: requestJson,
+    },
+    minimaxTimeoutMs(),
+    async (response) => {
+      const responseText = response.ok
+        ? await readMinimaxResponseText(
+            response,
+            MINIMAX_MAX_RESPONSE_BYTES,
+            () =>
+              new ClawpatchError(
+                `minimax provider response exceeded ${MINIMAX_MAX_RESPONSE_BYTES} bytes`,
+                8,
+                "malformed-output",
+              ),
+          )
+        : await readMinimaxResponseText(
+            response,
+            MINIMAX_MAX_ERROR_BYTES,
+            () =>
+              new ClawpatchError(
+                `minimax provider error body exceeded ${MINIMAX_MAX_ERROR_BYTES} bytes`,
+                minimaxExitCode(response.status),
+                minimaxHttpErrorCode(response.status),
+              ),
+          );
+      if (!response.ok) {
+        throw new ClawpatchError(
+          minimaxFailureMessage(response.status, responseText),
+          minimaxExitCode(response.status),
+          minimaxHttpErrorCode(response.status),
+        );
+      }
+      return responseText;
+    },
+  );
+  return extractMinimaxJson(text);
+}
+
+function minimaxApiKey(): string {
+  const apiKey = process.env["MINIMAX_API_KEY"];
+  if (apiKey === undefined || apiKey.length === 0) {
+    throw new ClawpatchError(
+      "minimax provider requires MINIMAX_API_KEY env var",
+      4,
+      "provider-auth",
+    );
+  }
+  return apiKey;
+}
+
+function minimaxHeaders(apiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+}
+
+async function withMinimaxResponse<T>(
+  url: string,
+  init: Omit<RequestInit, "signal">,
+  timeoutMs: number,
+  consume: (response: Response) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+      dispatcher: minimaxDispatcher(timeoutMs) as unknown as Dispatcher,
+    } as RequestInit & { dispatcher: Dispatcher });
+    return await consume(response);
+  } catch (err) {
+    if (err instanceof ClawpatchError) {
+      throw err;
+    }
+    if (isMinimaxTimeoutError(err)) {
+      throw new ClawpatchError(
+        `minimax provider timed out after ${timeoutMs}ms`,
+        1,
+        "provider-failure",
+      );
+    }
+    const name = err instanceof Error ? safeProviderPreview(err.name, 40) : "unknown";
+    throw new ClawpatchError(`minimax provider network error (${name})`, 1, "provider-failure");
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function isMinimaxTimeoutError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const cause =
+    err.cause instanceof Error ? `${err.cause.name} ${err.cause.message}` : String(err.cause ?? "");
+  return /AbortError|TimeoutError|timed out|timeout|UND_ERR_(?:HEADERS|BODY)_TIMEOUT/iu.test(
+    `${err.name} ${err.message} ${cause}`,
+  );
+}
+
+async function readMinimaxResponseText(
+  response: Response,
+  limitBytes: number,
+  overflowError: () => ClawpatchError,
+): Promise<string> {
+  if (response.body === null) {
+    return "";
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return `${text}${decoder.decode()}`;
+      }
+      if (value === undefined) {
+        continue;
+      }
+      bytes += value.byteLength;
+      if (bytes > limitBytes) {
+        await reader.cancel().catch(() => {});
+        throw overflowError();
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+  } catch (err) {
+    if (err instanceof ClawpatchError) {
+      throw err;
+    }
+    if (isMinimaxTimeoutError(err)) {
+      throw err;
+    }
+    throw new ClawpatchError(
+      "minimax provider failed while reading response",
+      1,
+      "provider-failure",
+    );
+  }
+}
+
+function extractMinimaxJson(text: string): unknown {
+  let envelope: unknown;
+  try {
+    envelope = JSON.parse(text) as unknown;
+  } catch {
+    throw new ClawpatchError(
+      `minimax provider produced a malformed JSON envelope (body chars=${text.length})`,
+      8,
+      "malformed-output",
+    );
+  }
+  const embeddedError = minimaxEmbeddedError(envelope);
+  if (embeddedError !== null) {
+    throw new ClawpatchError(
+      `minimax provider failed: ${embeddedError.signal}`,
+      embeddedError.exitCode,
+      embeddedError.exitCode === 4 ? "provider-auth" : "provider-failure",
+    );
+  }
+  const content = minimaxEnvelopeText(envelope);
+  if (content === null || content.trim().length === 0) {
+    throw new ClawpatchError(
+      "minimax provider response missing choices[0].message.content or output_text",
+      8,
+      "malformed-output",
+    );
+  }
+  const parsed = extractJson(content);
+  if (parsed === null) {
+    throw new ClawpatchError(
+      `minimax provider content contained no Clawpatch JSON (content chars=${content.length})`,
+      8,
+      "malformed-output",
+    );
+  }
+  return parsed;
+}
+
+type MinimaxEmbeddedError = { signal: string; exitCode: number };
+
+function minimaxEmbeddedError(envelope: unknown): MinimaxEmbeddedError | null {
+  if (typeof envelope !== "object" || envelope === null || Array.isArray(envelope)) {
+    return null;
+  }
+  const record = envelope as Record<string, unknown>;
+  const baseResp = record["base_resp"];
+  if (typeof baseResp === "object" && baseResp !== null && !Array.isArray(baseResp)) {
+    const base = baseResp as Record<string, unknown>;
+    if (typeof base["status_code"] === "number" && base["status_code"] !== 0) {
+      const signal = minimaxSignalParts(base, "base_resp.").join("; ");
+      return {
+        signal: signal.length === 0 ? "base_resp.status_code nonzero" : signal,
+        exitCode: minimaxEmbeddedExitCode(base["status_code"]),
+      };
+    }
+  }
+  if (record["status"] === "failed") {
+    const signal = minimaxSignalParts(record, "").join("; ");
+    return {
+      signal: signal.length === 0 ? "status=failed" : signal,
+      exitCode: minimaxEmbeddedExitCode(minimaxNumericErrorCode(record)),
+    };
+  }
+  return null;
+}
+
+function minimaxNumericErrorCode(record: Record<string, unknown>): number | null {
+  for (const key of ["status_code", "code"]) {
+    const value = record[key];
+    if (typeof value === "number") {
+      return value;
+    }
+    if (typeof value === "string" && /^-?\d+$/u.test(value)) {
+      return Number(value);
+    }
+  }
+  return null;
+}
+
+function minimaxEmbeddedExitCode(code: number | null): number {
+  if (code === 1004 || code === 2049) {
+    return 4;
+  }
+  if (code === 1002 || code === 1008 || code === 2056) {
+    return 5;
+  }
+  return 1;
+}
+
+function validateMinimaxModelsEnvelope(text: string): void {
+  let envelope: unknown;
+  try {
+    envelope = JSON.parse(text) as unknown;
+  } catch {
+    throw new ClawpatchError(
+      `minimax provider models response was malformed JSON (body chars=${text.length})`,
+      1,
+      "provider-failure",
+    );
+  }
+  const embeddedError = minimaxEmbeddedError(envelope);
+  if (embeddedError !== null) {
+    throw new ClawpatchError(
+      `minimax provider models check failed: ${embeddedError.signal}`,
+      embeddedError.exitCode,
+      embeddedError.exitCode === 4 ? "provider-auth" : "provider-failure",
+    );
+  }
+  if (typeof envelope !== "object" || envelope === null || Array.isArray(envelope)) {
+    throw new ClawpatchError(
+      "minimax provider models response was not an object",
+      1,
+      "provider-failure",
+    );
+  }
+  const record = envelope as Record<string, unknown>;
+  if (record["object"] !== "list" || !Array.isArray(record["data"])) {
+    throw new ClawpatchError(
+      "minimax provider models response was not a model list",
+      1,
+      "provider-failure",
+    );
+  }
+}
+
+function minimaxEnvelopeText(envelope: unknown): string | null {
+  if (typeof envelope === "string") {
+    return envelope;
+  }
+  if (typeof envelope !== "object" || envelope === null) {
+    return null;
+  }
+  const record = envelope as Record<string, unknown>;
+  if (typeof record["output_text"] === "string") {
+    return record["output_text"];
+  }
+  const choices = record["choices"];
+  if (Array.isArray(choices)) {
+    const first = choices[0] as unknown;
+    if (typeof first === "object" && first !== null) {
+      const firstRecord = first as Record<string, unknown>;
+      const message = firstRecord["message"];
+      if (typeof message === "object" && message !== null) {
+        const content = (message as Record<string, unknown>)["content"];
+        if (typeof content === "string") {
+          return content;
+        }
+      }
+      if (typeof firstRecord["text"] === "string") {
+        return firstRecord["text"];
+      }
+    }
+  }
+  const output = record["output"];
+  if (Array.isArray(output)) {
+    for (const item of output) {
+      if (typeof item !== "object" || item === null) {
+        continue;
+      }
+      const content = (item as Record<string, unknown>)["content"];
+      if (!Array.isArray(content)) {
+        continue;
+      }
+      const texts = content
+        .map((part) => {
+          if (typeof part !== "object" || part === null) {
+            return "";
+          }
+          const text = (part as Record<string, unknown>)["text"];
+          return typeof text === "string" ? text : "";
+        })
+        .filter((part) => part.length > 0);
+      if (texts.length > 0) {
+        return texts.join("");
+      }
+    }
+  }
+  return null;
+}
+
+const minimaxProvider: Provider = {
+  name: MINIMAX_PROVIDER_NAME,
+  async check(_root: string): Promise<string> {
+    await withMinimaxResponse(
+      minimaxEndpoint("models"),
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${minimaxApiKey()}` },
+      },
+      MINIMAX_CHECK_TIMEOUT_MS,
+      async (response) => {
+        const text = await readMinimaxResponseText(
+          response,
+          response.ok ? MINIMAX_MAX_MODELS_BYTES : MINIMAX_MAX_ERROR_BYTES,
+          () =>
+            new ClawpatchError(
+              `minimax provider models response exceeded ${
+                response.ok ? MINIMAX_MAX_MODELS_BYTES : MINIMAX_MAX_ERROR_BYTES
+              } bytes`,
+              minimaxExitCode(response.status),
+              response.ok ? "provider-failure" : minimaxHttpErrorCode(response.status),
+            ),
+        );
+        if (!response.ok) {
+          throw new ClawpatchError(
+            minimaxFailureMessage(response.status, text),
+            minimaxExitCode(response.status),
+            minimaxHttpErrorCode(response.status),
+          );
+        }
+        validateMinimaxModelsEnvelope(text);
+      },
+    );
+    return `provider=minimax default-model=${minimaxDefaultModel()} base=${minimaxBaseUrl()}`;
+  },
+  async map(root: string, prompt: string, options: ProviderOptions): Promise<AgentMapOutput> {
+    const output = await runMinimaxJson(root, prompt, options, agentMapJsonSchema, true);
+    return parseOrThrow(agentMapOutputSchema, output, "minimax agent-map");
+  },
+  async review(
+    root: string,
+    prompt: string,
+    options: ProviderOptions,
+  ): Promise<PartitionedReviewOutput> {
+    const output = await runMinimaxJson(root, prompt, options, reviewJsonSchema, true);
+    return parseReviewOutput(output);
+  },
+  async fix(_root: string, _prompt: string, _options: ProviderOptions): Promise<FixPlanOutput> {
+    throw new ClawpatchError(
+      "minimax provider does not support clawpatch fix: the chat-completions API cannot edit the worktree. Use --provider codex, acpx, claude, opencode, or pi for fix; use --provider minimax for map, review, and revalidate.",
+      2,
+      "unsupported-provider",
+    );
+  },
+  async revalidate(
+    root: string,
+    prompt: string,
+    options: ProviderOptions,
+  ): Promise<RevalidateOutput> {
+    const output = await runMinimaxJson(root, prompt, options, revalidateJsonSchema, true);
+    return parseOrThrow(revalidateOutputSchema, output, "minimax revalidate");
   },
 };
 
@@ -2315,6 +2925,16 @@ export const __testing = {
   parseCodexJson,
   parseReviewOutput,
   parseOrThrow,
+  extractMinimaxJson,
+  minimaxBaseUrl,
+  minimaxDefaultModel,
+  minimaxDispatcher,
+  minimaxEndpoint,
+  minimaxExitCode,
+  minimaxFailureMessage,
+  minimaxRequestBody,
+  minimaxTimeoutMs,
+  readMinimaxResponseText,
   piThinkingLevel,
   providerExitCode,
   providerJsonSchema,


### PR DESCRIPTION
## Summary

Adds a rewritten `minimax` provider for `map`, `review`, `revalidate`, and provider `check` operations. The provider is intentionally read-only: `fix` fails before provider network or filesystem side effects with `unsupported-provider` and exit code 2.

Closes #125.

## Maintainer Notes

- Default endpoint: `https://api.minimax.io/v1`
- Default model: `MiniMax-M3`
- Required credential: `MINIMAX_API_KEY`
- Optional overrides: `MINIMAX_BASE_URL`, `MINIMAX_MODEL`, `CLAWPATCH_MINIMAX_TIMEOUT_MS`, `CLAWPATCH_PROVIDER_TIMEOUT_MS`
- Request transport uses `undici` with timeout-sized dispatchers instead of Node's default fetch dispatcher.
- `MINIMAX_BASE_URL` is normalized and rejects URL credentials; non-loopback HTTP is rejected.
- MiniMax chat responses are schema-validated locally. The request does not send `response_format.json_schema` because the current MiniMax M-series chat docs do not document that compatibility.
- Provider errors are classified into auth, quota/rate-limit, malformed output, unsupported operation, and generic provider failures without exposing auth headers or raw response bodies.
- Package smoke now installs packed clawpatch plus packed runtime dependency artifacts, avoiding source-directory dependency installs that run dependency `prepare` scripts without dev dependencies.

## Verification

Local checks on the rewritten PR branch:

```text
pnpm typecheck
pnpm lint
pnpm format:check
pnpm test
pnpm build
pnpm pack:smoke
```

Results:

```text
Vitest: 825 passed, 1 skipped
pack:smoke: packaged CLI smoke mapped 13 features, 3 CUDA
```

Autoreview:

```text
autoreview clean: no accepted/actionable findings reported
```

GitHub Actions on head `05fba5cfe77873e243a16f583a07211519b2473f`:

```text
CI: success
CodeQL: success
Dependency Review: success
Security Gate: Secret Scanning: success
```

Live MiniMax proof is not included in this landing because this maintainer environment does not have `MINIMAX_API_KEY` set and no targeted 1Password item or field was provided. Per maintainer clarification, mocked fetch/source/test proof is sufficient to merge; publishing a release remains blocked until a redacted live `/models` check plus one schema-valid supported operation is run against the exact released commit.
