### PR TITLE
feat(provider): add Devin CLI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Supported provider names today:
 - `acpx`: any ACP-compatible coding agent (Codex / Claude / Pi / Gemini / ...) via openclaw/acpx
 - `claude`: local Claude Code CLI in print mode
 - `cursor`: local Cursor Agent CLI (experimental; `doctor` is enabled by default)
+- `devin`: local Devin CLI in print mode (`--permission-mode` enforces read-only for review/revalidate)
 - `grok`: local Grok Build CLI
 - `opencode`: local OpenCode CLI
 - `pi`: local Pi coding agent in print mode

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -19,6 +19,7 @@ Provider names today:
 - `codex`: shells out to `codex exec` (default)
 - `acpx`: routes through any ACP-compatible coding agent via `acpx`
 - `claude`: shells out to Claude Code in print mode (`claude -p`)
+- `devin`: shells out to the local Devin CLI in print mode (`devin --print --prompt-file`)
 - `grok`: shells out to the xAI Grok Build CLI in headless mode (`grok --prompt-file`)
 - `opencode`: shells out to `opencode run --format json`
 - `pi`: shells out to `pi -p` (non-interactive print mode)
@@ -137,6 +138,44 @@ first colon:
 Migration note: `--provider codex --model gpt-5-codex` is not equivalent to
 `--provider acpx --model gpt-5-codex`; the latter selects an ACP agent named
 `gpt-5-codex`. Use `--provider acpx --model codex:gpt-5-codex`.
+
+## Devin
+
+The `devin` provider shells out to the local [Devin CLI](https://docs.devin.ai/cli)
+in non-interactive print mode:
+
+- availability check: `devin --version`
+- review / revalidate: `--permission-mode auto` — the Devin runtime auto-approves
+  read-only tools only and never grants write/execute in print mode, so this is
+  enforced read-only behavior (not a prompt-only directive)
+- fix: `--permission-mode accept-edits` — the Devin runtime auto-approves workspace
+  edits; run `fix` only in an isolated trusted checkout
+- prompt delivery: writes the full Clawpatch prompt to a temporary file and calls
+  `devin --print --prompt-file <path> --permission-mode <mode>`
+- reasoning effort: the Devin CLI has no `--reasoning-effort` flag (verified against
+  v3000.2.17), so the requested effort level is injected into the prompt text
+- output: parsed from stdout with the shared JSON extractor
+- timeout: 300 seconds by default, override with `CLAWPATCH_DEVIN_TIMEOUT_MS` or
+  `CLAWPATCH_PROVIDER_TIMEOUT_MS`
+- model selection: `--model <model>` is passed through to Devin when configured;
+  when unset, Devin uses its own configured default (`~/.config/devin/config.json`
+  on macOS/Linux, `%APPDATA%\devin\config.json` on Windows)
+- environment: the Devin subprocess inherits the ambient environment so it can
+  locate its config-file credentials and proxy settings; clawpatch does not inject
+  or strip environment variables for this provider
+
+Provider selection:
+
+```bash
+clawpatch review --provider devin
+CLAWPATCH_PROVIDER=devin clawpatch review
+clawpatch fix --finding <id> --provider devin
+clawpatch doctor --provider devin
+```
+
+Authentication: run `devin auth login` once before using this provider. The
+provider `check` runs `devin --version` only; a missing or expired auth token
+surfaces as a `provider-failure` error on the first review/map/fix call.
 
 ## Claude
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -905,6 +905,7 @@ Implemented providers:
 - `acpx`: ACP-compatible agents through `acpx`.
 - `claude`: Claude Code CLI in print mode.
 - `cursor`: experimental Cursor Agent CLI integration.
+- `devin`: Devin CLI in print mode with `--permission-mode` read-only enforcement.
 - `grok`: Grok Build CLI.
 - `opencode`: OpenCode CLI.
 - `pi`: pi coding agent.

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ClawpatchError } from "./errors.js";
 import { __testing, extractJson, providerByName } from "./provider.js";
