### PR TITLE
fix(review): include changed features regardless of status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.2 - Unreleased
 
+- Fixed diff-scoped review and CI runs to include changed features regardless of their previous review status, preventing warm-state gates from silently skipping changed code, thanks @youhaowei.
 - Added Rust seed context for Cargo manifests, paired crate entrypoints, and directly declared modules across crate roots and binary layouts, thanks @Tanmay-008.
 
 ## 0.7.1 - 2026-07-20

--- a/src/review.ts
+++ b/src/review.ts
@@ -124,7 +124,8 @@ export async function reviewCommand(
             registryPostValidator,
             allowNonPendingFeatureReview:
               stringFlag(flags, "feature") !== undefined ||
-              stringFlag(flags, "featureList") !== undefined,
+              stringFlag(flags, "featureList") !== undefined ||
+              hasFileFilter(flags),
           });
           findingIds.push(...reviewed.findingIds);
           for (const dropped of reviewed.droppedFindings) {
@@ -545,7 +546,9 @@ async function selectReviewFeatures(
     }
     return stringFlag(flags, "limit") === undefined ? selected : limitFeatures(selected, flags);
   }
-  const candidates = selectReviewCandidates(features, flags);
+  const candidates = selectReviewCandidates(features, flags, {
+    ignoreStatus: hasFileFilter(flags),
+  });
   const sinceFiltered = await filterFeaturesByFilesSince(loaded.root, candidates, flags);
   return limitFeatures(sinceFiltered, flags);
 }

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -2,13 +2,19 @@ import { FeatureRecord, FindingRecord } from "./types.js";
 
 type Flags = Record<string, string | boolean>;
 
-export function selectReviewCandidates(features: FeatureRecord[], flags: Flags): FeatureRecord[] {
+export function selectReviewCandidates(
+  features: FeatureRecord[],
+  flags: Flags,
+  options: { ignoreStatus?: boolean } = {},
+): FeatureRecord[] {
   const featureId = stringFlag(flags, "feature");
   const projectFilter = stringFlag(flags, "project");
   const projectFeatures = filterFeaturesByProject(features, projectFilter);
   const selected =
     featureId === undefined
-      ? projectFeatures.filter((feature) => ["pending", "error"].includes(feature.status))
+      ? options.ignoreStatus === true
+        ? projectFeatures
+        : projectFeatures.filter((feature) => ["pending", "error"].includes(feature.status))
       : projectFeatures.filter((feature) => feature.featureId === featureId);
   return projectFilter === undefined ? selected : selected.toSorted(featureReviewRank);
 }

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -854,6 +854,64 @@ describe("workflow", () => {
     });
   });
 
+  it("selects changed features regardless of their previous review status", async () => {
+    const root = await sinceFixture("clawpatch-since-status-");
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    await writeFixture(root, "src/two.ts", "export const two = 'changed';\n");
+    await commitAll(root, "change two");
+    const paths = statePaths(join(root, ".clawpatch"));
+    const features = await readFeatures(paths);
+    const expected = expectedFeatureIds(features, new Set(["src/two.ts"]), true);
+    const statuses: FeatureRecord["status"][] = ["reviewed", "needs-fix", "fixed"];
+    let statusIndex = 0;
+    for (const feature of features) {
+      if (!expected.includes(feature.featureId)) {
+        continue;
+      }
+      await writeFeature(paths, {
+        ...feature,
+        status: statuses[statusIndex % statuses.length]!,
+      });
+      statusIndex += 1;
+    }
+
+    const reviewed = await reviewCommand(context, { since: "base", dryRun: true });
+
+    expect(expected.length).toBeGreaterThan(0);
+    expect(reviewed).toMatchObject({ dryRun: true, featureIds: expected });
+  });
+
+  it("reviews changed non-pending features through the warm-state CI workflow", async () => {
+    const root = await sinceFixture("clawpatch-ci-since-status-");
+    const context = await makeContext(testOptions(root));
+
+    await initCommand(context, {});
+    await mapCommand(context);
+    const paths = statePaths(join(root, ".clawpatch"));
+    const features = await readFeatures(paths);
+    const touched = expectedFeatureIds(features, new Set(["src/two.ts"]), true);
+    for (const feature of features) {
+      if (!touched.includes(feature.featureId)) {
+        continue;
+      }
+      await writeFeature(paths, { ...feature, status: "needs-fix" });
+    }
+    await writeFixture(root, "src/two.ts", "export const two = 'changed';\n");
+    await commitAll(root, "change two");
+
+    const result = await ciCommand(context, {
+      provider: "mock",
+      since: "base",
+      jobs: "1",
+    });
+
+    expect(touched.length).toBeGreaterThan(0);
+    expect(result).toMatchObject({ reviewed: touched.length });
+  });
+
   it("selects review features whose context files overlap the diff range", async () => {
     const root = await sinceFixture("clawpatch-since-context-");
     const context = await makeContext(testOptions(root));


### PR DESCRIPTION
## Summary

- make `review --since` and `review --include-dirty` select touched features regardless of prior review status
- allow those diff-scoped selections through the claim boundary
- cover direct dry-run selection and the warm-state `ci --since` workflow

Closes https://github.com/openclaw/clawpatch/issues/167

## Root cause

Diff-scoped review first applied the normal pending/error backlog filter, so touched features in `reviewed`, `needs-fix`, `fixed`, or other states never reached changed-file matching. Even after selecting them, the feature-claim path still rejected non-pending records. Together these could let a warm-state CI gate exit successfully without reviewing changed code.

## Proof

- `pnpm test` — 896 passed, 1 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- built CLI live run: a feature was moved to `reviewed`, then `node dist/cli.js ... review --include-dirty --dry-run --json` selected that exact changed feature
- black-box behavior contract: scoped selection included the reviewed feature; unscoped selection excluded it; `review --since HEAD --dry-run` returned `no features touched by diff`
- autoreview: clean, no accepted/actionable findings
- public model identifier gate: PASS; the candidate does not add model-bearing code or artifacts
