### PR TITLE
Fix oversized revalidation prompt metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.7.1 - Unreleased
 
+- Fixed revalidation prompts to compact historical and feature metadata and hard-cap metadata lists even when configured file limits are high, preventing provider input overflows, thanks @pai-scaffolde.
+
 ## 0.7.0 - 2026-06-15
 
 - Removed the direct MiniMax HTTP provider and its transport dependency; provider integrations are now explicitly limited to coding harnesses and agent CLIs.

--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -159,7 +159,7 @@ describe("review prompt provenance", () => {
     expect(prompt).toContain('"omittedAnalysisHistory": 37');
     expect(prompt).toContain('"omittedHistory": 35');
     expect(prompt).toContain("--- src/index.ts");
-    expect(prompt).not.toContain("docs/context-2499.md");
+    expect(prompt).not.toContain('"path": "docs/context-2499.md"');
     expect(prompt).not.toContain("large analysis 0");
     expect(prompt).not.toContain("large history 0");
   });

--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   REVIEW_PROMPT_FILE_CHAR_LIMIT,
   buildFixPrompt,
+  buildRevalidatePrompt,
   buildReviewPromptBundle,
 } from "./prompt.js";
 import { defaultConfig } from "./config.js";
@@ -104,6 +105,66 @@ describe("review prompt provenance", () => {
         expect.objectContaining({ path: "tests/index.test.ts", role: "test" }),
       ]),
     );
+  });
+
+  it("compacts revalidation feature metadata before provider submission", async () => {
+    const root = await fixtureRoot("clawpatch-revalidate-prompt-budget-");
+    await writeFixture(root, "src/index.ts", "export const value = 1;\n");
+    const largeFeature: FeatureRecord = {
+      ...feature(),
+      ownedFiles: [{ path: "src/index.ts", reason: "primary" }],
+      contextFiles: Array.from({ length: 2_500 }, (_, index) => ({
+        path: `docs/context-${index}.md`,
+        reason: `context ${"x".repeat(300)}`,
+      })),
+      tests: Array.from({ length: 200 }, (_, index) => ({
+        path: `tests/context-${index}.test.ts`,
+        command: null,
+      })),
+      findingIds: Array.from({ length: 200 }, (_, index) => `fnd_large_${index}`),
+      patchAttemptIds: Array.from({ length: 200 }, (_, index) => `patch_large_${index}`),
+      analysisHistory: Array.from({ length: 40 }, (_, index) => ({
+        runId: `run_large_${index}`,
+        kind: "review",
+        summary: `large analysis ${"x".repeat(1_000)}`,
+        provider: "codex",
+        model: null,
+        reasoningEffort: null,
+        createdAt: new Date(2026, 0, index + 1).toISOString(),
+      })),
+    };
+    const largeFinding: FindingRecord = {
+      ...finding("src/index.ts"),
+      history: Array.from({ length: 40 }, (_, index) => ({
+        runId: `run_history_${index}`,
+        kind: "revalidate",
+        status: "open",
+        note: null,
+        reasoning: `large history ${"x".repeat(1_000)}`,
+        commands: [],
+        createdAt: new Date(2026, 0, index + 1).toISOString(),
+      })),
+    };
+
+    const prompt = await buildRevalidatePrompt(
+      root,
+      largeFinding,
+      largeFeature,
+      [],
+      defaultConfig(),
+    );
+
+    expect(prompt.length).toBeLessThan(1_048_576);
+    expect(prompt).toContain('"omittedContextFiles": 2476');
+    expect(prompt).toContain('"omittedTests": 176');
+    expect(prompt).toContain('"omittedFindingIds": 150');
+    expect(prompt).toContain('"omittedPatchAttemptIds": 150');
+    expect(prompt).toContain('"omittedAnalysisHistory": 37');
+    expect(prompt).toContain('"omittedHistory": 35');
+    expect(prompt).toContain("--- src/index.ts");
+    expect(prompt).not.toContain("docs/context-2499.md");
+    expect(prompt).not.toContain("large analysis 0");
+    expect(prompt).not.toContain("large history 0");
   });
 
   it("does not list duplicate-skipped included files as omitted", async () => {

--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -145,18 +145,15 @@ describe("review prompt provenance", () => {
         createdAt: new Date(2026, 0, index + 1).toISOString(),
       })),
     };
+    const config = defaultConfig();
+    config.review.maxOwnedFiles = 10_000;
+    config.review.maxContextFiles = 10_000;
 
-    const prompt = await buildRevalidatePrompt(
-      root,
-      largeFinding,
-      largeFeature,
-      [],
-      defaultConfig(),
-    );
+    const prompt = await buildRevalidatePrompt(root, largeFinding, largeFeature, [], config);
 
     expect(prompt.length).toBeLessThan(1_048_576);
