### PR TITLE
chore(release): v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 0.7.2 - Unreleased
+## 0.7.2 - 2026-08-01
 
 - Reclaimed dead same-host review locks automatically and added `clean-locks --stale-only` for safe scripted cleanup while preserving live and remote locks, thanks @goutamadwant.
 - Fixed diff-scoped review and CI runs to include changed features regardless of their previous review status, preventing warm-state gates from silently skipping changed code, thanks @youhaowei.
-- Updated pnpm, Node typings, formatter and linter tooling, and security workflow actions.
+- Updated pnpm, Node typings, formatter and linter tooling, and security and repository automation actions.
 - Added Rust seed context for Cargo manifests, paired crate entrypoints, and directly declared modules across crate roots and binary layouts, thanks @Tanmay-008.
 
 ## 0.7.1 - 2026-07-20

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawpatch",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Automated code review that lands fixes.",
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
## Summary

- set the package version to 0.7.2
- date the 0.7.2 changelog while retaining all four credited release bullets
- reconcile the maintenance note with the final security and repository automation updates

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm exec vitest run --maxWorkers=1` — 900 passed, 1 skipped
- `pnpm build`
- `pnpm pack:smoke` — installed the packed artifact offline and mapped 13 features, including 3 CUDA features
- `npm pack --dry-run --json --ignore-scripts` — 244 expected entries, 368,715-byte tarball, no private or local state

The target version was confirmed absent from npm, Git tags, and GitHub Releases before this preparation commit.
