### PR TITLE
chore: open 0.7.3 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.7.3 - Unreleased
+
 ## 0.7.2 - 2026-08-01
 
 - Reclaimed dead same-host review locks automatically and added `clean-locks --stale-only` for safe scripted cleanup while preserving live and remote locks, thanks @goutamadwant.


### PR DESCRIPTION
## Summary

- open the 0.7.3 development section after the verified 0.7.2 release

## Verification

- `pnpm format:check`
- `git diff --check`
- autoreview clean with no accepted or actionable findings
