### PR TITLE
fix(mappers): timeout go list in the Go mapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,15 @@ jobs:
       - run: pnpm test
       - run: pnpm build
       - run: pnpm pack:smoke
+
+  windows-exec:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 26
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test src/exec.test.ts src/mappers/go.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
           node-version: 26
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm test src/exec.test.ts src/mappers/go.test.ts
+      - run: pnpm test src/exec.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Updated pnpm, Node typings, formatter and linter tooling, Vitest/Vite, CodeQL, TruffleHog, and the release workflow's npm CLI.
 - Fixed `clawpatch open-pr` so a stalled `git push` or `gh pr create` times out instead of hanging the command, thanks @SebTardif.
+- Fixed `clawpatch map` so a wedged `go list` times out instead of hanging Go repository mapping, thanks @SebTardif.
 - Bound npm trusted publishing to the `npm-release` GitHub environment and restored canonical package repository metadata.
 - Reworked the README around a verified install and quickstart path, with deeper command, mapper, provider, and safety details linked to the existing docs.
 - Updated transitive Vitest dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 - Fixed `clawpatch open-pr` so a stalled `git push` or `gh pr create` times out instead of hanging the command, thanks @SebTardif.
 - Fixed Windows command timeouts so a hung `taskkill` cannot keep the CLI or its direct child running after the cleanup deadline, thanks @SebTardif.
 - Fixed Windows shell validation commands with quoted executable paths.
-- Fixed `clawpatch map` so a wedged `go list` times out and falls back to repository files, thanks @SebTardif.
 - Bound npm trusted publishing to the `npm-release` GitHub environment and restored canonical package repository metadata.
+- Fixed `clawpatch map` so a wedged `go list` times out and falls back to repository files, thanks @SebTardif.
 - Reworked the README around a verified install and quickstart path, with deeper command, mapper, provider, and safety details linked to the existing docs.
 - Updated transitive Vitest dependencies.
 - Updated pnpm, formatter and linter tooling, and GitHub Actions dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Updated pnpm, Node typings, formatter and linter tooling, Vitest/Vite, CodeQL, TruffleHog, and the release workflow's npm CLI.
 - Fixed `clawpatch open-pr` so a stalled `git push` or `gh pr create` times out instead of hanging the command, thanks @SebTardif.
-- Fixed `clawpatch map` so a wedged `go list` times out instead of hanging Go repository mapping, thanks @SebTardif.
+- Fixed Windows command timeouts so a hung `taskkill` cannot keep the CLI or its direct child running after the cleanup deadline, thanks @SebTardif.
+- Fixed Windows shell validation commands with quoted executable paths.
+- Fixed `clawpatch map` so a wedged `go list` times out and falls back to repository files, thanks @SebTardif.
 - Bound npm trusted publishing to the `npm-release` GitHub environment and restored canonical package repository metadata.
 - Reworked the README around a verified install and quickstart path, with deeper command, mapper, provider, and safety details linked to the existing docs.
 - Updated transitive Vitest dependencies.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,8 +75,9 @@ Environment overrides:
 - `CLAWPATCH_CLAUDE_AUTH_CONTEXT` (`isolated` or `host`; default `isolated`)
 - `CLAWPATCH_GIT_PUSH_TIMEOUT_MS` (default `600000`, or 10 minutes)
 - `CLAWPATCH_GH_PR_CREATE_TIMEOUT_MS` (default `300000`, or 5 minutes)
+- `CLAWPATCH_GO_LIST_TIMEOUT_MS` (default `120000`, or 2 minutes)
 
-The `open-pr` timeout overrides must be positive millisecond values. Invalid values fall back to
+Timeout overrides must be positive millisecond values. Invalid values fall back to
 their defaults.
 
 `provider.codexConfig` passes primitive values to Codex as `-c key=value`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,10 +75,22 @@ Environment overrides:
 - `CLAWPATCH_CLAUDE_AUTH_CONTEXT` (`isolated` or `host`; default `isolated`)
 - `CLAWPATCH_GIT_PUSH_TIMEOUT_MS` (default `600000`, or 10 minutes)
 - `CLAWPATCH_GH_PR_CREATE_TIMEOUT_MS` (default `300000`, or 5 minutes)
