### PR TITLE
chore(deps): refresh schema and development dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.7.3 - Unreleased
 
+- Updated Zod to 4.5.2 for lower-memory runtime schema validation.
 - Updated pnpm, Node typings, formatter and linter tooling, Vitest/Vite, CodeQL, TruffleHog, and the release workflow's npm CLI.
 - Fixed `clawpatch open-pr` so a stalled `git push` or `gh pr create` times out instead of hanging the command, thanks @SebTardif.
 - Bound npm trusted publishing to the `npm-release` GitHub environment and restored canonical package repository metadata.

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   },
   "dependencies": {
     "proper-lockfile": "^4.1.2",
-    "zod": "^4.4.3"
+    "zod": "^4.5.2"
   },
   "devDependencies": {
-    "@types/node": "^26.3.0",
+    "@types/node": "^26.4.0",
     "@types/proper-lockfile": "^4.1.4",
     "oxfmt": "^0.65.0",
     "oxlint": "^1.80.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,12 +16,12 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
       zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ^4.5.2
+        version: 4.5.2
     devDependencies:
       '@types/node':
-        specifier: ^26.3.0
-        version: 26.3.0
+        specifier: ^26.4.0
+        version: 26.4.0
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -36,12 +36,12 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@26.3.0)(vite@8.2.2(@types/node@26.3.0))
+        version: 4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0))
 
 packages:
 
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+  '@jridgewell/sourcemap-codec@1.6.0':
+    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
 
   '@oxc-project/types@0.146.0':
     resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
@@ -401,8 +401,8 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@26.3.0':
-    resolution: {integrity: sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==}
+  '@types/node@26.4.0':
+    resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
 
   '@types/proper-lockfile@4.1.4':
     resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
@@ -871,12 +871,12 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.5.2:
+    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
 
 snapshots:
 
-  '@jridgewell/sourcemap-codec@1.5.5': {}
+  '@jridgewell/sourcemap-codec@1.6.0': {}
 
   '@oxc-project/types@0.146.0': {}
 
@@ -1052,7 +1052,7 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/node@26.3.0':
+  '@types/node@26.4.0':
     dependencies:
       undici-types: 8.3.0
 
@@ -1131,13 +1131,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.3.0))':
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.0))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.2(@types/node@26.3.0)
+      vite: 8.2.2(@types/node@26.4.0)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -1239,7 +1239,7 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   nanoid@3.3.18: {}
 
