### PR TITLE
fix(mapper): preserve uv workspace root context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Removed the direct MiniMax HTTP provider and its transport dependency; provider integrations are now explicitly limited to coding harnesses and agent CLIs.
 - Added uv workspace member mapping with repository-relative paths and member-local test commands while preserving mixed root source and test groups, thanks @srnm.
+- Fixed uv workspace mapping to preserve root features with member-associated tests and include workspace-root runtime metadata in member features, thanks @srnm.
 
 ## 0.6.0 - 2026-06-11
 

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -12700,6 +12700,32 @@ exclude = ["packages/legacy"]
     ).toBe(false);
   });
 
+  it("adds workspace root runtime metadata to uv workspace member features", async () => {
+    const root = await fixtureRoot("clawpatch-python-uv-workspace-runtime-context-");
+    await writeFixture(
+      root,
+      "pyproject.toml",
+      '[project]\nname = "workspace-root"\n\n[tool.uv.workspace]\nmembers = ["packages/backend"]\n',
+    );
+    await writeFixture(root, ".python-version", "3.14\n");
+    await writeFixture(root, "packages/backend/pyproject.toml", '[project]\nname = "backend"\n');
+    await writeFixture(root, "packages/backend/src/backend/app.py", "def run():\n    pass\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const backendSource = result.features.find(
+      (feature) => feature.title === "Python source packages/backend/src",
+    );
+
+    expect(backendSource?.contextFiles).toEqual(
+      expect.arrayContaining([
+        { path: "packages/backend/pyproject.toml", reason: "python target runtime metadata" },
+        { path: "pyproject.toml", reason: "python target runtime metadata" },
+        { path: ".python-version", reason: "python target runtime metadata" },
+      ]),
+    );
+  });
+
   it("does not duplicate uv workspace members from root-level Python mapping", async () => {
     const root = await fixtureRoot("clawpatch-python-uv-workspace-root-dedupe-");
     await writeFixture(
@@ -12726,6 +12752,40 @@ exclude = ["packages/legacy"]
           feature.ownedFiles.some((file) => file.path === "backend/src/backend/app.py"),
       ),
     ).toBe(false);
+  });
+
+  it("preserves root routes that only touch uv members through associated tests", async () => {
+    const root = await fixtureRoot("clawpatch-python-uv-workspace-root-route-tests-");
+    await writeFixture(
+      root,
+      "pyproject.toml",
+      '[project]\nname = "workspace-root"\ndependencies = ["fastapi"]\n\n[tool.uv.workspace]\nmembers = ["packages/backend"]\n',
+    );
+    await writeFixture(root, "packages/__init__.py", "");
+    await writeFixture(
+      root,
+      "packages/shared.py",
+      "from fastapi import FastAPI\n\napp = FastAPI()\n\n@app.get('/shared')\ndef shared():\n    return {'ok': True}\n",
+    );
+    await writeFixture(root, "packages/backend/pyproject.toml", '[project]\nname = "backend"\n');
+    await writeFixture(
+      root,
+      "packages/backend/tests/test_member.py",
+      "def test_member():\n    pass\n",
+    );
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+    const route = result.features.find((feature) => feature.title === "FastAPI route GET /shared");
+
+    expect(route?.ownedFiles).toEqual([
+      { path: "packages/shared.py", reason: "FastAPI route handler shared" },
+    ]);
+    expect(route?.tests).toEqual([]);
+    expect(route?.contextFiles).not.toContainEqual({
+      path: "packages/backend/tests/test_member.py",
+      reason: "associated test",
+    });
   });
 
   it("preserves non-member files from mixed uv workspace root source groups", async () => {

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -98,7 +98,9 @@ export async function pythonSeeds(root: string): Promise<FeatureSeed[]> {
     const memberSeeds = await pythonProjectSeeds(join(root, member), {
       testCommandOverride: uvWorkspaceMemberTestCommand(member),
     });
-    seeds.push(...memberSeeds.map((seed) => workspaceMemberSeed(seed, member)));
+    for (const seed of memberSeeds) {
+      seeds.push(await workspaceMemberSeed(root, seed, member));
+    }
   }
   return seeds;
 }
@@ -256,7 +258,10 @@ function pruneRootSeedUvMemberPaths(
     (seed.source !== "python-source-group" && seed.source !== "python-test-suite") ||
     seed.ownedFiles === undefined
   ) {
-    return null;
+    if (seedOwnedOrEntryTouchesUvMember(seed, members)) {
+      return null;
+    }
+    return pruneSeedUvMemberReferences(seed, members);
   }
   const ownedFiles = seed.ownedFiles.filter((file) => !pathTouchesUvMember(file.path, members));
   if (ownedFiles.length === 0) {
@@ -301,6 +306,31 @@ function pruneRootSeedUvMemberPaths(
   return pruned;
 }
 
+function seedOwnedOrEntryTouchesUvMember(seed: FeatureSeed, members: readonly string[]): boolean {
+  return (
+    pathTouchesUvMember(seed.entryPath, members) ||
+    (seed.ownedFiles?.some((file) => pathTouchesUvMember(file.path, members)) ?? false)
+  );
+}
+
+function pruneSeedUvMemberReferences(seed: FeatureSeed, members: readonly string[]): FeatureSeed {
+  const pruned: FeatureSeed = { ...seed };
+  if (seed.contextFiles !== undefined) {
+    pruned.contextFiles = seed.contextFiles.filter(
+      (file) => !pathTouchesUvMember(file.path, members),
+    );
+  }
+  if (seed.tests !== undefined) {
+    pruned.tests = seed.tests.filter((test) => !pathTouchesUvMember(test.path, members));
+  }
+  if (seed.testPrefixes !== undefined) {
+    pruned.testPrefixes = seed.testPrefixes.filter(
+      (prefix) => !pathTouchesUvMember(prefix, members),
+    );
+  }
+  return pruned;
+}
+
 function pathTouchesUvMember(path: string, members: readonly string[]): boolean {
   return members.some((member) => pathMatchesPrefix(path, member));
 }
@@ -315,11 +345,28 @@ function seedRepoPaths(seed: FeatureSeed): string[] {
   ]);
 }
 