-- `CLAWPATCH_GO_LIST_TIMEOUT_MS` (default `120000`, or 2 minutes)
+- `CLAWPATCH_TASKKILL_TIMEOUT_MS` (Windows cleanup deadline; default `5000`, or 5 seconds)
+- `CLAWPATCH_GO_LIST_TIMEOUT_MS` (Go discovery deadline; default `120000`, or 2 minutes)
 
-Timeout overrides must be positive millisecond values. Invalid values fall back to
+The `open-pr` timeout overrides must be positive millisecond values. Invalid values fall back to
 their defaults.
+
+`CLAWPATCH_TASKKILL_TIMEOUT_MS` must be between `1` and `2147483647` milliseconds;
+invalid values fall back to 5 seconds. Fractional values are truncated. Each Windows
+process-tree cleanup attempt is bounded independently of the command deadline.
+If cleanup fails or times out, Clawpatch also terminates the direct child; descendant
+cleanup remains best effort when `taskkill` is unavailable or hung.
+
+`CLAWPATCH_GO_LIST_TIMEOUT_MS` uses the same supported millisecond range. Invalid
+values fall back to 2 minutes, and fractional values are truncated. If `go list`
+times out, Clawpatch discards incomplete output and maps Go packages from repository
+files instead. Process cleanup can add a bounded delay after the discovery deadline.
 
 `provider.codexConfig` passes primitive values to Codex as `-c key=value`.
 Only config loaded by `--config` or `CLAWPATCH_CONFIG` may set non-empty

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,12 @@ package coordinates; set it to `true` only when that network access is acceptabl
 [Code review > Registry verifier](code-review.md#registry-verifier) for
 the full verdict matrix.
 
+Go package discovery has a two-minute deadline. `CLAWPATCH_GO_LIST_TIMEOUT_MS`
+accepts `1` through `2147483647` milliseconds; invalid values fall back to two
+minutes and fractional values are truncated. If `go list` times out, Clawpatch
+discards incomplete output and maps packages from repository files instead.
+Process cleanup can add a bounded delay after the discovery deadline.
+
 Environment overrides:
 
 - `CLAWPATCH_STATE_DIR`
@@ -73,10 +79,10 @@ Environment overrides:
 - `CLAWPATCH_MODEL`
 - `CLAWPATCH_REASONING_EFFORT`
 - `CLAWPATCH_CLAUDE_AUTH_CONTEXT` (`isolated` or `host`; default `isolated`)
+- `CLAWPATCH_GO_LIST_TIMEOUT_MS` (Go discovery deadline; default `120000`, or 2 minutes)
 - `CLAWPATCH_GIT_PUSH_TIMEOUT_MS` (default `600000`, or 10 minutes)
 - `CLAWPATCH_GH_PR_CREATE_TIMEOUT_MS` (default `300000`, or 5 minutes)
 - `CLAWPATCH_TASKKILL_TIMEOUT_MS` (Windows cleanup deadline; default `5000`, or 5 seconds)
-- `CLAWPATCH_GO_LIST_TIMEOUT_MS` (Go discovery deadline; default `120000`, or 2 minutes)
 
 The `open-pr` timeout overrides must be positive millisecond values. Invalid values fall back to
 their defaults.
@@ -86,11 +92,6 @@ invalid values fall back to 5 seconds. Fractional values are truncated. Each Win
 process-tree cleanup attempt is bounded independently of the command deadline.
 If cleanup fails or times out, Clawpatch also terminates the direct child; descendant
 cleanup remains best effort when `taskkill` is unavailable or hung.
-
-`CLAWPATCH_GO_LIST_TIMEOUT_MS` uses the same supported millisecond range. Invalid
-values fall back to 2 minutes, and fractional values are truncated. If `go list`
-times out, Clawpatch discards incomplete output and maps Go packages from repository
-files instead. Process cleanup can add a bounded delay after the discovery deadline.
 
 `provider.codexConfig` passes primitive values to Codex as `-c key=value`.
 Only config loaded by `--config` or `CLAWPATCH_CONFIG` may set non-empty

--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -1,8 +1,10 @@
-import { access, mkdtemp, writeFile } from "node:fs/promises";
+import childProcess, { spawn, type ChildProcess } from "node:child_process";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-import { runCommand, runCommandArgs } from "./exec.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runCommand, runCommandArgs, taskkillTimeoutMs, taskkillTree } from "./exec.js";
+import { shellQuotePath } from "./shell.js";
 
 describe("runCommand", () => {
   it("runs a shell command and passes stdin", async () => {
@@ -15,7 +17,7 @@ describe("runCommand", () => {
     );
 
     const result = await runCommand(
-      `${JSON.stringify(process.execPath)} ${JSON.stringify(script)}`,
+      `${shellQuotePath(process.execPath)} ${shellQuotePath(script)}`,
       dir,
       "ok",
     );
@@ -28,7 +30,7 @@ describe("runCommand", () => {
     const dir = await mkdtemp(join(tmpdir(), "clawpatch-exec-shell-"));
     const script = join(dir, "large-output.mjs");
     await writeFile(script, "process.stdout.write('x'.repeat(9000));", "utf8");
-    const command = `${JSON.stringify(process.execPath)} ${JSON.stringify(script)}`;
+    const command = `${shellQuotePath(process.execPath)} ${shellQuotePath(script)}`;
 
     const trimmed = await runCommand(command, dir);
     const raw = await runCommand(command, dir, undefined, { trimOutput: false });
@@ -45,13 +47,13 @@ describe("runCommand", () => {
     await writeFile(hanging, "setInterval(() => {}, 1000);", "utf8");
 
     const bounded = await runCommand(
-      `${JSON.stringify(process.execPath)} ${JSON.stringify(noisy)}`,
+      `${shellQuotePath(process.execPath)} ${shellQuotePath(noisy)}`,
       dir,
       undefined,
       { trimOutput: false, maxOutputChars: 10_000 },
     );
     const timedOut = await runCommand(
-      `${JSON.stringify(process.execPath)} ${JSON.stringify(hanging)}`,
+      `${shellQuotePath(process.execPath)} ${shellQuotePath(hanging)}`,
       dir,
       undefined,
       { timeoutMs: 50 },
@@ -220,3 +222,113 @@ describe("runCommandArgs", () => {
     expect(JSON.parse(result.stdout)).toEqual(args);
   });
 });
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:child_process")>();
+  return { ...original, spawn: vi.fn(original.spawn) };
+});
+
+const cleanupTimeoutMs = 1_000;
+
+describe("taskkillTree", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.mocked(spawn).mockImplementation(childProcess.spawn);
+  });
+
+  it("defaults to 5s and accepts supported millisecond overrides", () => {
+    vi.stubEnv("CLAWPATCH_TASKKILL_TIMEOUT_MS", undefined);
+    expect(taskkillTimeoutMs()).toBe(5_000);
+    vi.stubEnv("CLAWPATCH_TASKKILL_TIMEOUT_MS", "1234");
+    expect(taskkillTimeoutMs()).toBe(1_234);
+    vi.stubEnv("CLAWPATCH_TASKKILL_TIMEOUT_MS", "2147483647");
+    expect(taskkillTimeoutMs()).toBe(2_147_483_647);
+  });
+
+  it.each(["invalid", "", "0", "-1", "0.5", "Infinity", "2147483648"])(
+    "rejects unsupported timeout override %s",
+    (value) => {
+      vi.stubEnv("CLAWPATCH_TASKKILL_TIMEOUT_MS", value);
+      expect(taskkillTimeoutMs()).toBe(5_000);
+    },
+  );
+
+  it("bounds a verified hanging cleanup process", async () => {
+    const root = await mkdtemp(join(tmpdir(), "clawpatch-taskkill-"));
+    const marker = join(root, "killer.json");
+    const children = interceptTaskkill(marker);
+    try {
+      await taskkillTree(42_424, cleanupTimeoutMs);
+      expect(JSON.parse(await readFile(marker, "utf8"))).toEqual(["/pid", "42424", "/T", "/F"]);
+      expect(children).toHaveLength(1);
+      await expect
+        .poll(() => children[0]?.exitCode !== null || children[0]?.signalCode !== null)
+        .toBe(true);
+    } finally {
+      for (const child of children) child.kill("SIGKILL");
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(process.platform === "win32")(
+    "returns a timeout and kills the original child when taskkill hangs",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "clawpatch-taskkill-caller-"));
+      const marker = join(root, "killer.json");
+      const children = interceptTaskkill(marker);
+      vi.stubEnv("CLAWPATCH_TASKKILL_TIMEOUT_MS", String(cleanupTimeoutMs));
+      let pid: number | undefined;
+      try {
+        const result = await runCommandArgs(
+          process.execPath,
+          ["-e", "console.log(process.pid); setInterval(() => {}, 1000)"],
+          root,
+          undefined,
+          { timeoutMs: 1_000 },
+        );
+        pid = Number(result.stdout.trim());
+        expect(pid).toBeGreaterThan(0);
+        expect(result.exitCode).toBe(124);
+        expect(result.stderr).toContain("command timed out after 1000ms");
+        expect(JSON.parse(await readFile(marker, "utf8"))).toEqual([
+          "/pid",
+          String(pid),
+          "/T",
+          "/F",
+        ]);
+        expect(children.length).toBeGreaterThan(0);
+        expect(() => process.kill(pid!, 0)).toThrow();
+      } finally {
+        if (pid) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {}
+        }
+        for (const child of children) child.kill("SIGKILL");
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+});
+
+function interceptTaskkill(marker: string): ChildProcess[] {
+  const realSpawn = childProcess.spawn;
+  const children: ChildProcess[] = [];
+  vi.mocked(spawn).mockImplementation(((...params: Parameters<typeof spawn>) => {
+    const [program, args = [], options = {}] = params;
+    if (program !== "taskkill") return realSpawn(program, args, options);
+    const child = realSpawn(
+      process.execPath,
+      [
+        "-e",
+        "require('node:fs').writeFileSync(process.argv[1], JSON.stringify(process.argv.slice(2))); setInterval(() => {}, 1000)",
+        marker,
+        ...args,
+      ],
+      options,
+    );
+    children.push(child);
+    return child;
+  }) as typeof childProcess.spawn);
+  return children;
+}

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -10,11 +10,22 @@ type CommandOptions = {
   timeoutMs?: number;
   replaceEnv?: boolean;
   maxOutputChars?: number;
+  windowsVerbatimArguments?: boolean;
 };
 
 const abortSignals: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
 const abortableChildren = new Set<SpawnedChild>();
 const abortHandlers = new Map<NodeJS.Signals, () => void>();
+const defaultTaskkillTimeoutMs = 5_000;
+
+export function taskkillTimeoutMs(): number {
+  const configured = Number(
+    process.env["CLAWPATCH_TASKKILL_TIMEOUT_MS"] ?? String(defaultTaskkillTimeoutMs),
+  );
+  return Number.isFinite(configured) && configured >= 1 && configured <= 2_147_483_647
+    ? Math.trunc(configured)
+    : defaultTaskkillTimeoutMs;
+}
 
 export async function runCommand(
   command: string,
@@ -32,8 +43,13 @@ export async function runCommandRaw(
   options: CommandOptions = {},
 ): Promise<CommandResult> {
   const shell = process.platform === "win32" ? (process.env["ComSpec"] ?? "cmd.exe") : "/bin/sh";
-  const args = process.platform === "win32" ? ["/d", "/s", "/c", command] : ["-c", command];
-  const result = await runCommandArgs(shell, args, cwd, input, options);
+  const windows = process.platform === "win32";
+  // cmd.exe owns shell quoting; Node's executable argument escaping breaks quoted paths.
+  const args = windows ? ["/d", "/s", "/c", `"${command}"`] : ["-c", command];
+  const result = await runCommandArgs(shell, args, cwd, input, {
+    ...options,
+    windowsVerbatimArguments: windows,
+  });
   return { ...result, command };
 }
 
@@ -57,7 +73,8 @@ export async function runCommandArgs(
     detached: process.platform !== "win32" && options.timeoutMs !== undefined,
     shell: false,
     stdio: ["pipe", "pipe", "pipe"],
-    windowsVerbatimArguments: spawnSpec.windowsVerbatimArguments,
+    windowsVerbatimArguments:
+      options.windowsVerbatimArguments ?? spawnSpec.windowsVerbatimArguments,
   });
   const stdout = new OutputBuffer(options.maxOutputChars);
   const stderr = new OutputBuffer(options.maxOutputChars);
@@ -144,6 +161,10 @@ function terminateChild(child: SpawnedChild, onForceKill: () => void): NodeJS.Ti
 async function killChild(child: SpawnedChild, signal: NodeJS.Signals): Promise<void> {
   if (process.platform === "win32" && child.pid !== undefined) {
     await taskkillTree(child.pid);
+    // A failed or hung tree killer must not leave the direct child keeping the CLI alive.
+    try {
+      child.kill(signal);
+    } catch {}
     return;
   }
   try {
@@ -157,14 +178,33 @@ async function killChild(child: SpawnedChild, signal: NodeJS.Signals): Promise<v
   } catch {}
 }
 
-async function taskkillTree(pid: number): Promise<void> {
+export async function taskkillTree(pid: number, timeoutMs = taskkillTimeoutMs()): Promise<void> {
   await new Promise<void>((resolve) => {
     const killer = spawn("taskkill", ["/pid", String(pid), "/T", "/F"], {
       stdio: "ignore",
       windowsHide: true,
     });
-    killer.on("error", () => resolve());
-    killer.on("close", () => resolve());
+    let settled = false;
+    const finish = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      resolve();
+    };
+    const timeout = setTimeout(() => {
+      try {
+        killer.kill("SIGKILL");
+      } catch {}
+      finish();
+    }, timeoutMs);
+    killer.on("error", () => {
+      finish();
+    });
+    killer.on("close", () => {
+      finish();
+    });
   });
 }
 

--- a/src/mappers/go.test.ts
+++ b/src/mappers/go.test.ts
@@ -1,0 +1,102 @@
+import { chmod } from "node:fs/promises";
+import { delimiter, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { fixtureRoot, writeFixture } from "../test-helpers.js";
+import { goListTimeoutMs, goSeeds, runGoList } from "./go.js";
+import { emptyTaskGraph } from "./task-graph.js";
+import type { MapperContext } from "./types.js";
+
+const HANG_TEST_TIMEOUT_MS = 4_000;
+const SHORT_TIMEOUT_MS = 80;
+
+describe("go list timeout", () => {
+  const previousEnv = {
+    CLAWPATCH_GO_LIST_TIMEOUT_MS: process.env["CLAWPATCH_GO_LIST_TIMEOUT_MS"],
+    PATH: process.env["PATH"],
+  };
+
+  afterEach(() => {
+    restoreEnv("CLAWPATCH_GO_LIST_TIMEOUT_MS", previousEnv.CLAWPATCH_GO_LIST_TIMEOUT_MS);
+    restoreEnv("PATH", previousEnv.PATH);
+  });
+
+  it("defaults go list to 2m and rejects invalid overrides", () => {
+    delete process.env["CLAWPATCH_GO_LIST_TIMEOUT_MS"];
+    expect(goListTimeoutMs()).toBe(120_000);
+
+    process.env["CLAWPATCH_GO_LIST_TIMEOUT_MS"] = "1234";
+    expect(goListTimeoutMs()).toBe(1_234);
+
+    process.env["CLAWPATCH_GO_LIST_TIMEOUT_MS"] = "invalid";
+    expect(goListTimeoutMs()).toBe(120_000);
+
+    process.env["CLAWPATCH_GO_LIST_TIMEOUT_MS"] = "0";
+    expect(goListTimeoutMs()).toBe(120_000);
+  });
+
+  it(
+    "times out a hung go list instead of blocking the mapper",
+    { timeout: HANG_TEST_TIMEOUT_MS },
+    async () => {
+      const root = await fixtureRoot("clawpatch-go-list-timeout-");
+      await writeFixture(root, "go.mod", "module example.com/hang\n\ngo 1.26\n");
+      process.env["PATH"] = `${await writeHangGo(root)}${delimiter}${process.env["PATH"] ?? ""}`;
+
+      const started = Date.now();
+      const stdout = await runGoList(root, SHORT_TIMEOUT_MS);
+
+      expect(stdout).toBe("");
+      expect(Date.now() - started).toBeLessThan(1_500);
+    },
+  );
+
+  it(
+    "falls back to file mapping when go list times out",
+    { timeout: HANG_TEST_TIMEOUT_MS },
+    async () => {
+      const root = await fixtureRoot("clawpatch-go-list-timeout-fallback-");
+      await writeFixture(root, "go.mod", "module example.com/hang\n\ngo 1.26\n");
+      await writeFixture(root, "internal/store/chats.go", "package store\n");
+      process.env["PATH"] = `${await writeHangGo(root)}${delimiter}${process.env["PATH"] ?? ""}`;
+      process.env["CLAWPATCH_GO_LIST_TIMEOUT_MS"] = String(SHORT_TIMEOUT_MS);
+
+      const started = Date.now();
+      const seeds = await goSeeds(root, mapperContext(["internal/store/chats.go"]));
+
+      expect(Date.now() - started).toBeLessThan(1_500);
+      expect(seeds.map((seed) => seed.title)).toContain("Go package store");
+    },
+  );
+});
+
+async function writeHangGo(root: string): Promise<string> {
+  const binDir = join(root, "bin");
+  if (process.platform === "win32") {
+    await writeFixture(
+      root,
+      "bin/go.cmd",
+      "@echo off\r\n:loop\r\ntimeout /t 30 >nul\r\ngoto loop\r\n",
+    );
+    return binDir;
+  }
+  const wrapper = join(binDir, "go");
+  await writeFixture(root, "bin/go", "#!/bin/sh\nwhile true; do sleep 30; done\n");
+  await chmod(wrapper, 0o755);
+  return binDir;
+}
+
+function mapperContext(files: string[]): MapperContext {
+  return {
+    nodeProjects: async () => [],
+    nodeTaskGraph: async () => emptyTaskGraph(),
+    rootFiles: async () => files,
+  };
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}

--- a/src/mappers/go.test.ts
+++ b/src/mappers/go.test.ts
@@ -1,13 +1,15 @@
-import { chmod } from "node:fs/promises";
+import { chmod, readFile, rm } from "node:fs/promises";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { shellQuotePath } from "../shell.js";
 import { fixtureRoot, writeFixture } from "../test-helpers.js";
 import { goListTimeoutMs, goSeeds, runGoList } from "./go.js";
 import { emptyTaskGraph } from "./task-graph.js";
 import type { MapperContext } from "./types.js";
 
-const HANG_TEST_TIMEOUT_MS = 4_000;
-const SHORT_TIMEOUT_MS = 80;
+const HANG_TEST_TIMEOUT_MS = 10_000;
+const SHORT_TIMEOUT_MS = 3_000;
+const roots: string[] = [];
 
 describe("go list timeout", () => {
   const previousEnv = {
@@ -15,9 +17,10 @@ describe("go list timeout", () => {
     PATH: process.env["PATH"],
   };
 
-  afterEach(() => {
+  afterEach(async () => {
     restoreEnv("CLAWPATCH_GO_LIST_TIMEOUT_MS", previousEnv.CLAWPATCH_GO_LIST_TIMEOUT_MS);
     restoreEnv("PATH", previousEnv.PATH);
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
   });
 
   it("defaults go list to 2m and rejects invalid overrides", () => {
@@ -34,6 +37,16 @@ describe("go list timeout", () => {
     expect(goListTimeoutMs()).toBe(120_000);
   });
 
+  it.each(["-1", "0.5", "Infinity", "2147483648"])("rejects unsupported override %s", (value) => {
+    process.env["CLAWPATCH_GO_LIST_TIMEOUT_MS"] = value;
+    expect(goListTimeoutMs()).toBe(120_000);
+  });
+
+  it("accepts the maximum supported timer delay", () => {
+    process.env["CLAWPATCH_GO_LIST_TIMEOUT_MS"] = "2147483647";
+    expect(goListTimeoutMs()).toBe(2_147_483_647);
+  });
+
   it(
     "times out a hung go list instead of blocking the mapper",
     { timeout: HANG_TEST_TIMEOUT_MS },
@@ -46,7 +59,14 @@ describe("go list timeout", () => {
       const stdout = await runGoList(root, SHORT_TIMEOUT_MS);
 
       expect(stdout).toBe("");
-      expect(Date.now() - started).toBeLessThan(1_500);
+      expect(JSON.parse(await readFile(join(root, "go-invoked.json"), "utf8"))).toEqual([
+        "list",
+        "-e",
+        "-f",
+        "{{.Dir}}|{{.ImportPath}}|{{.Name}}",
+        "./...",
+      ]);
+      expect(Date.now() - started).toBeLessThan(7_000);
     },
   );
 
@@ -63,24 +83,36 @@ describe("go list timeout", () => {
       const started = Date.now();
       const seeds = await goSeeds(root, mapperContext(["internal/store/chats.go"]));
 
-      expect(Date.now() - started).toBeLessThan(1_500);
+      expect(Date.now() - started).toBeLessThan(7_000);
       expect(seeds.map((seed) => seed.title)).toContain("Go package store");
+      expect(await readFile(join(root, "go-invoked.json"), "utf8")).toContain("list");
     },
   );
 });
 
 async function writeHangGo(root: string): Promise<string> {
+  roots.push(root);
   const binDir = join(root, "bin");
+  const script = join(binDir, "go.cjs");
+  await writeFixture(
+    root,
+    "bin/go.cjs",
+    [
+      `require('node:fs').writeFileSync(${JSON.stringify(join(root, "go-invoked.json"))}, JSON.stringify(process.argv.slice(2)));`,
+      `console.log(${JSON.stringify(`${root}|example.com/hang|main`)});`,
+      "setInterval(() => {}, 1000);",
+    ].join("\n"),
+  );
   if (process.platform === "win32") {
-    await writeFixture(
-      root,
-      "bin/go.cmd",
-      "@echo off\r\n:loop\r\ntimeout /t 30 >nul\r\ngoto loop\r\n",
-    );
+    await writeFixture(root, "bin/go.cmd", `@echo off\r\n"${process.execPath}" "${script}" %*\r\n`);
     return binDir;
   }
   const wrapper = join(binDir, "go");
-  await writeFixture(root, "bin/go", "#!/bin/sh\nwhile true; do sleep 30; done\n");
+  await writeFixture(
+    root,
+    "bin/go",
+    `#!/bin/sh\nexec ${shellQuotePath(process.execPath)} ${shellQuotePath(script)} "$@"\n`,
+  );
   await chmod(wrapper, 0o755);
   return binDir;
 }

--- a/src/mappers/go.ts
+++ b/src/mappers/go.ts
@@ -1,9 +1,18 @@
-import { spawn } from "node:child_process";
 import { readdir, readFile, realpath } from "node:fs/promises";
 import { isAbsolute, join, relative } from "node:path";
+import { runCommandArgs } from "../exec.js";
 import { pathExists } from "../fs.js";
 import { packageKind, packageTrustBoundaries, normalize, shouldSkip } from "./shared.js";
 import { FeatureSeed, MapperContext, SeedFileRef, SeedTestRef } from "./types.js";
+
+const defaultGoListTimeoutMs = 120_000;
+
+export function goListTimeoutMs(): number {
+  const configured = Number(
+    process.env["CLAWPATCH_GO_LIST_TIMEOUT_MS"] ?? String(defaultGoListTimeoutMs),
+  );
+  return Number.isFinite(configured) && configured > 0 ? configured : defaultGoListTimeoutMs;
+}
 
 export async function goSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {
   if (!(await pathExists(join(root, "go.mod")))) {
@@ -96,21 +105,18 @@ async function fallbackGoPackages(
   return packages;
 }
 
-async function runGoList(root: string): Promise<string> {
-  const child = spawn("go", ["list", "-e", "-f", "{{.Dir}}|{{.ImportPath}}|{{.Name}}", "./..."], {
-    cwd: root,
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  let stdout = "";
-  child.stdout.setEncoding("utf8");
-  child.stdout.on("data", (chunk: string) => {
-    stdout += chunk;
-  });
-  await new Promise<void>((resolve) => {
-    child.on("close", () => resolve());
-    child.on("error", () => resolve());
-  });
-  return stdout;
+export async function runGoList(root: string, timeoutMs = goListTimeoutMs()): Promise<string> {
+  const result = await runCommandArgs(
+    "go",
+    ["list", "-e", "-f", "{{.Dir}}|{{.ImportPath}}|{{.Name}}", "./..."],
+    root,
+    undefined,
+    { timeoutMs, trimOutput: false },
+  );
+  if (result.exitCode === 124) {
+    return "";
+  }
+  return result.stdout;
 }
 
 async function isSkippedGoPackageDir(root: string, dir: string): Promise<boolean> {

--- a/src/mappers/go.ts
+++ b/src/mappers/go.ts
@@ -11,7 +11,9 @@ export function goListTimeoutMs(): number {
   const configured = Number(
     process.env["CLAWPATCH_GO_LIST_TIMEOUT_MS"] ?? String(defaultGoListTimeoutMs),
   );
-  return Number.isFinite(configured) && configured > 0 ? configured : defaultGoListTimeoutMs;
+  return Number.isFinite(configured) && configured >= 1 && configured <= 2_147_483_647
+    ? Math.trunc(configured)
+    : defaultGoListTimeoutMs;
 }
 
 export async function goSeeds(root: string, context: MapperContext): Promise<FeatureSeed[]> {


### PR DESCRIPTION
`clawpatch map` could hang indefinitely when `go list ./...` stalled. Go discovery now uses the shared command runner with a two-minute deadline (`CLAWPATCH_GO_LIST_TIMEOUT_MS`). On timeout, it discards incomplete output and uses the existing file-based package mapper.

The override accepts 1 through 2147483647 milliseconds, truncates fractional values, and falls back to two minutes for invalid values. This branch includes the shared Windows executor correction from #195, so a hung `taskkill` cannot make cleanup unbounded. Land #195 first; its executor code is identical here, and the remaining Go changes are arranged to merge cleanly afterward.

Regression tests verify that the hanging tool actually starts, that partial output is discarded, that fallback still emits `Go package store`, and that unsupported timer values fall back safely. The test deadline leaves time for process startup on loaded machines. Configuration docs and the changelog are updated; @SebTardif's original contribution and credit are preserved.

Built CLI proof used a synthetic Go module and a verified hanging `go` executable. On macOS, the original mapper remained hung at the four-second outer deadline. The corrected mapper returned in 1762ms, exit 0, and produced two features including `Go package store`. Native Windows returned in 1964ms with the same result and confirmed executable invocation.

```sh
CLAWPATCH_GO_LIST_TIMEOUT_MS=1000 node dist/cli.js map --root <synthetic-go-repo> --source heuristic --json --no-color
```

```text
go_invoked=true
go_args=list -e -f {{.Dir}}|{{.ImportPath}}|{{.Name}} ./...
features=2
FALLBACK_MAPPED_GO_PACKAGE_STORE=true
```

Focused Go tests pass on macOS (8 tests); native Windows executor and Go tests pass (28 passed, 1 Unix-only skip). The branch's GitHub CI runs typecheck, lint, formatting, the full suite, build, packaged CLI smoke, and Windows executor tests. Codex autoreview returned scoped-clean at the default P0 threshold.