@@ -1380,7 +1380,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  vite@8.2.2(@types/node@26.3.0):
+  vite@8.2.2(@types/node@26.4.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.7
@@ -1388,13 +1388,13 @@ snapshots:
       rolldown: 1.2.5
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.3.0
+      '@types/node': 26.4.0
       fsevents: 2.3.3
 
-  vitest@4.1.11(@types/node@26.3.0)(vite@8.2.2(@types/node@26.3.0)):
+  vitest@4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.3.0))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -1411,10 +1411,10 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.3.0)
+      vite: 8.2.2(@types/node@26.4.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.3.0
+      '@types/node': 26.4.0
     transitivePeerDependencies:
       - msw
 
@@ -1423,4 +1423,4 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  zod@4.4.3: {}
+  zod@4.5.2: {}


### PR DESCRIPTION
This refreshes dependencies released since the previous update while preserving the repository's 2,880-minute minimum release age. Zod's runtime schema implementation gains the memory improvements described in its [4.5 release notes](https://github.com/colinhacks/zod/releases/tag/v4.5.0); application APIs and validation contracts are unchanged.

Dependency changes:

- Runtime: Zod 4.4.3 → 4.5.2.
- Development: Node typings 26.3.0 → 26.4.0.
- Transitive: `@jridgewell/sourcemap-codec` 1.5.5 → 1.6.0.
- Regenerated the lockfile with `pnpm update --latest` using the pinned pnpm 11.24.0. No new dependencies.
- All GitHub Actions pins, pnpm, release-workflow npm, and remaining direct dependencies are current. No direct major upgrade is pending. The transitive Nano ID override remains on PostCSS's compatible 3.x line.
- Zod 4.5.3 and 4.5.4 were published less than two days before this refresh and remain deferred by the existing release-age policy. `pnpm outdated --format json` returns `{}` under that policy.

Live proof, on Node 26.8.1 and pnpm 11.24.0, from this checkout after `pnpm build`:

```console
$ node dist/cli.js --state-dir .git/deps-refresh-20260830/state init --json
```

Initialization exited 0 and created isolated task state. Then the built CLI processed the real clawpatch repository:

```console
$ node dist/cli.js --state-dir .git/deps-refresh-20260830/state map --source heuristic --json
{
  "features": 37,
  "new": 37,
  "changed": 0,
  "stale": 0,
  "source": "heuristic",
  "usedAgent": false,
  "reason": "heuristic mapper selected",
  "next": "clawpatch review --limit 3"
}
$ node dist/cli.js --state-dir .git/deps-refresh-20260830/state status --json
{
  "project": "clawpatch",
  "branch": "chore/deps-refresh-20260830",
  "dirty": true,
  "features": 37,
  "findings": 0,
  "openFindings": 0,
  "activeLocks": 0,
  "lockFiles": 0,
  "lastRun": null
}
$ node dist/cli.js --state-dir .git/deps-refresh-20260830/state report --json
{
  "findings": 0,
  "total": 0,
  "output": null,
  "items": [],
  "results": []
}
$ pnpm pack:smoke
$ node scripts/package-smoke.mjs
packaged CLI smoke mapped 13 features (3 CUDA)
```

The status command correctly reported the pending dependency edits as dirty. Package smoke installs the packed CLI and exercises mixed-language mapping with the refreshed runtime dependencies. This proof does not call a model provider.

CI reasoning: default-branch build/test [CI was green](https://github.com/openclaw/clawpatch/actions/runs/33146887267) at base commit `7666cda`, as were [secret scanning](https://github.com/openclaw/clawpatch/actions/runs/33146887279) and the latest [scheduled CodeQL scan](https://github.com/openclaw/clawpatch/actions/runs/33369268330). Stale and ClawSweeper Dispatch are repository operations, not build/test CI; their latest observed runs also succeeded. No workflow, assertion, or test was weakened, and no production or release action was run.

Local validation:

- Frozen install, typecheck, lint, formatting, build, package smoke, and `git diff --check` passed.
- `pnpm audit --json`: zero vulnerabilities across all severities.
- Required Codex autoreview returned scoped-clean with no accepted/actionable findings.
- **Local full-suite gate remains blocked by timing-sensitive integration tests on the shared host.** `pnpm test --maxWorkers=1` completed with 29/30 files passing, 906 tests passing, 1 skipped, and 1 failure: `open-pr.test.ts` measured 1,647 ms against its 1,500 ms elapsed assertion. The command returned the expected timeout error; the assertion also includes repository discovery and a local push.
- Focused retries on Node 26 and Node 24 also hit four-second test deadlines; a second full Node 26 run was stopped after the same tests failed. The host's observed load averages were 41.55 / 58.60 / 73.72. No test changes are included.
- A direct integration check of the built timeout runner against a real hung Node child returned `{"exitCode":124,"durationMs":588,"stderr":"command timed out after 80ms"}`.

An unchanged `main` baseline with the original dependencies also fails `pnpm test src/open-pr.test.ts`: the hung-push test exceeds its 4,000 ms deadline (3 passed, 1 failed). This reproduces the local timing problem without the dependency refresh.

The PR's [build/test CI passed](https://github.com/openclaw/clawpatch/actions/runs/33379398116), including frozen install, typecheck, lint, formatting, the full default-worker test suite, build, and package smoke. [CodeQL](https://github.com/openclaw/clawpatch/actions/runs/33379398180), [secret scanning](https://github.com/openclaw/clawpatch/actions/runs/33379398153), and [dependency review](https://github.com/openclaw/clawpatch/actions/runs/33379398143) also passed. Default-branch CI remains green and unchanged.

The requested local full-suite gate is still unmet despite successful CI. Recommend rerunning it on an uncongested host before landing; retain the existing timeout assertions. This PR is for orchestrator review and has not been merged.
