### PR TITLE
perf(mapper): lazily evaluate Node.js project discovery in MapperContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.1 - Unreleased
 
+- Improved feature mapping so pure non-Node repositories skip Node workspace and Turbo discovery while Node consumers share one lazy context, thanks @Tanmay-008.
 - Fixed revalidation prompts to compact historical and feature metadata and hard-cap metadata lists even when configured file limits are high, preventing provider input overflows, thanks @pai-scaffolde.
 - Added an opt-in Claude host auth context that preserves the default-deny environment, uses Claude Code safe mode, validates auth through doctor, and reports redacted OAuth failure signals, thanks @grantjayy.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.7.1 - Unreleased
 
-- Improved feature mapping so pure non-Node repositories skip Node workspace and Turbo discovery while Node consumers share one lazy context, thanks @Tanmay-008.
 - Fixed revalidation prompts to compact historical and feature metadata and hard-cap metadata lists even when configured file limits are high, preventing provider input overflows, thanks @pai-scaffolde.
 - Added an opt-in Claude host auth context that preserves the default-deny environment, uses Claude Code safe mode, validates auth through doctor, and reports redacted OAuth failure signals, thanks @grantjayy.
 

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1,8 +1,9 @@
 import { mkdir, symlink } from "node:fs/promises";
 import { basename, join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { detectProject } from "./detect.js";
 import { mapFeatures } from "./mapper.js";
+import * as projectsModule from "./mappers/projects.js";
 import { discoverNodeProjects, scriptCommand } from "./mappers/projects.js";
 import { turboTaskGraph } from "./mappers/turbo.js";
 import { fixtureRoot, writeFixture } from "./test-helpers.js";
@@ -12923,19 +12924,19 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\LandingPageController;\n" +
-        "use App\\Http\\Controllers\\TrackController;\n" +
-        "Route::get('/', LandingPageController::class);\n" +
-        "Route::post('/tracks', [TrackController::class, 'store']);\n" +
-        "Route::resource('catalog', TrackController::class);\n",
+      "use App\\Http\\Controllers\\LandingPageController;\n" +
+      "use App\\Http\\Controllers\\TrackController;\n" +
+      "Route::get('/', LandingPageController::class);\n" +
+      "Route::post('/tracks', [TrackController::class, 'store']);\n" +
+      "Route::resource('catalog', TrackController::class);\n",
     );
     await writeFixture(
       root,
       "app/Http/Controllers/TrackController.php",
       "<?php\nnamespace App\\Http\\Controllers;\n" +
-        "use App\\Http\\Requests\\StoreTrackRequest;\n" +
-        "use App\\Services\\TrackUploadService;\n" +
-        "final class TrackController {}\n",
+      "use App\\Http\\Requests\\StoreTrackRequest;\n" +
+      "use App\\Services\\TrackUploadService;\n" +
+      "final class TrackController {}\n",
     );
     await writeFixture(
       root,
@@ -13055,15 +13056,15 @@ exclude = ["packages/legacy"]
       root,
       "routes/admin.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\Admin\\{UserController};\n" +
-        "Route::prefix('admin')->middleware('auth')->get('/users', UserController::class);\n",
+      "use App\\Http\\Controllers\\Admin\\{UserController};\n" +
+      "Route::prefix('admin')->middleware('auth')->get('/users', UserController::class);\n",
     );
     await writeFixture(
       root,
       "routes/api.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\Api\\UserController;\n" +
-        "Route::get('/users', UserController::class);\n",
+      "use App\\Http\\Controllers\\Api\\UserController;\n" +
+      "Route::get('/users', UserController::class);\n",
     );
     await writeFixture(
       root,
@@ -13126,8 +13127,8 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "Route::get('/qualified', \\App\\Http\\Controllers\\QualifiedController::class);\n" +
-        "Route::post('/qualified-array', [App\\Http\\Controllers\\ArrayQualifiedController::class, 'store']);\n",
+      "Route::get('/qualified', \\App\\Http\\Controllers\\QualifiedController::class);\n" +
+      "Route::post('/qualified-array', [App\\Http\\Controllers\\ArrayQualifiedController::class, 'store']);\n",
     );
     await writeFixture(
       root,
@@ -13183,10 +13184,10 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\Admin\\UserController as AdminUserController;\n" +
-        "use App\\Http\\Controllers\\Api\\UserController as ApiUserController;\n" +
-        "Route::get('/admin/users', AdminUserController::class);\n" +
-        "Route::get('/api/users', ApiUserController::class);\n",
+      "use App\\Http\\Controllers\\Admin\\UserController as AdminUserController;\n" +
+      "use App\\Http\\Controllers\\Api\\UserController as ApiUserController;\n" +
+      "Route::get('/admin/users', AdminUserController::class);\n" +
+      "Route::get('/api/users', ApiUserController::class);\n",
     );
     await writeFixture(
       root,
@@ -13233,8 +13234,8 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\Api;\n" +
-        "Route::get('/api/users', Api\\UserController::class);\n",
+      "use App\\Http\\Controllers\\Api;\n" +
+      "Route::get('/api/users', Api\\UserController::class);\n",
     );
     await writeFixture(
       root,
@@ -13276,8 +13277,8 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\DashboardController;\n" +
-        "Route::prefix('{tenant}')->get('/dashboard', DashboardController::class);\n",
+      "use App\\Http\\Controllers\\DashboardController;\n" +
+      "Route::prefix('{tenant}')->get('/dashboard', DashboardController::class);\n",
     );
     await writeFixture(
       root,
@@ -13315,10 +13316,10 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\UserController;\n" +
-        'Route::group(["prefix" => "admin"], function () {\n' +
-        '    Route::get("/users", UserController::class);\n' +
-        "});\n",
+      "use App\\Http\\Controllers\\UserController;\n" +
+      'Route::group(["prefix" => "admin"], function () {\n' +
+      '    Route::get("/users", UserController::class);\n' +
+      "});\n",
     );
     await writeFixture(
       root,
@@ -13361,12 +13362,12 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\UserController;\n" +
-        "Route::group(['prefix' => 'admin'], function () {\n" +
-        "    Route::controller(UserController::class)->group(function () {\n" +
-        "        Route::get('/users', 'index');\n" +
-        "    });\n" +
-        "});\n",
+      "use App\\Http\\Controllers\\UserController;\n" +
+      "Route::group(['prefix' => 'admin'], function () {\n" +
+      "    Route::controller(UserController::class)->group(function () {\n" +
+      "        Route::get('/users', 'index');\n" +
+      "    });\n" +
+      "});\n",
     );
     await writeFixture(
       root,
@@ -13405,12 +13406,12 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\UserController;\n" +
-        "Route::group(['middleware' => 'auth'], function () {\n" +
-        "    Route::group(['prefix' => 'admin'], function () {\n" +
-        "        Route::get('/users', UserController::class);\n" +
-        "    });\n" +
-        "});\n",
+      "use App\\Http\\Controllers\\UserController;\n" +
+      "Route::group(['middleware' => 'auth'], function () {\n" +
+      "    Route::group(['prefix' => 'admin'], function () {\n" +
+      "        Route::get('/users', UserController::class);\n" +
+      "    });\n" +
+      "});\n",
     );
     await writeFixture(
       root,
@@ -13449,11 +13450,11 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\UserController;\n" +
-        "Route::prefix('admin')->controller(UserController::class)->group(function () {\n" +
-        "    Route::get('/users', 'index');\n" +
-        "    Route::post('/users', 'store');\n" +
-        "});\n",
+      "use App\\Http\\Controllers\\UserController;\n" +
+      "Route::prefix('admin')->controller(UserController::class)->group(function () {\n" +
+      "    Route::get('/users', 'index');\n" +
+      "    Route::post('/users', 'store');\n" +
+      "});\n",
     );
     await writeFixture(
       root,
@@ -13502,9 +13503,9 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\TrackController;\n" +
-        "Route::get('/tracks', TrackController::class);\n" +
-        "Route::post('/tracks', [TrackController::class, 'store']);\n",
+      "use App\\Http\\Controllers\\TrackController;\n" +
+      "Route::get('/tracks', TrackController::class);\n" +
+      "Route::post('/tracks', [TrackController::class, 'store']);\n",
     );
 
     const project = await detectProject(root);