-    expect(prompt).toContain('"omittedContextFiles": 2476');
-    expect(prompt).toContain('"omittedTests": 176');
+    expect(prompt).toContain('"omittedContextFiles": 2450');
+    expect(prompt).toContain('"omittedTests": 150');
     expect(prompt).toContain('"omittedFindingIds": 150');
     expect(prompt).toContain('"omittedPatchAttemptIds": 150');
     expect(prompt).toContain('"omittedAnalysisHistory": 37');

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -463,9 +463,9 @@ function revalidationFindingEvidence(finding: FindingRecord): object {
 }
 
 function revalidationFeatureEvidence(feature: FeatureRecord, config: ClawpatchConfig): object {
-  const ownedLimit = config.review.maxOwnedFiles;
-  const contextLimit = config.review.maxContextFiles;
-  const testLimit = config.review.maxContextFiles;
+  const ownedLimit = Math.min(config.review.maxOwnedFiles, REVALIDATE_METADATA_LIST_LIMIT);
+  const contextLimit = Math.min(config.review.maxContextFiles, REVALIDATE_METADATA_LIST_LIMIT);
+  const testLimit = Math.min(config.review.maxContextFiles, REVALIDATE_METADATA_LIST_LIMIT);
   return {
     schemaVersion: feature.schemaVersion,
     featureId: feature.featureId,

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -14,6 +14,7 @@ export type ReviewMode = "default" | "deslopify";
 
 export const REVIEW_PROMPT_FILE_CHAR_LIMIT = 24_000;
 const REVALIDATE_FILE_CONTEXT_CHAR_LIMIT = 120_000;
+const REVALIDATE_METADATA_LIST_LIMIT = 50;
 
 export type ReviewPromptFileRole = "owned" | "context" | "test";
 
@@ -432,10 +433,10 @@ Return strict JSON only:
 {"outcome":"fixed|open|false-positive|uncertain","reasoning":"string","commands":["string"]}
 
 Finding:
-${JSON.stringify(finding, null, 2)}
+${JSON.stringify(revalidationFindingEvidence(finding), null, 2)}
 
 Feature:
-${JSON.stringify(feature, null, 2)}
+${JSON.stringify(revalidationFeatureEvidence(feature, config), null, 2)}
 
 Linked patch attempts:
 ${JSON.stringify(
@@ -451,6 +452,53 @@ ${JSON.stringify(
 
 Relevant current files:
 ${fileBlocks.join("\n\n")}`;
+}
+
+function revalidationFindingEvidence(finding: FindingRecord): object {
+  return {
+    ...finding,
+    history: finding.history.slice(-5),
+    omittedHistory: Math.max(0, finding.history.length - 5),
+  };
+}
+
+function revalidationFeatureEvidence(feature: FeatureRecord, config: ClawpatchConfig): object {
+  const ownedLimit = config.review.maxOwnedFiles;
+  const contextLimit = config.review.maxContextFiles;
+  const testLimit = config.review.maxContextFiles;
+  return {
+    schemaVersion: feature.schemaVersion,
+    featureId: feature.featureId,
+    title: feature.title,
+    summary: feature.summary,
+    kind: feature.kind,
+    source: feature.source,
+    confidence: feature.confidence,
+    entrypoints: feature.entrypoints.slice(0, REVALIDATE_METADATA_LIST_LIMIT),
+    omittedEntrypoints: Math.max(0, feature.entrypoints.length - REVALIDATE_METADATA_LIST_LIMIT),
+    ownedFiles: feature.ownedFiles.slice(0, ownedLimit),
+    omittedOwnedFiles: Math.max(0, feature.ownedFiles.length - ownedLimit),
+    contextFiles: feature.contextFiles.slice(0, contextLimit),
+    omittedContextFiles: Math.max(0, feature.contextFiles.length - contextLimit),
+    tests: feature.tests.slice(0, testLimit),
+    omittedTests: Math.max(0, feature.tests.length - testLimit),
+    tags: feature.tags.slice(0, REVALIDATE_METADATA_LIST_LIMIT),
+    omittedTags: Math.max(0, feature.tags.length - REVALIDATE_METADATA_LIST_LIMIT),
+    trustBoundaries: feature.trustBoundaries,
+    status: feature.status,
+    lock: feature.lock,
+    findingIds: feature.findingIds.slice(0, REVALIDATE_METADATA_LIST_LIMIT),
+    omittedFindingIds: Math.max(0, feature.findingIds.length - REVALIDATE_METADATA_LIST_LIMIT),
+    patchAttemptIds: feature.patchAttemptIds.slice(0, REVALIDATE_METADATA_LIST_LIMIT),
+    omittedPatchAttemptIds: Math.max(
+      0,
+      feature.patchAttemptIds.length - REVALIDATE_METADATA_LIST_LIMIT,
+    ),
+    analysisHistory: feature.analysisHistory.slice(-3),
+    omittedAnalysisHistory: Math.max(0, feature.analysisHistory.length - 3),
+    createdAt: feature.createdAt,
+    updatedAt: feature.updatedAt,
+  };
 }
 
 function revalidationPatchEvidence(


### PR DESCRIPTION
## Summary
- Compact revalidation finding history and feature metadata before provider submission
- Preserve omitted counts for truncated metadata so providers know context was bounded
- Hard-cap revalidation metadata independently of user-configured review file limits
- Add a regression covering very large feature metadata staying below the provider input ceiling

## Maintainer repair
- Rebased onto current `main`
- Clamped owned, context, and test metadata lists to 50 entries even when `maxOwnedFiles` or `maxContextFiles` is raised
- Added the unreleased changelog entry while preserving contributor credit

## Verification
- Regression before repair: elevated file limits produced a 1,098,118-character prompt, exceeding the 1,048,576-character ceiling
- Regression after repair: `pnpm test src/prompt.test.ts` — 15 passed
- Full suite: `pnpm test` — 871 passed, 1 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- Built live provider proof: oversized metadata (2,500 context refs, 200 test refs, 40 history entries, configured limits 10,000) produced 162,761 characters / 162,765 bytes, then the real Codex revalidation provider returned a valid structured outcome
- Autoreview: `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings

Public Model Identifier Gate: PASS — the candidate adds no model identifiers; the only provider-bearing fixture value is the existing public provider name with a null model.