@@ -31,6 +32,9 @@ const {
   cursorFailureMessage,
   cursorPrompt,
   cursorTimeoutMs,
+  devinFailureMessage,
+  devinPrompt,
+  devinTimeoutMs,
   extractAcpxJson,
   extractCursorJson,
   extractClaudeStructuredOutput,
@@ -796,10 +800,10 @@ describe("Claude provider helpers", () => {
 
     expect(claudeEnv(false, "/tmp/claude", "isolated")).toEqual({
       PATH: "/bin",
-      HOME: "/tmp/claude/home",
-      XDG_CONFIG_HOME: "/tmp/claude/xdg-config",
-      XDG_CACHE_HOME: "/tmp/claude/xdg-cache",
-      XDG_DATA_HOME: "/tmp/claude/xdg-data",
+      HOME: join("/tmp/claude", "home"),
+      XDG_CONFIG_HOME: join("/tmp/claude", "xdg-config"),
+      XDG_CACHE_HOME: join("/tmp/claude", "xdg-cache"),
+      XDG_DATA_HOME: join("/tmp/claude", "xdg-data"),
       TMPDIR: "/tmp/claude",
       TEMP: "/tmp/claude",
       TMP: "/tmp/claude",
@@ -807,10 +811,10 @@ describe("Claude provider helpers", () => {
     });
     expect(claudeEnv(true, "/tmp/claude", "isolated")).toEqual({
       PATH: "/bin",
-      HOME: "/tmp/claude/home",
-      XDG_CONFIG_HOME: "/tmp/claude/xdg-config",
-      XDG_CACHE_HOME: "/tmp/claude/xdg-cache",
-      XDG_DATA_HOME: "/tmp/claude/xdg-data",
+      HOME: join("/tmp/claude", "home"),
+      XDG_CONFIG_HOME: join("/tmp/claude", "xdg-config"),
+      XDG_CACHE_HOME: join("/tmp/claude", "xdg-cache"),
+      XDG_DATA_HOME: join("/tmp/claude", "xdg-data"),
       TMPDIR: "/tmp/claude",
       TEMP: "/tmp/claude",
       TMP: "/tmp/claude",
@@ -836,9 +840,9 @@ describe("Claude provider helpers", () => {
       HOME: "/host-home",
       USERPROFILE: "C:\\Users\\operator",
       CLAUDE_CONFIG_DIR: "/host-claude-config",
-      XDG_CONFIG_HOME: "/tmp/claude/xdg-config",
-      XDG_CACHE_HOME: "/tmp/claude/xdg-cache",
-      XDG_DATA_HOME: "/tmp/claude/xdg-data",
+      XDG_CONFIG_HOME: join("/tmp/claude", "xdg-config"),
+      XDG_CACHE_HOME: join("/tmp/claude", "xdg-cache"),
+      XDG_DATA_HOME: join("/tmp/claude", "xdg-data"),
       TMPDIR: "/tmp/claude",
       TEMP: "/tmp/claude",
       TMP: "/tmp/claude",
@@ -886,10 +890,10 @@ describe("Claude provider helpers", () => {
 
     expect(claudeEnv(false, "/tmp/claude", "isolated")).toEqual({
       PATH: "/bin",
-      HOME: "/tmp/claude/home",
-      XDG_CONFIG_HOME: "/tmp/claude/xdg-config",
-      XDG_CACHE_HOME: "/tmp/claude/xdg-cache",
-      XDG_DATA_HOME: "/tmp/claude/xdg-data",
+      HOME: join("/tmp/claude", "home"),
+      XDG_CONFIG_HOME: join("/tmp/claude", "xdg-config"),
+      XDG_CACHE_HOME: join("/tmp/claude", "xdg-cache"),
+      XDG_DATA_HOME: join("/tmp/claude", "xdg-data"),
       TMPDIR: "/tmp/claude",
       TEMP: "/tmp/claude",
       TMP: "/tmp/claude",
@@ -1742,6 +1746,7 @@ describe("providerByName", () => {
   it("returns provider instances for optional CLI-backed providers", () => {
     expect(providerByName("acpx").name).toBe("acpx");
     expect(providerByName("claude").name).toBe("claude");
+    expect(providerByName("devin").name).toBe("devin");
     expect(providerByName("grok").name).toBe("grok");
     expect(providerByName("opencode").name).toBe("opencode");
     expect(providerByName("pi").name).toBe("pi");
@@ -1830,6 +1835,48 @@ describe("evidenceRefSchema tolerance", () => {
     });
     expect(parsed.startLine).toBeNull();
     expect(parsed.endLine).toBeNull();
+  });
+});
+
+describe("Devin provider helpers", () => {
+  it("injects reasoning effort into the prompt and appends the JSON schema", () => {
+    const schema = { type: "object", properties: { ok: { type: "boolean" } } };
+    const withoutEffort = devinPrompt("review this", schema, null);
+    expect(withoutEffort).toContain("review this");
+    expect(withoutEffort).toContain("Return ONLY a JSON object");
+    expect(withoutEffort).toContain(JSON.stringify(schema));
+    expect(withoutEffort).not.toContain("REASONING EFFORT");
+
+    const withEffort = devinPrompt("review this", schema, "xhigh");
+    expect(withEffort).toContain("REASONING EFFORT: XHIGH");
+    expect(withEffort).toContain("Apply xhigh reasoning depth");
+    expect(withEffort).toContain("review this");
+    expect(withEffort).toContain(JSON.stringify(schema));
+
+    // "none" effort is treated like no effort (no preamble)
+    const noneEffort = devinPrompt("review this", schema, "none");
+    expect(noneEffort).not.toContain("REASONING EFFORT");
+  });
+
+  it("uses Devin-specific timeout before generic provider timeout", () => {
+    delete process.env["CLAWPATCH_DEVIN_TIMEOUT_MS"];
+    delete process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"];
+    expect(devinTimeoutMs()).toBe(300_000);
+
+    process.env["CLAWPATCH_PROVIDER_TIMEOUT_MS"] = "2000";
+    expect(devinTimeoutMs()).toBe(2000);
+
+    process.env["CLAWPATCH_DEVIN_TIMEOUT_MS"] = "3000";
+    expect(devinTimeoutMs()).toBe(3000);
+
+    process.env["CLAWPATCH_DEVIN_TIMEOUT_MS"] = "bad";
+    expect(devinTimeoutMs()).toBe(300_000);
+  });
+
+  it("uses bounded failure previews from stderr or stdout", () => {
+    expect(devinFailureMessage("", "auth required")).toContain("auth required");
+    expect(devinFailureMessage("stdout failure", "")).toContain("stdout failure");
+    expect(devinFailureMessage("", "")).toBe("devin provider failed");
   });
 });
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -6,6 +6,7 @@ import { acpxProvider, acpxTesting } from "./providers/acpx.js";
 import { claudeProvider, claudeTesting } from "./providers/claude.js";
 import { codexProvider, codexTesting } from "./providers/codex.js";
 import { cursorProvider, cursorTesting } from "./providers/cursor.js";
+import { devinProvider, devinTesting } from "./providers/devin.js";
 import { grokProvider } from "./providers/grok.js";
 import { mockFailProvider, mockProvider } from "./providers/mock.js";
 import { opencodeProvider, opencodeTesting } from "./providers/opencode.js";
@@ -18,6 +19,7 @@ const providers: Readonly<Record<string, Provider>> = {
   claude: claudeProvider,
   codex: codexProvider,
   cursor: cursorProvider,
+  devin: devinProvider,
   grok: grokProvider,
   mock: mockProvider,
   "mock-fail": mockFailProvider,
@@ -39,6 +41,7 @@ export const __testing = {
   ...claudeTesting,
   ...codexTesting,
   ...cursorTesting,
+  ...devinTesting,
   ...opencodeTesting,
   ...piTesting,
   providerExitCode,

--- a/src/providers/devin.ts
+++ b/src/providers/devin.ts
@@ -1,0 +1,158 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runCommandArgs } from "../exec.js";
+import { ClawpatchError } from "../errors.js";
+import { providerExitCode } from "../provider-errors.js";
+import { extractJson, safeProviderPreview } from "../provider-json.js";
+import { parseOrThrow, parseReviewOutput } from "../provider-output.js";
+import { providerCheckTimeoutMs, providerTimeoutMs } from "../provider-runtime.js";
+import {
+  agentMapJsonSchema,
+  fixPlanJsonSchema,
+  reviewJsonSchema,
+  revalidateJsonSchema,
+} from "../provider-schema.js";
+import type { PartitionedReviewOutput, Provider, ProviderOptions } from "../provider-types.js";
+import {
+  AgentMapOutput,
+  FixPlanOutput,
+  RevalidateOutput,
+  agentMapOutputSchema,
+  fixPlanOutputSchema,
+  revalidateOutputSchema,
+} from "../types.js";
+
+const DEVIN_DEFAULT_TIMEOUT_MS = 300_000;
+
+// Devin CLI permission modes (verified against `devin --help`, v3000.2.17):
+//   auto         — auto-approves read-only tools only; prompts for writes (print mode never
+//                  grants, so this is effective read-only enforcement for review/revalidate)
+//   accept-edits — auto-approves workspace edits in addition to read-only tools (used for fix)
+const DEVIN_READ_PERMISSION_MODE = "auto";
+const DEVIN_WRITE_PERMISSION_MODE = "accept-edits";
+
+export const devinProvider: Provider = {
+  name: "devin",
+  async check(root: string): Promise<string> {
+    const result = await runCommandArgs("devin", ["--version"], root, undefined, {
+      timeoutMs: providerCheckTimeoutMs(),
+    });
+    if (result.exitCode !== 0) {
+      throw new ClawpatchError(
+        "devin CLI not available. Install from https://docs.devin.ai/cli",
+        4,
+        "provider-auth",
+      );
+    }
+    return result.stdout.trim() || result.stderr.trim();
+  },
+  async map(root: string, prompt: string, options: ProviderOptions): Promise<AgentMapOutput> {
+    const output = await runDevinJson(root, prompt, options, agentMapJsonSchema, true);
+    return parseOrThrow(agentMapOutputSchema, output, "devin agent-map");
+  },
+  async review(
+    root: string,
+    prompt: string,
+    options: ProviderOptions,
+  ): Promise<PartitionedReviewOutput> {
+    const output = await runDevinJson(root, prompt, options, reviewJsonSchema, true);
+    return parseReviewOutput(output);
+  },
+  async fix(root: string, prompt: string, options: ProviderOptions): Promise<FixPlanOutput> {
+    const output = await runDevinJson(root, prompt, options, fixPlanJsonSchema, false);
+    return parseOrThrow(fixPlanOutputSchema, output, "devin fix-plan");
+  },
+  async revalidate(
+    root: string,
+    prompt: string,
+    options: ProviderOptions,
+  ): Promise<RevalidateOutput> {
+    const output = await runDevinJson(root, prompt, options, revalidateJsonSchema, true);
+    return parseOrThrow(revalidateOutputSchema, output, "devin revalidate");
+  },
+};
+
+async function runDevinJson(
+  root: string,
+  prompt: string,
+  options: ProviderOptions,
+  schema: object,
+  readOnly: boolean,
+): Promise<unknown> {
+  const dir = await mkdtemp(join(tmpdir(), "clawpatch-devin-"));
+  const promptPath = join(dir, "prompt.txt");
+  try {
+    await writeFile(promptPath, devinPrompt(prompt, schema, options.reasoningEffort), "utf8");
+    const args = [
+      "--print",
+      "--prompt-file",
+      promptPath,
+      "--permission-mode",
+      readOnly ? DEVIN_READ_PERMISSION_MODE : DEVIN_WRITE_PERMISSION_MODE,
+    ];
+    if (options.model !== null) {
+      args.push("--model", options.model);
+    }
+    const result = await runCommandArgs("devin", args, root, undefined, {
+      trimOutput: false,
+      timeoutMs: devinTimeoutMs(),
+    });
+    if (result.exitCode !== 0) {
+      throw new ClawpatchError(
+        devinFailureMessage(result.stdout, result.stderr),
+        providerExitCode(result.stdout, result.stderr),
+        "provider-failure",
+      );
+    }
+    const json = extractJson(result.stdout);
+    if (json === null) {
+      throw new ClawpatchError(
+        `devin provider produced unparseable JSON output (preview: ${safeProviderPreview(result.stdout)})`,
+        8,
+        "malformed-output",
+      );
+    }
+    return json;
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function devinPrompt(prompt: string, schema: object, reasoningEffort: string | null): string {
+  const effortPreamble =
+    reasoningEffort !== null && reasoningEffort !== "none"
+      ? `REASONING EFFORT: ${reasoningEffort.toUpperCase()}\n` +
+        `Apply ${reasoningEffort} reasoning depth to this review. ` +
+        `At "high" or "xhigh", exhaustively analyze every file, trace data flows, ` +
+        `and consider edge cases that lower-effort passes would miss.\n\n`
+      : "";
+  return (
+    `${effortPreamble}${prompt}\n\n` +
+    "Return ONLY a JSON object matching this schema. No prose preamble, no markdown fences, " +
+    "no thinking-out-loud text before the JSON. " +
+    `Schema:\n${JSON.stringify(schema)}\n`
+  );
+}
+
+function devinFailureMessage(stdout: string, stderr: string): string {
+  const stderrPreview = safeProviderPreview(stderr);
+  if (stderrPreview.length > 0) {
+    return `devin provider failed: ${stderrPreview}`;
+  }
+  const stdoutPreview = safeProviderPreview(stdout);
+  if (stdoutPreview.length > 0) {
+    return `devin provider failed: ${stdoutPreview}`;
+  }
+  return "devin provider failed";
+}
+
+function devinTimeoutMs(): number {
+  return providerTimeoutMs("CLAWPATCH_DEVIN_TIMEOUT_MS", DEVIN_DEFAULT_TIMEOUT_MS);
+}
+
+export const devinTesting = {
+  devinFailureMessage,
+  devinPrompt,
+  devinTimeoutMs,
+};


### PR DESCRIPTION
## Summary

Adds a `devin` provider backed by the local [Devin CLI](https://docs.devin.ai/cli) in non-interactive print mode. Provider selection via `--provider devin` / `CLAWPATCH_PROVIDER=devin`, with Devin-backed `map`, `review`, `fix`, `revalidate`, and `doctor --provider devin`.

Follows the same conventions as the `claude` (#93) and `grok` providers: a `src/providers/devin.ts` module exporting `devinProvider` + `devinTesting`, registered in `src/provider.ts`, with helper tests in `src/provider.test.ts` and documentation in `docs/providers.md`, `README.md`, and `docs/spec.md`.

## Motivation

Devin CLI (Cognition's agent CLI) is a coding-harness CLI that fits clawpatch's provider model (shells out to a local agent CLI, parses structured JSON output). Adding it expands the set of supported review/fix backends alongside `codex`, `claude`, `grok`, `opencode`, `pi`, and `cursor`.

## Implementation details

- **Read-only enforcement via `--permission-mode`**: review and revalidate use `--permission-mode auto` (the Devin runtime auto-approves read-only tools only and never grants writes in print mode). Fix uses `--permission-mode accept-edits`. This is real tool-level enforcement, not a prompt-only directive — the same approach opencode uses with `OPENCODE_PERMISSION` and grok uses with `--disallowed-tools`.
- **Prompt delivery**: writes the full clawpatch prompt to a temp file and calls `devin --print --prompt-file <path> --permission-mode <mode>`.
- **JSON output**: parsed from stdout with the shared `extractJson` helper (same approach as `grok`, `opencode`, `pi` — the Devin CLI has no native `--json-schema` flag).
- **Reasoning effort**: the Devin CLI has no `--reasoning-effort` flag (verified against v3000.2.17), so the requested effort level is injected into the prompt text.
- **Model pass-through**: `--model <model>` is passed through when configured; when unset, Devin uses its own configured default (`~/.config/devin/config.json` on macOS/Linux, `%APPDATA%\devin\config.json` on Windows).
- **Environment**: the Devin subprocess inherits the ambient environment. Devin uses config-file-based auth (not env-var API keys), like `grok`, `cursor`, `opencode`, and `pi`. Strict env isolation (as `claude` does) would break Devin's credential discovery. This is consistent with the dominant provider pattern (4 of 5 comparable providers use ambient env).
- **Timeout**: 300s default, override with `CLAWPATCH_DEVIN_TIMEOUT_MS` or `CLAWPATCH_PROVIDER_TIMEOUT_MS`.
- **Version gating**: not implemented. No known Devin CLI security advisories exist as of v3000.2.17. The `check` method validates availability via `devin --version`.

Also includes a minor cross-platform fix: the Claude env test block in `src/provider.test.ts` now uses `path.join` instead of forward-slash string literals for path expectations, so those tests pass on Windows as well as Unix.

## Testing performed

- `pnpm typecheck` — passed (0 errors)
- `pnpm lint` — passed (0 warnings, 0 errors, 113 files, 125 rules)
- `pnpm format:check` — changed files pass (pre-existing CRLF format issues on 181 other files are unrelated to this PR)
- `pnpm test` — 871 passed, 22 skipped, 0 failed (full suite on the combined working tree)
- `pnpm build` — passed (clean compile)
- Devin provider helper tests: 3 passed (prompt construction with reasoning effort, timeout precedence, failure message previews)
- `providerByName("devin")` registry test: passed
- Verified Devin CLI flag surface against the real binary (`devin --version` → `devin 3000.2.17`, `--print`, `--prompt-file`, `--model`, `--permission-mode` all confirmed)

#### Test plan

- [ ] CI passes on Linux (`pnpm typecheck && pnpm lint && pnpm format:check && pnpm test && pnpm build`)
- [ ] `clawpatch doctor --provider devin` detects the Devin CLI (requires `devin auth login` first)
- [ ] `clawpatch review --provider devin --limit 1` produces structured findings
- [ ] `clawpatch map --source agent --provider devin` produces feature records