-function workspaceMemberSeed(seed: FeatureSeed, member: string): FeatureSeed {
+async function workspaceMemberSeed(
+  workspaceRoot: string,
+  seed: FeatureSeed,
+  member: string,
+): Promise<FeatureSeed> {
   const prefixPath = (path: string): string => `${member}/${path}`;
   const genericSource = seed.source === "python-source-group";
   const genericTestSuite = seed.source === "python-test-suite";
   const entryPath = prefixPath(seed.entryPath);
+  const contextFiles =
+    seed.contextFiles === undefined
+      ? undefined
+      : seed.contextFiles.map((file) => ({
+          ...file,
+          path: prefixPath(file.path),
+        }));
+  const workspaceRuntimeContext = await pythonRuntimeContextFiles(
+    workspaceRoot,
+    seed.ownedFiles === undefined
+      ? [entryPath]
+      : seed.ownedFiles.map((file) => prefixPath(file.path)),
+  );
   return {
     ...seed,
     title: genericSource
@@ -337,19 +384,25 @@ function workspaceMemberSeed(seed: FeatureSeed, member: string): FeatureSeed {
     ...(seed.ownedFiles === undefined
       ? {}
       : { ownedFiles: seed.ownedFiles.map((file) => ({ ...file, path: prefixPath(file.path) })) }),
-    ...(seed.contextFiles === undefined
-      ? {}
-      : {
-          contextFiles: seed.contextFiles.map((file) => ({
-            ...file,
-            path: prefixPath(file.path),
-          })),
-        }),
+    contextFiles: uniqueSeedFileRefs([...(contextFiles ?? []), ...workspaceRuntimeContext]),
     ...(seed.tests === undefined
       ? {}
       : { tests: seed.tests.map((test) => ({ ...test, path: prefixPath(test.path) })) }),
     ...(seed.testPrefixes === undefined ? {} : { testPrefixes: seed.testPrefixes.map(prefixPath) }),
   };
+}
+
+function uniqueSeedFileRefs(refs: SeedFileRef[]): SeedFileRef[] {
+  const seen = new Set<string>();
+  const output: SeedFileRef[] = [];
+  for (const ref of refs) {
+    if (seen.has(ref.path)) {
+      continue;
+    }
+    seen.add(ref.path);
+    output.push(ref);
+  }
+  return output;
 }
 
 function workspaceMemberSummary(seed: FeatureSeed, member: string): string {


### PR DESCRIPTION
## Summary

- Preserve root Python route seeds when their only uv member overlap is associated tests or context.
- Add workspace-root runtime metadata such as `.python-version` and root `pyproject.toml` to uv workspace member features after prefixing member paths.
- Add focused uv workspace mapper regressions for both post-merge review findings.

## Validation

- `pnpm test src/mapper.test.ts -t "uv workspace"` - 1 file passed, 6 tests passed, 421 skipped
- `pnpm test src/mapper.test.ts` - 1 file passed, 427 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`

## Live CLI Proof

Built the PR branch, then ran the public CLI against a temporary real Git repo with:

- root `pyproject.toml` declaring `[tool.uv.workspace] members = ["packages/backend"]`
- root `.python-version`
- root FastAPI route in `packages/shared.py`
- uv member source in `packages/backend/src/backend/app.py`
- uv member test in `packages/backend/tests/test_member.py`

Commands:

```sh
pnpm build
node dist/cli.js --root /var/folders/pt/ypkl4z8j259641vyf8sr6wph0000gn/T/clawpatch-pr-138-proof-dKKiZM --json --quiet init
node dist/cli.js --root /var/folders/pt/ypkl4z8j259641vyf8sr6wph0000gn/T/clawpatch-pr-138-proof-dKKiZM --json --quiet map --source heuristic
```

`init` detected Python/FastAPI/uv and `map` returned:

```json
{
  "features": 6,
  "new": 6,
  "changed": 0,
  "stale": 0,
  "source": "heuristic",
  "usedAgent": false,
  "reason": "heuristic mapper selected",
  "next": "clawpatch review --limit 3"
}
```

Relevant mapped feature JSON from `.clawpatch/features/*.json`:

```json
[
  {
    "title": "FastAPI route GET /shared",
    "kind": "route",
    "entrypoints": [
      {
        "path": "packages/shared.py",
        "symbol": "shared",
        "route": "GET /shared",
        "command": null
      }
    ],
    "ownedFiles": [
      {
        "path": "packages/shared.py",
        "reason": "FastAPI route handler shared"
      }
    ],
    "contextFiles": [
      {
        "path": "pyproject.toml",
        "reason": "python target runtime metadata"
      },
      {
        "path": ".python-version",
        "reason": "python target runtime metadata"
      }
    ],
    "tests": [],
    "tags": ["python", "fastapi", "route"]
  },
  {
    "title": "Python source packages/backend/src",
    "kind": "library",
    "entrypoints": [
      {
        "path": "packages/backend/src",
        "symbol": "packages/backend/src",
        "route": null,
        "command": null
      }
    ],
    "ownedFiles": [
      {
        "path": "packages/backend/src/backend/app.py",
        "reason": "source group src"
      }
    ],
    "contextFiles": [
      {
        "path": "packages/backend/pyproject.toml",
        "reason": "python target runtime metadata"
      },
      {
        "path": "pyproject.toml",
        "reason": "python target runtime metadata"
      },
      {
        "path": ".python-version",
        "reason": "python target runtime metadata"
      }
    ],
    "tests": [],
    "tags": ["python", "source-group", "workspace", "uv-workspace"]
  }
]
```

This demonstrates both requested behaviors through the CLI path: the root route is preserved while member-associated tests are pruned, and the uv member source feature includes workspace-root runtime metadata.

## Notes

Follow-up to #133. This addresses the post-merge Codex findings about root route seeds with member-only associated tests and workspace-root runtime metadata for uv workspace member features.