### PR TITLE
feat(mapper): map uv workspace members with repo-relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.6.1 - Unreleased
 
+- Added uv workspace member mapping with repository-relative paths and member-local test commands while preserving mixed root source and test groups, thanks @srnm.
+
 ## 0.6.0 - 2026-06-11
 
 - Added trusted Codex CLI config passthrough for explicit config files while rejecting repository-controlled passthrough config, thanks @brad-ai-agent.

--- a/docs/feature-mapping.md
+++ b/docs/feature-mapping.md
@@ -163,7 +163,8 @@ same C/C++ shapes, including legacy `FindCUDA` `cuda_add_executable` and
 grouped per directory into bounded, low-confidence source groups.
 
 Python mapping covers `pyproject.toml`, `setup.cfg`, `setup.py`, and
-`requirements.txt` metadata; `[project.scripts]`, `[tool.poetry.scripts]`,
+`requirements.txt` metadata; uv workspace members declared by
+`[tool.uv.workspace]`; `[project.scripts]`, `[tool.poetry.scripts]`,
 `setup.cfg` `console_scripts`, and `setup.py` console script entry points; root
 app files; source groups under common Python source roots including `web/`;
 pytest files; Flask `@*.route(...)` handlers; FastAPI `@*.get(...)` /

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -12758,6 +12758,58 @@ exclude = ["packages/legacy"]
     expect(backendSources[0]?.entrypoints[0]?.path).toBe("packages/backend/src");
   });
 
+  it("preserves non-member tests from mixed uv workspace root test suites", async () => {
+    const root = await fixtureRoot("clawpatch-python-uv-workspace-root-mixed-tests-");
+    await writeFixture(
+      root,
+      "pyproject.toml",
+      '[project]\nname = "workspace-root"\n\n[tool.uv.workspace]\nmembers = ["tests/member"]\n',
+    );
+    await writeFixture(root, "tests/test_root.py", "def test_root():\n    pass\n");
+    await writeFixture(root, "tests/member/pyproject.toml", '[project]\nname = "member"\n');
+    await writeFixture(root, "tests/member/tests/test_member.py", "def test_member():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const rootTests = result.features.find(
+      (feature) => feature.title === "Python test suite tests",
+    );
+    const memberTests = result.features.find(
+      (feature) => feature.title === "Python test suite tests/member/tests",
+    );
+
+    expect(rootTests?.ownedFiles).toEqual([{ path: "tests/test_root.py", reason: "pytest file" }]);
+    expect(rootTests?.tests).toEqual([{ path: "tests/test_root.py", command: "uv run pytest" }]);
+    expect(memberTests?.tests).toEqual([
+      {
+        path: "tests/member/tests/test_member.py",
+        command: "uv run --directory tests/member pytest",
+      },
+    ]);
+  });
+
+  it("retargets pruned root test suites when a uv member owns the synthetic suite path", async () => {
+    const root = await fixtureRoot("clawpatch-python-uv-workspace-root-test-member-");
+    await writeFixture(
+      root,
+      "pyproject.toml",
+      '[project]\nname = "workspace-root"\n\n[tool.uv.workspace]\nmembers = ["tests"]\n',
+    );
+    await writeFixture(root, "test_root.py", "def test_root():\n    pass\n");
+    await writeFixture(root, "tests/pyproject.toml", '[project]\nname = "member"\n');
+    await writeFixture(root, "tests/test_member.py", "def test_member():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const rootTests = result.features.find((feature) =>
+      feature.ownedFiles.some((file) => file.path === "test_root.py"),
+    );
+
+    expect(rootTests?.title).toBe("Python test suite root");
+    expect(rootTests?.entrypoints[0]?.path).toBe(".");
+    expect(rootTests?.ownedFiles).toEqual([{ path: "test_root.py", reason: "pytest file" }]);
+  });
+
   symlinkIt("does not discover uv workspace members through symlinked package roots", async () => {
     const root = await fixtureRoot("clawpatch-python-uv-workspace-symlink-");
     const outside = await fixtureRoot("clawpatch-python-uv-workspace-outside-");

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -12570,6 +12570,216 @@ add_executable(headerapp include/headers.hpp)
     );
   });
 