@@ -13516,10 +13517,10 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\TrackController;\n" +
-        "Route::get('/catalog/tracks', TrackController::class);\n" +
-        "Route::get('/tracks', TrackController::class);\n" +
-        "Route::post('/tracks', [TrackController::class, 'store']);\n",
+      "use App\\Http\\Controllers\\TrackController;\n" +
+      "Route::get('/catalog/tracks', TrackController::class);\n" +
+      "Route::get('/tracks', TrackController::class);\n" +
+      "Route::post('/tracks', [TrackController::class, 'store']);\n",
     );
 
     const second = await mapFeatures(root, project, []);
@@ -13553,10 +13554,10 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-        "use App\\Http\\Controllers\\ArchiveController;\n" +
-        "// Route::get('/old', ArchiveController::class);\n" +
-        "/*\nRoute::get('/blocked', ArchiveController::class);\n*/\n" +
-        "Route::get('/current', ArchiveController::class);\n",
+      "use App\\Http\\Controllers\\ArchiveController;\n" +
+      "// Route::get('/old', ArchiveController::class);\n" +
+      "/*\nRoute::get('/blocked', ArchiveController::class);\n*/\n" +
+      "Route::get('/current', ArchiveController::class);\n",
     );
     await writeFixture(
       root,
@@ -13598,9 +13599,9 @@ exclude = ["packages/legacy"]
       root,
       "app/Console/Commands/SyncCatalog.php",
       "<?php\nnamespace App\\Console\\Commands;\n" +
-        "// protected $signature = 'app:old-sync';\n" +
-        "/* #[Signature('app:blocked-sync')] */\n" +
-        "final class SyncCatalog { protected $signature = 'app:sync-catalog {--force}'; }\n",
+      "// protected $signature = 'app:old-sync';\n" +
+      "/* #[Signature('app:blocked-sync')] */\n" +
+      "final class SyncCatalog { protected $signature = 'app:sync-catalog {--force}'; }\n",
     );
 
     const project = await detectProject(root);
@@ -17188,5 +17189,18 @@ EndProject
     expect(titles).not.toContain(".NET project Example");
     expect(ownedFiles).not.toContain("fixtures/Sample/Sample.cs");
     expect(ownedFiles).not.toContain("testdata/Example/Example.cs");
+  });
+
+  it("skips Node.js project discovery I/O for pure Go projects", async () => {
+    const root = await fixtureRoot("clawpatch-map-node-coupling-");
+    await writeFixture(root, "go.mod", "module example.com/go-app\n");
+    await writeFixture(root, "main.go", "package main\nfunc main() {}\n");
+
+    const spy = vi.spyOn(projectsModule, "discoverNodeProjects");
+
+    const project = await detectProject(root);
+    await mapFeatures(root, project, []);
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -17263,6 +17263,22 @@ EndProject
     expect(result.features.map((feature) => feature.title)).toContain("Node source apps/web/src");
   });
 
