### PR TITLE
feat(claude): opt-in subscription (OAuth) auth via CLAWPATCH_CLAUDE_SUBSCRIPTION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.6.1 - Unreleased
 
+- Added opt-in Claude subscription (OAuth) auth for the `claude` provider via `CLAWPATCH_CLAUDE_SUBSCRIPTION=1`, which inherits the host environment and swaps `--bare` for empty `--setting-sources` so reviews bill against a local Claude Code subscription instead of an API key.
+
 ## 0.6.0 - 2026-06-11
 
 - Added trusted Codex CLI config passthrough for explicit config files while rejecting repository-controlled passthrough config, thanks @brad-ai-agent.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -140,7 +140,9 @@ Migration note: `--provider codex --model gpt-5-codex` is not equivalent to
 
 The `claude` provider shells out to the local
 [Claude Code CLI](https://code.claude.com/docs/en/cli-usage) in non-interactive
-print mode.
+print mode. It supports two authentication modes: a hardened, isolated
+**API-key** mode (default) and an opt-in **subscription** (OAuth) mode that
+reuses your local Claude Code login.
 
 Install Claude Code and authenticate with an Anthropic API key:
 
@@ -148,6 +150,31 @@ Install Claude Code and authenticate with an Anthropic API key:
 export ANTHROPIC_API_KEY=sk-ant-...
 claude --version
 ```
+
+### Subscription (OAuth) auth
+
+To bill against your Claude Code subscription instead of an API key, set
+`CLAWPATCH_CLAUDE_SUBSCRIPTION=1`. Clawpatch then runs Claude Code with the
+host environment inherited (so it can resolve OAuth credentials from the macOS
+Keychain / `~/.claude`) and replaces `--bare` with empty `--setting-sources`
+for equivalent ambient-config isolation:
+
+```bash
+export CLAWPATCH_CLAUDE_SUBSCRIPTION=1
+clawpatch review --provider claude --model opus --limit 1
+```
+
+`--bare` is incompatible with OAuth (it is built for `apiKeyHelper` / API-key
+auth and reports `Not logged in · Please run /login`). Empty `--setting-sources`
+loads no user/project/local settings — no hooks, skills, or MCP — while leaving
+auth intact, because credentials are not a setting source. Subscription mode
+uses your Claude Code OAuth login even when `ANTHROPIC_API_KEY` is present in the
+environment.
+
+**Isolation trade-off:** subscription mode inherits the host environment and
+exposes `~/.claude` to the Claude subprocess, so it forgoes the default mode's
+env-scrub isolation. Use it only on trusted repositories — the same guidance
+that applies to the `acpx`, `grok`, and `pi` providers.
 
 Provider selection:
 
@@ -170,15 +197,21 @@ How the Claude provider works:
   binary is available, reads `claude --version`, and blocks known vulnerable
   versions. It does not validate auth or make a network call; auth failures are
   reported on the first provider-backed command.
-- Auth/isolation: provider runs use `--bare` with a default-deny environment.
-  Clawpatch forwards only minimal execution variables plus explicit Anthropic
-  API key, Vertex AI, Google ADC, cloud-gateway, and Bedrock/AWS auth variables.
-  It does not pass host `HOME`, OAuth/keychain state, or whole Claude
-  config/cache directories; OAuth subscription auth is not available in Claude
-  Code `--bare` mode. Cloud auth env is available to Claude Code itself, while
-  Claude tool subprocess env scrubbing is enabled. AWS profile names are
-  forwarded only when `AWS_CONFIG_FILE` or `AWS_SHARED_CREDENTIALS_FILE` points
-  at explicit profile files.
+- Auth/isolation (default API-key mode): provider runs use `--bare` with a
+  default-deny environment. Clawpatch forwards only minimal execution variables
+  plus explicit Anthropic API key, Vertex AI, Google ADC, cloud-gateway, and
+  Bedrock/AWS auth variables. It does not pass host `HOME`, OAuth/keychain
+  state, or whole Claude config/cache directories; OAuth subscription auth is
+  not available in this hardened `--bare` mode. Cloud auth env is available to
+  Claude Code itself, while Claude tool subprocess env scrubbing is enabled. AWS
+  profile names are forwarded only when `AWS_CONFIG_FILE` or
+  `AWS_SHARED_CREDENTIALS_FILE` points at explicit profile files.
+- Auth/isolation (subscription mode, `CLAWPATCH_CLAUDE_SUBSCRIPTION=1`):
+  provider runs inherit the host environment and drop `--bare` in favor of empty
+  `--setting-sources`, so Claude Code resolves OAuth subscription credentials.
+  See [Subscription (OAuth) auth](#subscription-oauth-auth) for the isolation
+  trade-off. All other flags (structured output, tool restrictions, MCP/slash
+  isolation) are unchanged.
 - Structured output: provider runs use `--output-format json --json-schema`
   and parse the returned `structured_output` field.
 - Read-only operations (map, review, revalidate): use

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -19,6 +19,7 @@ const {
   claudeArgs,
   claudeEffort,
   claudeEnv,
+  claudeSubscriptionEnabled,
   claudeExitCode,
   claudeFailureMessage,
   claudeTimeoutMs,
@@ -761,6 +762,70 @@ describe("Claude provider helpers", () => {
     expect(args).toContain("acceptEdits");
     expect(args).not.toContain("Read,Grep,Glob");
     expect(args).not.toContain("dontAsk");
+  });
+
+  it("swaps --bare for empty --setting-sources in subscription mode", () => {
+    const args = claudeArgs(
+      { type: "object" },
+      { model: null, reasoningEffort: null, skipGitRepoCheck: false },
+      true,
+      true,
+    );
+
+    expect(args).toEqual([
+      "-p",
+      "--output-format",
+      "json",
+      "--json-schema",
+      '{"type":"object"}',
+      "--tools",
+      "Read,Grep,Glob",
+      "--permission-mode",
+      "dontAsk",
+      "--no-session-persistence",
+      "--setting-sources",
+      "",
+      "--strict-mcp-config",
+      "--mcp-config",
+      '{"mcpServers":{}}',
+      "--disable-slash-commands",
+      "--no-chrome",
+    ]);
+    expect(args).not.toContain("--bare");
+  });
+
+  it("inherits the host environment in subscription mode for OAuth auth", () => {
+    process.env = {
+      PATH: "/bin",
+      HOME: "/Users/dev",
+      CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+      OPENAI_API_KEY: "host-only",
+    };
+
+    // Subscription mode forgoes the scrubbed allowlist: HOME stays real so
+    // Keychain/~/.claude OAuth resolves, and no throwaway HOME/scrub flag is set.
+    const env = claudeEnv(true, "/tmp/claude", true);
+    expect(env["HOME"]).toBe("/Users/dev");
+    expect(env["CLAUDE_CODE_OAUTH_TOKEN"]).toBe("oauth-token");
+    expect(env).not.toHaveProperty("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB");
+
+    // The hardened default still scrubs to a throwaway HOME.
+    expect(claudeEnv(true, "/tmp/claude", false)["HOME"]).toBe("/tmp/claude/home");
+  });
+
+  it("reads the subscription toggle from CLAWPATCH_CLAUDE_SUBSCRIPTION", () => {
+    delete process.env["CLAWPATCH_CLAUDE_SUBSCRIPTION"];
+    expect(claudeSubscriptionEnabled()).toBe(false);
+
+    for (const truthy of ["1", "true", "TRUE", "yes", "on"]) {
+      process.env["CLAWPATCH_CLAUDE_SUBSCRIPTION"] = truthy;
+      expect(claudeSubscriptionEnabled()).toBe(true);
+    }
+
+    for (const falsy of ["0", "false", "no", "", "off"]) {
+      process.env["CLAWPATCH_CLAUDE_SUBSCRIPTION"] = falsy;
+      expect(claudeSubscriptionEnabled()).toBe(false);
+    }
   });
 
   it("passes model and supported effort while ignoring skipGitRepoCheck", () => {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1527,10 +1527,12 @@ async function runClaudeJson(
 ): Promise<unknown> {
   const version = await claudeVersion(root);
   assertClaudeVersionAllowed(version);
-  const args = claudeArgs(schema, options, readOnly);
+  const subscription = claudeSubscriptionEnabled();
+  const args = claudeArgs(schema, options, readOnly, subscription);
   const result = await runClaudeCommand(args, root, prompt, {
     includeAuth: true,
     timeoutMs: claudeTimeoutMs(),
+    subscription,
   });
   if (result.exitCode !== 0) {
     throw new ClawpatchError(
@@ -1553,7 +1555,12 @@ async function claudeVersion(root: string): Promise<string> {
   return result.stdout.trim() || result.stderr.trim();
 }
 
-function claudeArgs(schema: object, options: ProviderOptions, readOnly: boolean): string[] {
+function claudeArgs(
+  schema: object,
+  options: ProviderOptions,
+  readOnly: boolean,
+  subscription = false,
+): string[] {
   const args = [
     "-p",
     "--output-format",
@@ -1565,13 +1572,23 @@ function claudeArgs(schema: object, options: ProviderOptions, readOnly: boolean)
     "--permission-mode",
     readOnly ? "dontAsk" : "acceptEdits",
     "--no-session-persistence",
-    "--bare",
+  ];
+  if (subscription) {
+    // OAuth subscription auth is unavailable in `--bare` mode (it is built for
+    // apiKeyHelper / API-key auth). Use empty `--setting-sources` for equivalent
+    // isolation — it loads no user/project/local settings, hooks, or skills —
+    // while leaving auth intact, since credentials are not a setting source.
+    args.push("--setting-sources", "");
+  } else {
+    args.push("--bare");
+  }
+  args.push(
     "--strict-mcp-config",
     "--mcp-config",
     JSON.stringify({ mcpServers: {} }),
     "--disable-slash-commands",
     "--no-chrome",
-  ];
+  );
   addClaudeModelArgs(args, options);
   return args;
 }
@@ -1596,11 +1613,11 @@ async function runClaudeCommand(
   args: string[],
   root: string,
   input: string | undefined,
-  options: { includeAuth: boolean; timeoutMs: number },
+  options: { includeAuth: boolean; timeoutMs: number; subscription?: boolean },
 ): Promise<Awaited<ReturnType<typeof runCommandArgs>>> {
   const dir = await mkdtemp(join(tmpdir(), "clawpatch-claude-"));
   try {
-    const env = claudeEnv(options.includeAuth, dir);
+    const env = claudeEnv(options.includeAuth, dir, options.subscription ?? false);
     return await runCommandArgs(claudeExecutable(), args, root, input, {
       trimOutput: false,
       timeoutMs: options.timeoutMs,
@@ -1612,7 +1629,31 @@ async function runClaudeCommand(
   }
 }
 
-function claudeEnv(includeAuth: boolean, baseDir: string): NodeJS.ProcessEnv {
+/**
+ * Whether the Claude provider should authenticate with the host's Claude Code
+ * OAuth subscription instead of the default hardened API-key path. Enabled with
+ * a truthy `CLAWPATCH_CLAUDE_SUBSCRIPTION` (`1`/`true`/`yes`/`on`).
+ *
+ * Subscription mode inherits the host environment (so Claude Code can resolve
+ * OAuth credentials from the macOS Keychain / `~/.claude`), which necessarily
+ * exposes host env and config to the subprocess. Use it only on trusted repos.
+ */
+function claudeSubscriptionEnabled(): boolean {
+  const raw = process.env["CLAWPATCH_CLAUDE_SUBSCRIPTION"]?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+function claudeEnv(
+  includeAuth: boolean,
+  baseDir: string,
+  subscription = false,
+): NodeJS.ProcessEnv {
+  if (subscription) {
+    // Inherit the host environment unchanged so Claude Code can resolve OAuth
+    // subscription credentials (macOS Keychain / ~/.claude). This deliberately
+    // forgoes the default env-scrub isolation; only use on trusted repositories.
+    return { ...process.env };
+  }
   const env: NodeJS.ProcessEnv = {};
   copyPathEnv(env);
   copyEnv(env, "SystemRoot");
@@ -2933,6 +2974,7 @@ export const __testing = {
   claudeArgs,
   claudeEffort,
   claudeEnv,
+  claudeSubscriptionEnabled,
   claudeExitCode,
   claudeFailureMessage,
   claudeTimeoutMs,


### PR DESCRIPTION
## Summary

The `claude` provider's hardened default uses `--bare` plus a scrubbed environment with a throwaway `HOME`, which makes OAuth **subscription** auth impossible — `--bare` is built for `apiKeyHelper` / API-key auth and reports `Not logged in · Please run /login`. That forced API-key billing even when a local Claude Code subscription was available (the docs previously stated subscription auth was simply unavailable).

This adds an **opt-in subscription mode**, enabled with a truthy `CLAWPATCH_CLAUDE_SUBSCRIPTION` (`1`/`true`/`yes`/`on`). In this mode the provider:

- **inherits the host environment** so Claude Code can resolve OAuth credentials (macOS Keychain / `~/.claude`), and
- **swaps `--bare` for empty `--setting-sources`**, which loads no user/project/local settings (no hooks, skills, or MCP) for equivalent ambient-config isolation while leaving auth intact — credentials are not a setting source.

Everything else is unchanged: structured `--json-schema` output, read-only tool restrictions (`Read,Grep,Glob` + `dontAsk`), MCP/slash-command isolation, and the version security gate. The **default hardened API-key path is untouched**.

## Why not stream-json / `-p` changes?

The blocker was never the `-p` transport — it's `--bare` + env-scrub. With those addressed, the existing `-p --output-format json --json-schema` path returns a native `structured_output` object on subscription, so no transport rewrite was needed.

## Verification

Live-tested against a real Claude Code subscription (`claude 2.1.177`):

- ✅ `review --provider claude` with `CLAWPATCH_CLAUDE_SUBSCRIPTION=1` and **`ANTHROPIC_API_KEY` unset** → produced structured findings (proof of OAuth billing).
- ✅ Negative control: default mode (no flag, no API key) → fails, confirming the flag is load-bearing and the default is unchanged.
- ✅ Precedence: with a **bogus `ANTHROPIC_API_KEY` set**, subscription mode still succeeds → OAuth login takes precedence, so the flag is honest.
- ✅ `pnpm typecheck`, `pnpm lint`, `pnpm test` (838 passed, 1 skipped) — including 3 new unit tests for `claudeArgs`/`claudeEnv`/`claudeSubscriptionEnabled`.

## Trade-off (documented)

Subscription mode exposes the host env and `~/.claude` to the subprocess, so it forgoes the default env-scrub isolation. Use it only on trusted repositories — the same guidance that applies to the `acpx`, `grok`, and `pi` providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)