### PR TITLE
fix(release): align npm trusted publisher identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
   release:
     name: Publish npm and GitHub release
     runs-on: ubuntu-latest
+    environment: npm-release
     timeout-minutes: 20
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Bound npm trusted publishing to the `npm-release` GitHub environment and restored canonical package repository metadata.
 - Reworked the README around a verified install and quickstart path, with deeper command, mapper, provider, and safety details linked to the existing docs.
 - Updated transitive Vitest dependencies.
 - Updated pnpm, formatter and linter tooling, and GitHub Actions dependencies.

--- a/docs/release-prep.md
+++ b/docs/release-prep.md
@@ -38,6 +38,9 @@ npm pack --dry-run --json --ignore-scripts
 
 ## Manual Checks
 
+- Confirm npm Trusted Publisher is bound to GitHub repository
+  `openclaw/clawpatch`, workflow filename `release.yml`, environment
+  `npm-release`, and the `npm publish` action.
 - Confirm `CHANGELOG.md` has all user-visible, operational, or security-relevant
   changes under the next unreleased version.
 - Confirm README and docs mention any new mapper behavior, commands, or safety

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.7.2",
   "description": "Automated code review that lands fixes.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openclaw/clawpatch.git"
+  },
   "bin": {
     "clawpatch": "dist/cli.js"
   },


### PR DESCRIPTION
## Summary

- bind the release job to the `npm-release` GitHub environment so its OIDC identity has one explicit, documented environment claim
- restore canonical repository metadata required by npm provenance and trust tooling
- document the exact npm Trusted Publisher tuple that the registry administrator must configure

This repairs the repository side of #177. The npm package administrator still needs to update the private npmjs.com Trusted Publisher setting to match before the next release.

## Proof

- `actionlint .github/workflows/release.yml`
- `npm trust github clawpatch --file release.yml --environment npm-release --allow-publish --dry-run --json`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` (29 files, 903 passed, 1 skipped)
- `pnpm build`
- `pnpm pack:smoke` (13 features mapped, including 3 CUDA)
- autoreview clean

No package was published and no release was created.
