### PR TITLE
chore(deps): update pnpm to 11.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,5 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee"
+  "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1"
 }


### PR DESCRIPTION
## Summary

- update the integrity-pinned project package manager from pnpm 11.20.0 to 11.21.0
- retain the existing 48-hour minimum release-age policy for package dependencies

The registry pass found no eligible package or lockfile updates. Oxfmt 0.63.0 and Oxlint 1.78.0 are newer but were published only about 15 hours before this pass, so pnpm correctly excluded them under `minimumReleaseAge: 2880`. PR #185 separately owns the current GitHub Actions digest refresh.

## Verification

```text
$ pnpm --version
11.21.0

$ pnpm install --frozen-lockfile
Already up to date
Done in 212ms using pnpm v11.21.0

$ pnpm typecheck
exit 0

$ pnpm lint
exit 0

$ pnpm format:check
All matched files use the correct format.

$ pnpm test -- --silent
Test Files  29 passed (29)
Tests  900 passed | 1 skipped (901)

$ pnpm build
exit 0

$ pnpm pack:smoke
packaged CLI smoke mapped 13 features (3 CUDA)

$ node dist/cli.js --version
0.7.2
```