+  it("preserves package-less Nx projects outside conventional roots", async () => {
+    const root = await fixtureRoot("clawpatch-map-package-less-nx-");
+    await writeFixture(
+      root,
+      "tools/cli/project.json",
+      JSON.stringify({ name: "cli", sourceRoot: "tools/cli/src" }),
+    );
+    await writeFixture(root, "tools/cli/src/index.ts", "export function main() {}\n");
+
+    const project = await detectProject(root);
+    const result = await mapFeatures(root, project, []);
+
+    expect(project.detected.languages).not.toContain("typescript");
+    expect(result.features.map((feature) => feature.title)).toContain("Node source tools/cli/src");
+  });
+
   it("propagates Turbo failures and retries with a fresh mapping context", async () => {
     const root = await fixtureRoot("clawpatch-map-turbo-failure-");
     await writeFixture(root, "package.json", JSON.stringify({ name: "node-app" }));

--- a/src/mapper.test.ts
+++ b/src/mapper.test.ts
@@ -1,14 +1,19 @@
 import { mkdir, symlink } from "node:fs/promises";
 import { basename, join } from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { detectProject } from "./detect.js";
 import { mapFeatures } from "./mapper.js";
 import * as projectsModule from "./mappers/projects.js";
 import { discoverNodeProjects, scriptCommand } from "./mappers/projects.js";
+import * as turboModule from "./mappers/turbo.js";
 import { turboTaskGraph } from "./mappers/turbo.js";
 import { fixtureRoot, writeFixture } from "./test-helpers.js";
 
 const symlinkIt = process.platform === "win32" ? it.skip : it;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("mapFeatures", () => {
   it("quotes dynamic Node validation command parts", () => {
@@ -1121,6 +1126,8 @@ describe("mapFeatures", () => {
     );
     await writeFixture(root, "apps/web/src/pages/HomePage.test.tsx", "test('home', () => {});\n");
 
+    const projectsSpy = vi.spyOn(projectsModule, "discoverNodeProjects");
+    const taskGraphSpy = vi.spyOn(turboModule, "turboTaskGraph");
     const project = await detectProject(root);
     const result = await mapFeatures(root, project, []);
     const route = result.features.find((feature) => feature.title === "React route /home");
@@ -1128,6 +1135,8 @@ describe("mapFeatures", () => {
     expect(route?.tests).toEqual([
       { path: "apps/web/src/pages/HomePage.test.tsx", command: "pnpm turbo run test --filter web" },
     ]);
+    expect(projectsSpy).toHaveBeenCalledTimes(1);
+    expect(taskGraphSpy).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses fallback validation commands for persistent Turbo tasks", async () => {
@@ -12924,19 +12933,19 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\LandingPageController;\n" +
-      "use App\\Http\\Controllers\\TrackController;\n" +
-      "Route::get('/', LandingPageController::class);\n" +
-      "Route::post('/tracks', [TrackController::class, 'store']);\n" +
-      "Route::resource('catalog', TrackController::class);\n",
+        "use App\\Http\\Controllers\\LandingPageController;\n" +
+        "use App\\Http\\Controllers\\TrackController;\n" +
+        "Route::get('/', LandingPageController::class);\n" +
+        "Route::post('/tracks', [TrackController::class, 'store']);\n" +
+        "Route::resource('catalog', TrackController::class);\n",
     );
     await writeFixture(
       root,
       "app/Http/Controllers/TrackController.php",
       "<?php\nnamespace App\\Http\\Controllers;\n" +
-      "use App\\Http\\Requests\\StoreTrackRequest;\n" +
-      "use App\\Services\\TrackUploadService;\n" +
-      "final class TrackController {}\n",
+        "use App\\Http\\Requests\\StoreTrackRequest;\n" +
+        "use App\\Services\\TrackUploadService;\n" +
+        "final class TrackController {}\n",
     );
     await writeFixture(
       root,
@@ -13056,15 +13065,15 @@ exclude = ["packages/legacy"]
       root,
       "routes/admin.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\Admin\\{UserController};\n" +
-      "Route::prefix('admin')->middleware('auth')->get('/users', UserController::class);\n",
+        "use App\\Http\\Controllers\\Admin\\{UserController};\n" +
+        "Route::prefix('admin')->middleware('auth')->get('/users', UserController::class);\n",
     );
     await writeFixture(
       root,
       "routes/api.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\Api\\UserController;\n" +
-      "Route::get('/users', UserController::class);\n",
+        "use App\\Http\\Controllers\\Api\\UserController;\n" +
+        "Route::get('/users', UserController::class);\n",
     );
     await writeFixture(
       root,
@@ -13127,8 +13136,8 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "Route::get('/qualified', \\App\\Http\\Controllers\\QualifiedController::class);\n" +
-      "Route::post('/qualified-array', [App\\Http\\Controllers\\ArrayQualifiedController::class, 'store']);\n",
+        "Route::get('/qualified', \\App\\Http\\Controllers\\QualifiedController::class);\n" +
+        "Route::post('/qualified-array', [App\\Http\\Controllers\\ArrayQualifiedController::class, 'store']);\n",
     );
     await writeFixture(
       root,
@@ -13184,10 +13193,10 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\Admin\\UserController as AdminUserController;\n" +
-      "use App\\Http\\Controllers\\Api\\UserController as ApiUserController;\n" +
-      "Route::get('/admin/users', AdminUserController::class);\n" +
-      "Route::get('/api/users', ApiUserController::class);\n",
+        "use App\\Http\\Controllers\\Admin\\UserController as AdminUserController;\n" +
+        "use App\\Http\\Controllers\\Api\\UserController as ApiUserController;\n" +
+        "Route::get('/admin/users', AdminUserController::class);\n" +
+        "Route::get('/api/users', ApiUserController::class);\n",
     );
     await writeFixture(
       root,
@@ -13234,8 +13243,8 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\Api;\n" +
-      "Route::get('/api/users', Api\\UserController::class);\n",
+        "use App\\Http\\Controllers\\Api;\n" +
+        "Route::get('/api/users', Api\\UserController::class);\n",
     );
     await writeFixture(
       root,
@@ -13277,8 +13286,8 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\DashboardController;\n" +
-      "Route::prefix('{tenant}')->get('/dashboard', DashboardController::class);\n",
+        "use App\\Http\\Controllers\\DashboardController;\n" +
+        "Route::prefix('{tenant}')->get('/dashboard', DashboardController::class);\n",
     );
     await writeFixture(
       root,
@@ -13316,10 +13325,10 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\UserController;\n" +
-      'Route::group(["prefix" => "admin"], function () {\n' +
-      '    Route::get("/users", UserController::class);\n' +
-      "});\n",
+        "use App\\Http\\Controllers\\UserController;\n" +
+        'Route::group(["prefix" => "admin"], function () {\n' +
+        '    Route::get("/users", UserController::class);\n' +
+        "});\n",
     );
     await writeFixture(
       root,
@@ -13362,12 +13371,12 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\UserController;\n" +
-      "Route::group(['prefix' => 'admin'], function () {\n" +
-      "    Route::controller(UserController::class)->group(function () {\n" +
-      "        Route::get('/users', 'index');\n" +
-      "    });\n" +
-      "});\n",
+        "use App\\Http\\Controllers\\UserController;\n" +
+        "Route::group(['prefix' => 'admin'], function () {\n" +
+        "    Route::controller(UserController::class)->group(function () {\n" +
+        "        Route::get('/users', 'index');\n" +
+        "    });\n" +
+        "});\n",
     );
     await writeFixture(
       root,
@@ -13406,12 +13415,12 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\UserController;\n" +
-      "Route::group(['middleware' => 'auth'], function () {\n" +
-      "    Route::group(['prefix' => 'admin'], function () {\n" +
-      "        Route::get('/users', UserController::class);\n" +
-      "    });\n" +
-      "});\n",
+        "use App\\Http\\Controllers\\UserController;\n" +
+        "Route::group(['middleware' => 'auth'], function () {\n" +
+        "    Route::group(['prefix' => 'admin'], function () {\n" +
+        "        Route::get('/users', UserController::class);\n" +
+        "    });\n" +
+        "});\n",
     );
     await writeFixture(
       root,
@@ -13450,11 +13459,11 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\UserController;\n" +
-      "Route::prefix('admin')->controller(UserController::class)->group(function () {\n" +
-      "    Route::get('/users', 'index');\n" +
-      "    Route::post('/users', 'store');\n" +
-      "});\n",
+        "use App\\Http\\Controllers\\UserController;\n" +
+        "Route::prefix('admin')->controller(UserController::class)->group(function () {\n" +
+        "    Route::get('/users', 'index');\n" +
+        "    Route::post('/users', 'store');\n" +
+        "});\n",
     );
     await writeFixture(
       root,
@@ -13503,9 +13512,9 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\TrackController;\n" +
-      "Route::get('/tracks', TrackController::class);\n" +
-      "Route::post('/tracks', [TrackController::class, 'store']);\n",
+        "use App\\Http\\Controllers\\TrackController;\n" +
+        "Route::get('/tracks', TrackController::class);\n" +
+        "Route::post('/tracks', [TrackController::class, 'store']);\n",
     );
 
     const project = await detectProject(root);
@@ -13517,10 +13526,10 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\TrackController;\n" +
-      "Route::get('/catalog/tracks', TrackController::class);\n" +
-      "Route::get('/tracks', TrackController::class);\n" +
-      "Route::post('/tracks', [TrackController::class, 'store']);\n",
+        "use App\\Http\\Controllers\\TrackController;\n" +
+        "Route::get('/catalog/tracks', TrackController::class);\n" +
+        "Route::get('/tracks', TrackController::class);\n" +
+        "Route::post('/tracks', [TrackController::class, 'store']);\n",
     );
 
     const second = await mapFeatures(root, project, []);
@@ -13554,10 +13563,10 @@ exclude = ["packages/legacy"]
       root,
       "routes/web.php",
       "<?php\n" +
-      "use App\\Http\\Controllers\\ArchiveController;\n" +
-      "// Route::get('/old', ArchiveController::class);\n" +
-      "/*\nRoute::get('/blocked', ArchiveController::class);\n*/\n" +
-      "Route::get('/current', ArchiveController::class);\n",
+        "use App\\Http\\Controllers\\ArchiveController;\n" +
+        "// Route::get('/old', ArchiveController::class);\n" +
+        "/*\nRoute::get('/blocked', ArchiveController::class);\n*/\n" +
+        "Route::get('/current', ArchiveController::class);\n",
     );
     await writeFixture(
       root,
@@ -13599,9 +13608,9 @@ exclude = ["packages/legacy"]
       root,
       "app/Console/Commands/SyncCatalog.php",
       "<?php\nnamespace App\\Console\\Commands;\n" +
-      "// protected $signature = 'app:old-sync';\n" +
-      "/* #[Signature('app:blocked-sync')] */\n" +
-      "final class SyncCatalog { protected $signature = 'app:sync-catalog {--force}'; }\n",
+        "// protected $signature = 'app:old-sync';\n" +
+        "/* #[Signature('app:blocked-sync')] */\n" +
+        "final class SyncCatalog { protected $signature = 'app:sync-catalog {--force}'; }\n",
     );
 
     const project = await detectProject(root);
@@ -17191,16 +17200,81 @@ EndProject
     expect(ownedFiles).not.toContain("testdata/Example/Example.cs");
   });
 
-  it("skips Node.js project discovery I/O for pure Go projects", async () => {
-    const root = await fixtureRoot("clawpatch-map-node-coupling-");
+  it.each([
+    {
+      name: "Go",
+      manifest: ["go.mod", "module example.com/go-app\n"],
+      source: ["main.go", "package main\nfunc main() {}\n"],
+    },
+    {
+      name: "Python",
+      manifest: ["pyproject.toml", "[project]\nname = 'python-app'\nversion = '1.0.0'\n"],
+      source: ["src/app.py", "def main(): pass\n"],
+    },
+  ] as const)(
+    "skips Node project and Turbo I/O for pure $name projects",
+    async ({ manifest, source }) => {
+      const root = await fixtureRoot("clawpatch-map-node-coupling-");
+      await writeFixture(root, manifest[0], manifest[1]);
+      await writeFixture(root, source[0], source[1]);
+      const projectsSpy = vi.spyOn(projectsModule, "discoverNodeProjects");
+      const taskGraphSpy = vi.spyOn(turboModule, "turboTaskGraph");
+
+      const project = await detectProject(root);
+      await mapFeatures(root, project, []);
+
+      expect(projectsSpy).not.toHaveBeenCalled();
+      expect(taskGraphSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not block non-Node mappers on the fallback Node signal", async () => {
+    const root = await fixtureRoot("clawpatch-map-node-signal-");
     await writeFixture(root, "go.mod", "module example.com/go-app\n");
     await writeFixture(root, "main.go", "package main\nfunc main() {}\n");
+    const signal = Promise.withResolvers<boolean>();
+    vi.spyOn(projectsModule, "hasFallbackNodeProjectSignal").mockReturnValue(signal.promise);
+    const projectsSpy = vi.spyOn(projectsModule, "discoverNodeProjects");
+    const goDone = Promise.withResolvers<void>();
+    const project = await detectProject(root);
 
-    const spy = vi.spyOn(projectsModule, "discoverNodeProjects");
+    const mapping = mapFeatures(root, project, [], {
+      onProgress(event) {
+        if (event.event === "mapper-done" && event.mapper === "go") {
+          goDone.resolve();
+        }
+      },
+    });
+    await goDone.promise;
+
+    expect(projectsSpy).not.toHaveBeenCalled();
+    signal.resolve(false);
+    await expect(mapping).resolves.toBeDefined();
+  });
+
+  it("preserves package-less Node projects under conventional roots", async () => {
+    const root = await fixtureRoot("clawpatch-map-package-less-node-");
+    await writeFixture(root, "apps/web/src/index.ts", "export function start() {}\n");
 
     const project = await detectProject(root);
-    await mapFeatures(root, project, []);
+    const result = await mapFeatures(root, project, []);
 
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(project.detected.languages).not.toContain("typescript");
+    expect(result.features.map((feature) => feature.title)).toContain("Node source apps/web/src");
+  });
+
+  it("propagates Turbo failures and retries with a fresh mapping context", async () => {
+    const root = await fixtureRoot("clawpatch-map-turbo-failure-");
+    await writeFixture(root, "package.json", JSON.stringify({ name: "node-app" }));
+    await writeFixture(root, "src/index.ts", "export const value = true;\n");
+    await writeFixture(root, "turbo.json", "not-json\n");
+    const taskGraphSpy = vi.spyOn(turboModule, "turboTaskGraph");
+    const project = await detectProject(root);
+
+    await expect(mapFeatures(root, project, [])).rejects.toThrow();
+    await writeFixture(root, "turbo.json", JSON.stringify({ tasks: {} }));
+    await expect(mapFeatures(root, project, [])).resolves.toBeDefined();
+
+    expect(taskGraphSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -19,7 +19,8 @@ import { nodeRouteSeeds } from "./mappers/node-routes.js";
 import { nodeSeeds } from "./mappers/node.js";
 import { pythonSeeds } from "./mappers/python.js";
 import { reactSeeds } from "./mappers/react.js";
-import { discoverNodeProjects } from "./mappers/projects.js";
+import { createMapperContext } from "./mappers/context.js";
+import { discoverNodeProjects, hasFallbackNodeProjectSignal } from "./mappers/projects.js";
 import { rubySeeds } from "./mappers/ruby.js";
 import { rustSeeds } from "./mappers/rust.js";
 import { createNearbyTestFinder, PathFilters, pathMatchesFilters } from "./mappers/shared.js";
@@ -48,10 +49,10 @@ export type MapOptions = {
 };
 
 const featureMappers: FeatureMapper[] = [
-  { name: "node", map: nodeSeeds },
-  { name: "next", map: nextSeeds },
-  { name: "react", map: reactSeeds },
-  { name: "node-routes", map: nodeRouteSeeds },
+  { name: "node", usesNodeContext: true, map: nodeSeeds },
+  { name: "next", usesNodeContext: true, map: nextSeeds },
+  { name: "react", usesNodeContext: true, map: reactSeeds },
+  { name: "node-routes", usesNodeContext: true, map: nodeRouteSeeds },
   { name: "go", map: goSeeds },
   { name: "python", map: pythonSeeds },
   { name: "ruby", map: rubySeeds },
@@ -73,7 +74,7 @@ export async function mapFeatures(
   existing: FeatureRecord[],
   options: MapOptions = {},
 ): Promise<MapResult> {
-  const seeds = await collectSeeds(root, options);
+  const seeds = await collectSeeds(root, project, options);
   return mapFeatureSeeds(root, project, existing, seeds, options);
 }
 
@@ -285,28 +286,24 @@ function uniqueTests(tests: Array<{ path: string; command: string | null }>): Ar
   return output;
 }
 
-async function collectSeeds(root: string, options: MapOptions): Promise<FeatureSeed[]> {
-  let projectsPromise: ReturnType<typeof discoverNodeProjects> | null = null;
-  let taskGraphPromise: ReturnType<typeof turboTaskGraph> | null = null;
-  const context: MapperContext = {
-    projects() {
-      if (projectsPromise === null) {
-        projectsPromise = discoverNodeProjects(root);
-      }
-      return projectsPromise;
-    },
-    taskGraph() {
-      if (taskGraphPromise === null) {
-        taskGraphPromise = this.projects().then((projects) => turboTaskGraph(root, projects));
-      }
-      return taskGraphPromise;
-    },
-  };
+async function collectSeeds(
+  root: string,
+  project: ProjectRecord,
+  options: MapOptions,
+): Promise<FeatureSeed[]> {
+  const context: MapperContext = createMapperContext({
+    discoverNodeProjects: () => discoverNodeProjects(root),
+    buildNodeTaskGraph: (projects) => turboTaskGraph(root, projects),
+  });
+  const runNodeMappers = shouldRunNodeMappers(root, project);
   const groups = await Promise.all(
     featureMappers.map(async (mapper) => {
       const started = Date.now();
       options.onProgress?.({ event: "mapper-start", mapper: mapper.name });
-      const seeds = await mapper.map(root, context);
+      const seeds =
+        mapper.usesNodeContext === true && !(await runNodeMappers)
+          ? []
+          : await mapper.map(root, context);
       options.onProgress?.({
         event: "mapper-done",
         mapper: mapper.name,
@@ -317,6 +314,20 @@ async function collectSeeds(root: string, options: MapOptions): Promise<FeatureS
     }),
   );
   return dedupeFeatureSeeds(groups.flat());
+}
+
+async function shouldRunNodeMappers(root: string, project: ProjectRecord): Promise<boolean> {
+  if (
+    project.detected.languages.some((language) =>
+      ["javascript", "typescript"].includes(language),
+    ) ||
+    project.detected.packageManagers.some((manager) =>
+      ["node", "npm", "pnpm", "yarn", "bun"].includes(manager),
+    )
+  ) {
+    return true;
+  }
+  return hasFallbackNodeProjectSignal(root);
 }
 
 function statusForChangedFeature(status: FeatureRecord["status"]): FeatureRecord["status"] {

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -286,10 +286,21 @@ function uniqueTests(tests: Array<{ path: string; command: string | null }>): Ar
 }
 
 async function collectSeeds(root: string, options: MapOptions): Promise<FeatureSeed[]> {
-  const projects = await discoverNodeProjects(root);
+  let projectsPromise: ReturnType<typeof discoverNodeProjects> | null = null;
+  let taskGraphPromise: ReturnType<typeof turboTaskGraph> | null = null;
   const context: MapperContext = {
-    projects,
-    taskGraph: await turboTaskGraph(root, projects),
+    projects() {
+      if (projectsPromise === null) {
+        projectsPromise = discoverNodeProjects(root);
+      }
+      return projectsPromise;
+    },
+    taskGraph() {
+      if (taskGraphPromise === null) {
+        taskGraphPromise = this.projects().then((projects) => turboTaskGraph(root, projects));
+      }
+      return taskGraphPromise;
+    },
   };
   const groups = await Promise.all(
     featureMappers.map(async (mapper) => {

--- a/src/mappers/context.test.ts
+++ b/src/mappers/context.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMapperContext } from "./context.js";
+import { emptyTaskGraph } from "./task-graph.js";
+
+describe("createMapperContext", () => {
+  it("shares concurrent first access across all Node consumers", async () => {
+    const projects: [] = [];
+    const graph = emptyTaskGraph();
+    const discoverNodeProjects = vi.fn(async () => projects);
+    const buildNodeTaskGraph = vi.fn(async () => graph);
+    const context = createMapperContext({ discoverNodeProjects, buildNodeTaskGraph });
+
+    const results = await Promise.all([
+      context.nodeProjects(),
+      context.nodeProjects(),
+      context.nodeTaskGraph(),
+      context.nodeTaskGraph(),
+    ]);
+
+    expect(results).toEqual([projects, projects, graph, graph]);
+    expect(discoverNodeProjects).toHaveBeenCalledTimes(1);
+    expect(buildNodeTaskGraph).toHaveBeenCalledTimes(1);
+    expect(buildNodeTaskGraph).toHaveBeenCalledWith(projects);
+  });
+
+  it("shares project discovery failures without starting the task graph", async () => {
+    const failure = new Error("project discovery failed");
+    const discoverNodeProjects = vi.fn(async () => {
+      throw failure;
+    });
+    const buildNodeTaskGraph = vi.fn(async () => emptyTaskGraph());
+    const context = createMapperContext({ discoverNodeProjects, buildNodeTaskGraph });
+
+    const results = await Promise.allSettled([
+      context.nodeProjects(),
+      context.nodeProjects(),
+      context.nodeTaskGraph(),
+    ]);
+
+    expect(results).toEqual([
+      { status: "rejected", reason: failure },
+      { status: "rejected", reason: failure },
+      { status: "rejected", reason: failure },
+    ]);
+    expect(discoverNodeProjects).toHaveBeenCalledTimes(1);
+    expect(buildNodeTaskGraph).not.toHaveBeenCalled();
+  });
+
+  it("shares task graph failures", async () => {
+    const failure = new Error("task graph failed");
+    const discoverNodeProjects = vi.fn(async () => []);
+    const buildNodeTaskGraph = vi.fn(async () => {
+      throw failure;
+    });
+    const context = createMapperContext({ discoverNodeProjects, buildNodeTaskGraph });
+
+    const results = await Promise.allSettled([context.nodeTaskGraph(), context.nodeTaskGraph()]);
+
+    expect(results).toEqual([
+      { status: "rejected", reason: failure },
+      { status: "rejected", reason: failure },
+    ]);
+    expect(discoverNodeProjects).toHaveBeenCalledTimes(1);
+    expect(buildNodeTaskGraph).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates memoized data with each mapping context", async () => {
+    const discoverNodeProjects = vi.fn(async () => []);
+    const buildNodeTaskGraph = vi.fn(async () => emptyTaskGraph());
+
+    await createMapperContext({ discoverNodeProjects, buildNodeTaskGraph }).nodeTaskGraph();
+    await createMapperContext({ discoverNodeProjects, buildNodeTaskGraph }).nodeTaskGraph();
+
+    expect(discoverNodeProjects).toHaveBeenCalledTimes(2);
+    expect(buildNodeTaskGraph).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/mappers/context.ts
+++ b/src/mappers/context.ts
@@ -1,0 +1,22 @@
+import type { NodeProjectInfo } from "./projects.js";
+import type { WorkspaceTaskGraph } from "./task-graph.js";
+import type { MapperContext } from "./types.js";
+
+export type MapperContextLoaders = {
+  discoverNodeProjects(): Promise<NodeProjectInfo[]>;
+  buildNodeTaskGraph(projects: NodeProjectInfo[]): Promise<WorkspaceTaskGraph>;
+};
+
+export function createMapperContext(loaders: MapperContextLoaders): MapperContext {
+  const nodeProjects = memoizeAsync(loaders.discoverNodeProjects);
+  const nodeTaskGraph = memoizeAsync(async () => loaders.buildNodeTaskGraph(await nodeProjects()));
+  return { nodeProjects, nodeTaskGraph };
+}
+
+function memoizeAsync<T>(loader: () => Promise<T>): () => Promise<T> {
+  let promise: Promise<T> | null = null;
+  return () => {
+    promise ??= Promise.resolve().then(loader);
+    return promise;
+  };
+}

--- a/src/mappers/next.ts
+++ b/src/mappers/next.ts
@@ -13,14 +13,12 @@ import type { WorkspaceTaskGraph } from "./task-graph.js";
 import { FeatureSeed, MapperContext, suppressedTestCommandTag } from "./types.js";
 
 export async function nextSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
-  const projects = await context.projects();
-  const taskGraph = await context.taskGraph();
+  const projects = await context.nodeProjects();
+  const taskGraph = await context.nodeTaskGraph();
   const rootProject = projects.find((project) => project.root === ".");
   const rootHasNext = rootProject === undefined ? false : hasNextDependency(rootProject);
   const seedGroups = await Promise.all(
-    projects.map(async (project) =>
-      projectNextSeeds(root, project, taskGraph, rootHasNext),
-    ),
+    projects.map(async (project) => projectNextSeeds(root, project, taskGraph, rootHasNext)),
   );
   return seedGroups.flat();
 }

--- a/src/mappers/next.ts
+++ b/src/mappers/next.ts
@@ -13,11 +13,13 @@ import type { WorkspaceTaskGraph } from "./task-graph.js";
 import { FeatureSeed, MapperContext, suppressedTestCommandTag } from "./types.js";
 
 export async function nextSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
-  const rootProject = context.projects.find((project) => project.root === ".");
+  const projects = await context.projects();
+  const taskGraph = await context.taskGraph();
+  const rootProject = projects.find((project) => project.root === ".");
   const rootHasNext = rootProject === undefined ? false : hasNextDependency(rootProject);
   const seedGroups = await Promise.all(
-    context.projects.map(async (project) =>
-      projectNextSeeds(root, project, context.taskGraph, rootHasNext),
+    projects.map(async (project) =>
+      projectNextSeeds(root, project, taskGraph, rootHasNext),
     ),
   );
   return seedGroups.flat();

--- a/src/mappers/node-routes.ts
+++ b/src/mappers/node-routes.ts
@@ -16,6 +16,7 @@ import {
   suppressedTestCommandTag,
 } from "./types.js";
 import type { NodeProjectInfo } from "./projects.js";
+import { WorkspaceTaskGraph } from "./task-graph.js";
 
 type ServerFramework = "express" | "fastify" | "hono";
 
@@ -80,18 +81,20 @@ const routeChainPattern =
   /(^|[^A-Za-z0-9_$])([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*)\s*\.\s*route\s*\(/gu;
 
 export async function nodeRouteSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
+  const projects = await context.projects();
+  const taskGraph = await context.taskGraph();
   const seeds: FeatureSeed[] = [];
   const rootFrameworks = serverFrameworks(
-    context.projects.find((project) => project.root === ".") ?? null,
+    projects.find((project) => project.root === ".") ?? null,
   );
-  for (const project of context.projects) {
+  for (const project of projects) {
     const frameworks = serverFrameworks(project);
     const effectiveFrameworks =
       frameworks.length > 0 ? frameworks : project.packageJson === null ? rootFrameworks : [];
     if (effectiveFrameworks.length === 0) {
       continue;
     }
-    seeds.push(...(await projectRouteSeeds(root, project, context, effectiveFrameworks)));
+    seeds.push(...(await projectRouteSeeds(root, project, projects, taskGraph, effectiveFrameworks)));
   }
   return seeds;
 }
@@ -108,12 +111,13 @@ function serverFrameworks(project: NodeProjectInfo | null): ServerFramework[] {
 async function projectRouteSeeds(
   root: string,
   project: NodeProjectInfo,
-  context: MapperContext,
+  projects: NodeProjectInfo[],
+  taskGraph: WorkspaceTaskGraph,
   frameworks: ServerFramework[],
 ): Promise<FeatureSeed[]> {
-  const files = await packageSourceFiles(root, project, context.projects);
-  const tests = await packageTestFiles(root, project, context.projects);
-  const testCommand = projectTargetCommand(project, "test", context.taskGraph);
+  const files = await packageSourceFiles(root, project, projects);
+  const tests = await packageTestFiles(root, project, projects);
+  const testCommand = projectTargetCommand(project, "test", taskGraph);
   const projectContext = await projectContextFiles(root, project);
   const seeds: FeatureSeed[] = [];
 

--- a/src/mappers/node-routes.ts
+++ b/src/mappers/node-routes.ts
@@ -16,7 +16,7 @@ import {
   suppressedTestCommandTag,
 } from "./types.js";
 import type { NodeProjectInfo } from "./projects.js";
-import { WorkspaceTaskGraph } from "./task-graph.js";
+import type { WorkspaceTaskGraph } from "./task-graph.js";
 
 type ServerFramework = "express" | "fastify" | "hono";
 
@@ -81,12 +81,10 @@ const routeChainPattern =
   /(^|[^A-Za-z0-9_$])([A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)*)\s*\.\s*route\s*\(/gu;
 
 export async function nodeRouteSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
-  const projects = await context.projects();
-  const taskGraph = await context.taskGraph();
+  const projects = await context.nodeProjects();
+  const taskGraph = await context.nodeTaskGraph();
   const seeds: FeatureSeed[] = [];
-  const rootFrameworks = serverFrameworks(
-    projects.find((project) => project.root === ".") ?? null,
-  );
+  const rootFrameworks = serverFrameworks(projects.find((project) => project.root === ".") ?? null);
   for (const project of projects) {
     const frameworks = serverFrameworks(project);
     const effectiveFrameworks =
@@ -94,7 +92,9 @@ export async function nodeRouteSeeds(root: string, context: MapperContext): Prom
     if (effectiveFrameworks.length === 0) {
       continue;
     }
-    seeds.push(...(await projectRouteSeeds(root, project, projects, taskGraph, effectiveFrameworks)));
+    seeds.push(
+      ...(await projectRouteSeeds(root, project, projects, taskGraph, effectiveFrameworks)),
+    );
   }
   return seeds;
 }

--- a/src/mappers/node.ts
+++ b/src/mappers/node.ts
@@ -67,8 +67,8 @@ const semanticSourceSegments = [
 export async function nodeSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
 
-  const projects = await context.projects();
-  const taskGraph = await context.taskGraph();
+  const projects = await context.nodeProjects();
+  const taskGraph = await context.nodeTaskGraph();
   for (const info of projects) {
     if (hasNodePackage(info)) {
       seeds.push(...(await packageSeeds(root, info, taskGraph)));

--- a/src/mappers/node.ts
+++ b/src/mappers/node.ts
@@ -67,11 +67,13 @@ const semanticSourceSegments = [
 export async function nodeSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
   const seeds: FeatureSeed[] = [];
 
-  for (const info of context.projects) {
+  const projects = await context.projects();
+  const taskGraph = await context.taskGraph();
+  for (const info of projects) {
     if (hasNodePackage(info)) {
-      seeds.push(...(await packageSeeds(root, info, context.taskGraph)));
+      seeds.push(...(await packageSeeds(root, info, taskGraph)));
     }
-    seeds.push(...(await sourceGroupSeeds(root, info, context.taskGraph)));
+    seeds.push(...(await sourceGroupSeeds(root, info, taskGraph)));
   }
 
   return seeds;

--- a/src/mappers/projects.ts
+++ b/src/mappers/projects.ts
@@ -126,6 +126,52 @@ export async function discoverNodeProjects(root: string): Promise<NodeProjectInf
   return [...byRoot.values()].toSorted((left, right) => left.root.localeCompare(right.root));
 }
 
+export async function hasFallbackNodeProjectSignal(root: string): Promise<boolean> {
+  if (await pathExists(join(root, "nx.json"))) {
+    return true;
+  }
+  for (const prefix of ["apps", "packages", "frontend", "client", "web"]) {
+    if (await hasNestedPackageJson(root, prefix, 4)) {
+      return true;
+    }
+  }
+  const candidates = ["frontend", "client", "web", "ui"];
+  for (const parent of ["apps", "packages", "extensions", "plugins"]) {
+    for (const entry of await safeDirectoryEntries(root, parent)) {
+      candidates.push(`${parent}/${entry}`);
+    }
+  }
+  for (const candidate of candidates) {
+    if (
+      (await pathExists(join(root, candidate, "package.json"))) ||
+      (await pathExists(join(root, candidate, "project.json"))) ||
+      (await hasGenericProjectSignal(root, null, candidate))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function hasNestedPackageJson(
+  root: string,
+  prefix: string,
+  remainingDepth: number,
+): Promise<boolean> {
+  if (remainingDepth < 0 || shouldSkipProjectDir(prefix)) {
+    return false;
+  }
+  if (await pathExists(join(root, prefix, "package.json"))) {
+    return true;
+  }
+  for (const entry of await safeDirectoryEntries(root, prefix)) {
+    if (await hasNestedPackageJson(root, `${prefix}/${entry}`, remainingDepth - 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function discoverDeclaredPackageRoots(
   root: string,
   rootPackage: NodePackageJson | null,

--- a/src/mappers/projects.ts
+++ b/src/mappers/projects.ts
@@ -127,7 +127,7 @@ export async function discoverNodeProjects(root: string): Promise<NodeProjectInf
 }
 
 export async function hasFallbackNodeProjectSignal(root: string): Promise<boolean> {
-  if (await pathExists(join(root, "nx.json"))) {
+  if ((await pathExists(join(root, "nx.json"))) || (await hasNestedNxProject(root, "", 5))) {
     return true;
   }
   for (const prefix of ["apps", "packages", "frontend", "client", "web"]) {
@@ -147,6 +147,26 @@ export async function hasFallbackNodeProjectSignal(root: string): Promise<boolea
       (await pathExists(join(root, candidate, "project.json"))) ||
       (await hasGenericProjectSignal(root, null, candidate))
     ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function hasNestedNxProject(
+  root: string,
+  prefix: string,
+  remainingDepth: number,
+): Promise<boolean> {
+  if (remainingDepth < 0 || shouldSkipProjectDir(prefix)) {
+    return false;
+  }
+  if (prefix.length > 0 && (await pathExists(join(root, prefix, "project.json")))) {
+    return true;
+  }
+  for (const entry of await safeDirectoryEntries(root, prefix)) {
+    const child = prefix.length === 0 ? entry : `${prefix}/${entry}`;
+    if (await hasNestedNxProject(root, child, remainingDepth - 1)) {
       return true;
     }
   }

--- a/src/mappers/react.ts
+++ b/src/mappers/react.ts
@@ -82,7 +82,7 @@ const contextImportExtensions = new Set([
 ]);
 
 export async function reactSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
-  const packages = await discoverReactPackages(root, context.projects, context.taskGraph);
+  const packages = await discoverReactPackages(root, await context.projects(), await context.taskGraph());
   const importResolver = createReactImportResolver(root);
   const seeds: FeatureSeed[] = [];
   for (const info of packages) {

--- a/src/mappers/react.ts
+++ b/src/mappers/react.ts
@@ -82,7 +82,11 @@ const contextImportExtensions = new Set([
 ]);
 
 export async function reactSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
-  const packages = await discoverReactPackages(root, await context.projects(), await context.taskGraph());
+  const packages = await discoverReactPackages(
+    root,
+    await context.nodeProjects(),
+    await context.nodeTaskGraph(),
+  );
   const importResolver = createReactImportResolver(root);
   const seeds: FeatureSeed[] = [];
   for (const info of packages) {

--- a/src/mappers/types.ts
+++ b/src/mappers/types.ts
@@ -41,6 +41,6 @@ export type FeatureMapper = {
 };
 
 export type MapperContext = {
-  projects: NodeProjectInfo[];
-  taskGraph: WorkspaceTaskGraph;
+  projects(): Promise<NodeProjectInfo[]>;
+  taskGraph(): Promise<WorkspaceTaskGraph>;
 };

--- a/src/mappers/types.ts
+++ b/src/mappers/types.ts
@@ -37,10 +37,11 @@ export const suppressedTestCommandTag = "validation:test-suppressed";
 
 export type FeatureMapper = {
   name: string;
+  usesNodeContext?: boolean;
   map(root: string, context: MapperContext): Promise<FeatureSeed[]>;
 };
 
 export type MapperContext = {
-  projects(): Promise<NodeProjectInfo[]>;
-  taskGraph(): Promise<WorkspaceTaskGraph>;
+  nodeProjects(): Promise<NodeProjectInfo[]>;
+  nodeTaskGraph(): Promise<WorkspaceTaskGraph>;
 };


### PR DESCRIPTION
## Summary

Fix eager Node project and Turbo task-graph work for repositories that do not use Node, while preserving the contributor's lazy shared-context design.

The repaired implementation:

- Gates the four Node-family mappers behind existing detection plus bounded fallback signals.
- Starts non-Node mappers without waiting for the fallback Node signal.
- Memoizes Node project discovery and Turbo graph construction once per mapping run, including concurrent first access and failure propagation.
- Preserves package-less conventional projects, nested React packages, and package-less Nx projects outside conventional roots.
- Retries discovery on a fresh mapping run after a prior run fails.

## Validation

Exact-head proof, instrumentation, real-repository CLI runs, timings, dependency/security audit, and model gate: https://github.com/openclaw/clawpatch/pull/156#issuecomment-4951382920

Hosted exact-head gates:

- CI: https://github.com/openclaw/clawpatch/actions/runs/29194767256
- Verified-secret scan: https://github.com/openclaw/clawpatch/actions/runs/29194767255
- CodeQL: https://github.com/openclaw/clawpatch/actions/runs/29194767264

## Release-note context and credit

Release-note context is preserved here for the release process and credits `@Tanmay-008`. The contributor's original commit remains the first commit in this PR, followed by maintainer repair commits with co-author credit.

Fixes #155