+  it("maps uv workspace Python members with repo-relative paths", async () => {
+    const root = await fixtureRoot("clawpatch-python-uv-workspace-");
+    await writeFixture(
+      root,
+      "pyproject.toml",
+      `[project]
+name = "workspace-root"
+dependencies = ["pytest"]
+
+[tool.uv.workspace]
+members = ["packages/*", "../outside/*", "tools/*"]
+exclude = ["packages/legacy"]
+`,
+    );
+    await writeFixture(root, "uv.lock", "");
+    await writeFixture(root, "src/workspace_root/__init__.py", "");
+    await writeFixture(
+      root,
+      "packages/backend/pyproject.toml",
+      '[project]\nname = "backend"\ndependencies = ["fastapi"]\n',
+    );
+    await writeFixture(
+      root,
+      "packages/backend/src/backend/app.py",
+      "from fastapi import FastAPI\n\napp = FastAPI()\n\n@app.get('/health')\ndef health():\n    return {'ok': True}\n",
+    );
+    await writeFixture(root, "packages/backend/tests/test_app.py", "def test_app():\n    pass\n");
+    await writeFixture(
+      root,
+      "packages/quoted; pkg/pyproject.toml",
+      '[project]\nname = "quoted-pkg"\n',
+    );
+    await writeFixture(
+      root,
+      "packages/quoted; pkg/tests/test_quoted.py",
+      "def test_quoted():\n    pass\n",
+    );
+    await writeFixture(
+      root,
+      "packages/ibkr-bridge-client/pyproject.toml",
+      '[project]\nname = "ibkr-bridge-client"\n',
+    );
+    await writeFixture(
+      root,
+      "packages/ibkr-bridge-client/src/ibkr_bridge_client/client.py",
+      "def connect():\n    pass\n",
+    );
+    await writeFixture(
+      root,
+      "packages/ibkr-bridge-client/tests/test_client.py",
+      "def test_client():\n    pass\n",
+    );
+    await writeFixture(
+      root,
+      "packages/ibkr-instruments/pyproject.toml",
+      '[project]\nname = "ibkr-instruments"\n',
+    );
+    await writeFixture(
+      root,
+      "packages/ibkr-instruments/src/ibkr_instruments/store.py",
+      "def save():\n    pass\n",
+    );
+    await writeFixture(
+      root,
+      "packages/ibkr-instruments/tests/test_store.py",
+      "def test_store():\n    pass\n",
+    );
+    await writeFixture(root, "packages/legacy/pyproject.toml", '[project]\nname = "legacy"\n');
+    await writeFixture(root, "packages/legacy/src/legacy/app.py", "def legacy():\n    pass\n");
+    await writeFixture(root, "tools/no-manifest/src/tool.py", "def tool():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const titles = result.features.map((feature) => feature.title);
+    const backendSource = result.features.find(
+      (feature) => feature.title === "Python source packages/backend/src",
+    );
+    const backendTests = result.features.find(
+      (feature) => feature.title === "Python test suite packages/backend/tests",
+    );
+    const quotedTests = result.features.find(
+      (feature) => feature.title === "Python test suite packages/quoted; pkg/tests",
+    );
+    const fastApiRoute = result.features.find(
+      (feature) => feature.title === "FastAPI route GET /health",
+    );
+
+    expect(titles).toContain("Python project backend");
+    expect(titles).toContain("Python project ibkr-bridge-client");
+    expect(titles).toContain("Python project ibkr-instruments");
+    expect(titles).not.toContain("Python project legacy");
+    expect(backendSource?.entrypoints[0]?.path).toBe("packages/backend/src");
+    expect(backendSource?.ownedFiles).toEqual([
+      { path: "packages/backend/src/backend/app.py", reason: "source group src" },
+    ]);
+    expect(backendSource?.tags).toEqual(
+      expect.arrayContaining(["python", "source-group", "workspace", "uv-workspace"]),
+    );
+    expect(backendTests?.tests).toEqual([
+      {
+        path: "packages/backend/tests/test_app.py",
+        command: "uv run --directory packages/backend pytest",
+      },
+    ]);
+    expect(quotedTests?.tests).toEqual([
+      {
+        path: "packages/quoted; pkg/tests/test_quoted.py",
+        command: 'uv run --directory "packages/quoted; pkg" pytest',
+      },
+    ]);
+    expect(fastApiRoute?.entrypoints[0]?.path).toBe("packages/backend/src/backend/app.py");
+    expect(fastApiRoute?.summary).toBe(
+      "FastAPI route GET /health handled by health in packages/backend/src/backend/app.py.",
+    );
+    expect(
+      result.features.find((feature) => feature.title === "Python project backend")?.summary,
+    ).toBe("Python project metadata in packages/backend/pyproject.toml.");
+    expect(fastApiRoute?.tests).toEqual([
+      {
+        path: "packages/backend/tests/test_app.py",
+        command: "uv run --directory packages/backend pytest",
+      },
+    ]);
+    expect(
+      result.features.some((feature) =>
+        feature.ownedFiles.some((file) => file.path.startsWith("tools/no-manifest")),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not duplicate uv workspace members from root-level Python mapping", async () => {
+    const root = await fixtureRoot("clawpatch-python-uv-workspace-root-dedupe-");
+    await writeFixture(
+      root,
+      "pyproject.toml",
+      '[project]\nname = "workspace-root"\n\n[tool.uv.workspace]\nmembers = ["packages/*"]\n',
+    );
+    await writeFixture(root, "packages/__init__.py", "");
+    await writeFixture(root, "packages/backend/pyproject.toml", '[project]\nname = "backend"\n');
+    await writeFixture(root, "packages/backend/src/backend/app.py", "def run():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const backendSources = result.features.filter((feature) =>
+      feature.ownedFiles.some((file) => file.path.endsWith("packages/backend/src/backend/app.py")),
+    );
+
+    expect(backendSources).toHaveLength(1);
+    expect(backendSources[0]?.entrypoints[0]?.path).toBe("packages/backend/src");
+    expect(
+      result.features.some(
+        (feature) =>
+          feature.title === "Python source src" ||
+          feature.ownedFiles.some((file) => file.path === "backend/src/backend/app.py"),
+      ),
+    ).toBe(false);
+  });
+
+  it("preserves non-member files from mixed uv workspace root source groups", async () => {
+    const root = await fixtureRoot("clawpatch-python-uv-workspace-root-mixed-");
+    await writeFixture(
+      root,
+      "pyproject.toml",
+      '[project]\nname = "workspace-root"\n\n[tool.uv.workspace]\nmembers = ["packages/*"]\n',
+    );
+    await writeFixture(root, "packages/__init__.py", "");
+    await writeFixture(root, "packages/shared.py", "def shared():\n    pass\n");
+    await writeFixture(root, "packages/backend/pyproject.toml", '[project]\nname = "backend"\n');
+    await writeFixture(root, "packages/backend/src/backend/app.py", "def run():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const packageSource = result.features.find(
+      (feature) => feature.title === "Python source packages",
+    );
+    const backendSources = result.features.filter((feature) =>
+      feature.ownedFiles.some((file) => file.path.endsWith("packages/backend/src/backend/app.py")),
+    );
+
+    expect(packageSource?.ownedFiles.map((file) => file.path).toSorted()).toEqual([
+      "packages/__init__.py",
+      "packages/shared.py",
+    ]);
+    expect(packageSource?.summary).toBe("Python source group packages with 2 files.");
+    expect(backendSources).toHaveLength(1);
+    expect(backendSources[0]?.entrypoints[0]?.path).toBe("packages/backend/src");
+  });
+
+  symlinkIt("does not discover uv workspace members through symlinked package roots", async () => {
+    const root = await fixtureRoot("clawpatch-python-uv-workspace-symlink-");
+    const outside = await fixtureRoot("clawpatch-python-uv-workspace-outside-");
+    await writeFixture(
+      root,
+      "pyproject.toml",
+      '[project]\nname = "workspace-root"\n\n[tool.uv.workspace]\nmembers = ["packages/*"]\n',
+    );
+    await writeFixture(root, "uv.lock", "");
+    await writeFixture(outside, "external/pyproject.toml", '[project]\nname = "external"\n');
+    await writeFixture(outside, "external/src/external/app.py", "def app():\n    pass\n");
+    await mkdir(join(root, "packages"), { recursive: true });
+    await symlink(join(outside, "external"), join(root, "packages", "external"), "dir");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(result.features.map((feature) => feature.title)).not.toContain(
+      "Python project external",
+    );
+  });
+
   it("detects and maps Laravel application slices", async () => {
     const root = await fixtureRoot("clawpatch-laravel-map-");
     await writeFixture(

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -1,10 +1,12 @@
 import { readFile, readdir } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { pathExists } from "../fs.js";
+import { shellQuotePath } from "../shell.js";
 import { partitionFileGroups } from "./grouping.js";
 import {
   isSafeDirectory,
   isSafeFile,
+  normalize,
   packageKind,
   packageTrustBoundaries,
   pathMatchesPrefix,
@@ -47,6 +49,10 @@ type PyprojectInfo = {
   hasPytest: boolean;
 };
 
+type PythonSeedOptions = {
+  testCommandOverride?: string | null;
+};
+
 const sourceRoots = ["src", "app", "apps", "lib", "scripts", "web"] as const;
 const fastApiRouteTargetPattern = [
   "(?:[A-Za-z_][A-Za-z0-9_]*\\.)*",
@@ -86,12 +92,31 @@ const flaskRootEntryFiles = [
 ] as const;
 
 export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
+  const uvMembers = await uvWorkspaceMemberDirs(root);
+  const seeds = filterRootSeedsUnderUvMembers(await pythonProjectSeeds(root), uvMembers);
+  for (const member of uvMembers) {
+    const memberSeeds = await pythonProjectSeeds(join(root, member), {
+      testCommandOverride: uvWorkspaceMemberTestCommand(member),
+    });
+    seeds.push(...memberSeeds.map((seed) => workspaceMemberSeed(seed, member)));
+  }
+  return seeds;
+}
+
+function uvWorkspaceMemberTestCommand(member: string): string {
+  return `uv run --directory ${shellQuotePath(member)} pytest`;
+}
+
+async function pythonProjectSeeds(
+  root: string,
+  options: PythonSeedOptions = {},
+): Promise<FeatureSeed[]> {
   if (!(await isPythonProject(root))) {
     return [];
   }
   const metadata = await readPythonProjectMetadata(root);
   const metadataFiles = await pythonMetadataFiles(root);
-  const testCommand = await pythonTestCommand(root, metadata);
+  const testCommand = options.testCommandOverride ?? (await pythonTestCommand(root, metadata));
   const testFiles = await pythonTestFiles(root);
   const seeds: FeatureSeed[] = [];
 
@@ -194,6 +219,299 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
   }
 
   return seeds;
+}
+
+function filterRootSeedsUnderUvMembers(
+  seeds: FeatureSeed[],
+  members: readonly string[],
+): FeatureSeed[] {
+  if (members.length === 0) {
+    return seeds;
+  }
+  const filtered: FeatureSeed[] = [];
+  for (const seed of seeds) {
+    if (!seedTouchesUvMember(seed, members)) {
+      filtered.push(seed);
+      continue;
+    }
+    const pruned = pruneSourceGroupSeedUvMemberPaths(seed, members);
+    if (pruned !== null) {
+      filtered.push(pruned);
+    }
+  }
+  return filtered;
+}
+
+function seedTouchesUvMember(seed: FeatureSeed, members: readonly string[]): boolean {
+  return seedRepoPaths(seed).some((path) =>
+    members.some((member) => pathMatchesPrefix(path, member)),
+  );
+}
+
+function pruneSourceGroupSeedUvMemberPaths(
+  seed: FeatureSeed,
+  members: readonly string[],
+): FeatureSeed | null {
+  if (seed.source !== "python-source-group" || seed.ownedFiles === undefined) {
+    return null;
+  }
+  const ownedFiles = seed.ownedFiles.filter((file) => !pathTouchesUvMember(file.path, members));
+  if (ownedFiles.length === 0) {
+    return null;
+  }
+  const pruned: FeatureSeed = {
+    ...seed,
+    ownedFiles,
+    summary:
+      ownedFiles.length === 1
+        ? `Python source file ${ownedFiles[0]?.path}.`
+        : `Python source group ${seed.entryPath} with ${ownedFiles.length} files.`,
+  };
+  if (seed.contextFiles !== undefined) {
+    pruned.contextFiles = seed.contextFiles.filter(
+      (file) => !pathTouchesUvMember(file.path, members),
+    );
+  }
+  if (seed.tests !== undefined) {
+    pruned.tests = seed.tests.filter((test) => !pathTouchesUvMember(test.path, members));
+  }
+  if (seed.testPrefixes !== undefined) {
+    pruned.testPrefixes = seed.testPrefixes.filter(
+      (prefix) => !pathTouchesUvMember(prefix, members),
+    );
+  }
+  return pruned;
+}
+
+function pathTouchesUvMember(path: string, members: readonly string[]): boolean {
+  return members.some((member) => pathMatchesPrefix(path, member));
+}
+
+function seedRepoPaths(seed: FeatureSeed): string[] {
+  return uniquePaths([
+    seed.entryPath,
+    ...(seed.ownedFiles?.map((file) => file.path) ?? []),
+    ...(seed.contextFiles?.map((file) => file.path) ?? []),
+    ...(seed.tests?.map((test) => test.path) ?? []),
+    ...(seed.testPrefixes ?? []),
+  ]);
+}
+
+function workspaceMemberSeed(seed: FeatureSeed, member: string): FeatureSeed {
+  const prefixPath = (path: string): string => `${member}/${path}`;
+  const genericSource = seed.source === "python-source-group";
+  const genericTestSuite = seed.source === "python-test-suite";
+  const entryPath = prefixPath(seed.entryPath);
+  return {
+    ...seed,
+    title: genericSource
+      ? `Python source ${entryPath}`
+      : genericTestSuite
+        ? `Python test suite ${entryPath}`
+        : seed.title,
+    summary: workspaceMemberSummary(seed, member),
+    entryPath,
+    symbol:
+      (genericSource || genericTestSuite) && seed.symbol !== null
+        ? prefixPath(seed.symbol)
+        : seed.symbol,
+    tags: uniquePaths([...seed.tags, "workspace", "uv-workspace"]),
+    ...(seed.ownedFiles === undefined
+      ? {}
+      : { ownedFiles: seed.ownedFiles.map((file) => ({ ...file, path: prefixPath(file.path) })) }),
+    ...(seed.contextFiles === undefined
+      ? {}
+      : {
+          contextFiles: seed.contextFiles.map((file) => ({
+            ...file,
+            path: prefixPath(file.path),
+          })),
+        }),
+    ...(seed.tests === undefined
+      ? {}
+      : { tests: seed.tests.map((test) => ({ ...test, path: prefixPath(test.path) })) }),
+    ...(seed.testPrefixes === undefined ? {} : { testPrefixes: seed.testPrefixes.map(prefixPath) }),
+  };
+}
+
+function workspaceMemberSummary(seed: FeatureSeed, member: string): string {
+  if (seed.source === "python-source-group") {
+    return prefixedPythonSourceSummary(seed, member);
+  }
+  if (seed.source === "python-test-suite") {
+    return `Python pytest files in ${member}/${seed.entryPath}.`;
+  }
+  const memberPaths = uniquePaths([
+    seed.entryPath,
+    ...(seed.ownedFiles?.map((file) => file.path) ?? []),
+    ...(seed.contextFiles?.map((file) => file.path) ?? []),
+    ...(seed.tests?.map((test) => test.path) ?? []),
+  ]).toSorted((left, right) => right.length - left.length);
+  let summary = seed.summary;
+  for (const path of memberPaths) {
+    summary = summary.split(path).join(`${member}/${path}`);
+  }
+  return summary;
+}
+
+function prefixedPythonSourceSummary(seed: FeatureSeed, member: string): string {
+  const ownedFiles = seed.ownedFiles?.map((file) => `${member}/${file.path}`) ?? [];
+  if (ownedFiles.length === 1) {
+    return `Python source file ${ownedFiles[0]}.`;
+  }
+  return `Python source group ${member}/${seed.entryPath} with ${ownedFiles.length} files.`;
+}
+
+async function uvWorkspaceMemberDirs(root: string): Promise<string[]> {
+  if (!(await pathExists(join(root, "pyproject.toml")))) {
+    return [];
+  }
+  const source = await readFile(join(root, "pyproject.toml"), "utf8");
+  const workspace = table(source, "tool.uv.workspace");
+  if (workspace.length === 0) {
+    return [];
+  }
+  const members = workspaceArrayValues(workspace, "members");
+  const excludes = workspaceArrayValues(workspace, "exclude").map(workspaceMemberPath);
+  const dirs = new Set<string>();
+  for (const value of members) {
+    const member = workspaceMemberPath(value);
+    if (!isSafeWorkspacePattern(member)) {
+      continue;
+    }
+    const candidates = hasWorkspaceGlob(member)
+      ? await expandWorkspaceMemberPattern(root, member)
+      : [member];
+    for (const candidate of candidates) {
+      if (
+        candidate.length > 0 &&
+        candidate !== "." &&
+        !workspaceMemberExcluded(candidate, excludes) &&
+        (await isSafeDirectory(root, join(root, candidate))) &&
+        (await isSafeFile(root, join(root, candidate, "pyproject.toml")))
+      ) {
+        dirs.add(candidate);
+      }
+    }
+  }
+  return [...dirs].toSorted();
+}
+
+function workspaceArrayValues(source: string, key: string): string[] {
+  return tomlArrayAssignments(source, [key]).flatMap(arrayValues);
+}
+
+function workspaceMemberPath(path: string): string {
+  return normalize(path).replace(/^\.\//u, "").replace(/\/+$/u, "");
+}
+
+function isSafeWorkspacePattern(path: string): boolean {
+  return isSafeWorkspacePath(path.replace(/[*?]/gu, "x"));
+}
+
+function isSafeWorkspacePath(path: string): boolean {
+  return (
+    path.length > 0 && path !== "." && !path.startsWith("/") && !path.split("/").includes("..")
+  );
+}
+
+function hasWorkspaceGlob(path: string): boolean {
+  return /[*?]/u.test(path);
+}
+
+async function expandWorkspaceMemberPattern(root: string, pattern: string): Promise<string[]> {
+  const members: string[] = [];
+  const parts = pattern.split("/");
+  async function visit(base: string, remaining: string[]): Promise<void> {
+    const [part, ...rest] = remaining;
+    if (part === undefined) {
+      if (
+        base.length > 0 &&
+        base !== "." &&
+        (await isSafeDirectory(root, join(root, base))) &&
+        (await isSafeFile(root, join(root, base, "pyproject.toml")))
+      ) {
+        members.push(base);
+      }
+      return;
+    }
+    if (part === "**") {
+      await visit(base, rest);
+      for (const entry of await safeWorkspaceEntries(root, base)) {
+        const next = base.length === 0 ? entry : `${base}/${entry}`;
+        await visit(next, remaining);
+      }
+      return;
+    }
+    if (!hasWorkspaceGlob(part)) {
+      await visit(base.length === 0 ? part : `${base}/${part}`, rest);
+      return;
+    }
+    const matcher = workspaceGlobSegmentRegExp(part);
+    for (const entry of await safeWorkspaceEntries(root, base)) {
+      if (matcher.test(entry)) {
+        await visit(base.length === 0 ? entry : `${base}/${entry}`, rest);
+      }
+    }
+  }
+  await visit("", parts);
+  return members;
+}
+
+async function safeWorkspaceEntries(root: string, base: string): Promise<string[]> {
+  const dir = join(root, base);
+  if (!(await isSafeDirectory(root, dir))) {
+    return [];
+  }
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  return entries
+    .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
+    .map((entry) => entry.name)
+    .filter((entry) => {
+      const path = base.length === 0 ? entry : `${base}/${entry}`;
+      return !pythonShouldSkip(path);
+    })
+    .toSorted();
+}
+
+function workspaceMemberExcluded(member: string, excludes: string[]): boolean {
+  return excludes.some((exclude) => workspacePatternMatches(exclude, member));
+}
+
+function workspacePatternMatches(pattern: string, member: string): boolean {
+  if (!isSafeWorkspacePattern(pattern)) {
+    return false;
+  }
+  return workspaceGlobMatches(pattern, member);
+}
+
+function workspaceGlobMatches(pattern: string, member: string): boolean {
+  const patternParts = pattern.split("/");
+  const memberParts = member.split("/");
+  function match(patternIndex: number, memberIndex: number): boolean {
+    const part = patternParts[patternIndex];
+    if (part === undefined) {
+      return memberIndex === memberParts.length;
+    }
+    if (part === "**") {
+      return (
+        match(patternIndex + 1, memberIndex) ||
+        (memberIndex < memberParts.length && match(patternIndex, memberIndex + 1))
+      );
+    }
+    const memberPart = memberParts[memberIndex];
+    return (
+      memberPart !== undefined &&
+      workspaceGlobSegmentRegExp(part).test(memberPart) &&
+      match(patternIndex + 1, memberIndex + 1)
+    );
+  }
+  return match(0, 0);
+}
+
+function workspaceGlobSegmentRegExp(segment: string): RegExp {
+  const escaped = segment.replace(/[.+^${}()|[\]\\]/gu, "\\$&");
+  return new RegExp(`^${escaped.replace(/\*/gu, "[^/]*").replace(/\?/gu, "[^/]")}$`, "u");
 }
 
 async function isPythonProject(root: string): Promise<boolean> {

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -234,7 +234,7 @@ function filterRootSeedsUnderUvMembers(
       filtered.push(seed);
       continue;
     }
-    const pruned = pruneSourceGroupSeedUvMemberPaths(seed, members);
+    const pruned = pruneRootSeedUvMemberPaths(seed, members);
     if (pruned !== null) {
       filtered.push(pruned);
     }
@@ -248,24 +248,42 @@ function seedTouchesUvMember(seed: FeatureSeed, members: readonly string[]): boo
   );
 }
 
-function pruneSourceGroupSeedUvMemberPaths(
+function pruneRootSeedUvMemberPaths(
   seed: FeatureSeed,
   members: readonly string[],
 ): FeatureSeed | null {
-  if (seed.source !== "python-source-group" || seed.ownedFiles === undefined) {
+  if (
+    (seed.source !== "python-source-group" && seed.source !== "python-test-suite") ||
+    seed.ownedFiles === undefined
+  ) {
     return null;
   }
   const ownedFiles = seed.ownedFiles.filter((file) => !pathTouchesUvMember(file.path, members));
   if (ownedFiles.length === 0) {
     return null;
   }
+  const prunedTestEntryPath =
+    seed.source === "python-test-suite" && pathTouchesUvMember(seed.entryPath, members)
+      ? "."
+      : seed.entryPath;
+  const prunedTestTitle =
+    prunedTestEntryPath === "."
+      ? "Python test suite root"
+      : `Python test suite ${prunedTestEntryPath}`;
   const pruned: FeatureSeed = {
     ...seed,
+    title: seed.source === "python-test-suite" ? prunedTestTitle : seed.title,
+    entryPath: prunedTestEntryPath,
+    symbol: seed.source === "python-test-suite" ? prunedTestEntryPath : seed.symbol,
     ownedFiles,
     summary:
-      ownedFiles.length === 1
-        ? `Python source file ${ownedFiles[0]?.path}.`
-        : `Python source group ${seed.entryPath} with ${ownedFiles.length} files.`,
+      seed.source === "python-source-group"
+        ? ownedFiles.length === 1
+          ? `Python source file ${ownedFiles[0]?.path}.`
+          : `Python source group ${seed.entryPath} with ${ownedFiles.length} files.`
+        : prunedTestEntryPath === "."
+          ? "Python pytest files at repository root."
+          : `Python pytest files in ${prunedTestEntryPath}.`,
   };
   if (seed.contextFiles !== undefined) {
     pruned.contextFiles = seed.contextFiles.filter(


### PR DESCRIPTION
## Summary

- Map uv workspace members as independent Python projects and prefix their seeds with repo-relative member paths.
- Scope uv member validation commands to the mapped member directory with `uv run --directory <member> pytest`.
- Filter duplicate root Python seeds that touch uv workspace members while preserving non-member files from mixed root source groups.
- Document uv workspace member mapping and add focused mapper coverage for member paths, globs, excludes, tests, runtime context, console scripts, mixed root/member source groups, and shell-quoted member directory commands.

## Why

uv workspaces can contain multiple `pyproject.toml` member projects. Root-only Python mapping can miss member-local metadata or produce paths scoped relative to the member instead of the repository. This keeps mapped features usable from the clawpatch repo root and ensures validation runs from the intended uv member directory.

## Validation

- `pnpm test src/mapper.test.ts -t "uv workspace"` - 1 file passed, 4 tests passed, 419 skipped
- `pnpm test src/mapper.test.ts` - 1 file passed, 423 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm build`

## Proof

Focused mapper tests build uv workspace fixtures with explicit members, globbed members, excluded members, member tests, runtime metadata, console scripts, shell-sensitive member paths, and mixed root/member source groups. The resulting features use repo-relative member paths such as `packages/backend/pyproject.toml`, emit member-scoped validation commands such as `uv run --directory packages/backend pytest`, shell-quote member paths when needed such as `uv run --directory "packages/quoted; pkg" pytest`, filter duplicate root-level member seeds, and preserve non-member root files such as `packages/shared.py` in the root `Python source packages` feature.

Live CLI proof with the built CLI against `/private/tmp/clawpatch-uv-proof`, a real uv workspace with root `packages/shared.py` plus `packages/backend` and `packages/quoted-pkg` members:

```text
$ node dist/cli.js --root /private/tmp/clawpatch-uv-proof --state-dir /private/tmp/clawpatch-uv-proof/.clawpatch --no-input map --source heuristic --json
clawpatch map mapper-done mapper=python seeds=7 elapsed=0s
clawpatch map done features=7 usedAgent=false elapsed=0s
```

Relevant mapped feature output from `.clawpatch/features`:

```json
{
  "title": "Python source packages/backend/src",
  "entrypoints": [{ "path": "packages/backend/src" }],
  "ownedFiles": [{ "path": "packages/backend/src/backend/app.py" }],
  "tests": [{
    "path": "packages/backend/tests/test_app.py",
    "command": "uv run --directory packages/backend pytest"
  }]
}
{
  "title": "Python source packages",
  "entrypoints": [{ "path": "packages" }],
  "ownedFiles": [
    { "path": "packages/__init__.py" },
    { "path": "packages/shared.py" }
  ],
  "tests": []
}
{
  "title": "Python test suite packages/backend/tests",
  "tests": [{
    "path": "packages/backend/tests/test_app.py",
    "command": "uv run --directory packages/backend pytest"
  }]
}
```

This confirms the built CLI preserves root-only files, maps member paths relative to the repository root, and scopes uv member validation commands to the member directory.