### PR TITLE
test: allow scheduling headroom in timeout regressions

### DIFF
--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -139,7 +139,7 @@ describe("runCommandArgs", () => {
     }
   });
 
-  it("returns after timeout even when descendants inherit stdio", async () => {
+  it("returns after timeout even when descendants inherit stdio", { timeout: 10_000 }, async () => {
     const dir = await mkdtemp(join(tmpdir(), "clawpatch-exec-timeout-"));
     const childScript = join(dir, "child.mjs");
     const parentScript = join(dir, "parent.mjs");
@@ -160,8 +160,9 @@ describe("runCommandArgs", () => {
     });
 
     expect(result.exitCode).toBe(124);
-    expect(result.durationMs).toBeLessThan(1500);
-    expect(Date.now() - started).toBeLessThan(1500);
+    // Allow shared-host scheduling headroom while still catching delayed pipe teardown.
+    expect(result.durationMs).toBeLessThan(5_000);
+    expect(Date.now() - started).toBeLessThan(5_000);
     expect(result.stderr).toContain("command timed out after 50ms");
   });
 

--- a/src/open-pr.test.ts
+++ b/src/open-pr.test.ts
@@ -8,8 +8,10 @@ import { statePaths, writePatchAttempt } from "./state.js";
 import { fixtureRoot, testOptions, writeFixture } from "./test-helpers.js";
 import type { PatchAttempt } from "./types.js";
 
-const HANG_TEST_TIMEOUT_MS = 4_000;
+const HANG_TEST_TIMEOUT_MS = 15_000;
 const SHORT_TIMEOUT_MS = 80;
+// Real git subprocesses need scheduling headroom on shared CI hosts.
+const RETURN_TIMEOUT_MS = 5_000;
 
 describe("open-pr command timeouts", () => {
   const previousEnv = {
@@ -67,7 +69,7 @@ describe("open-pr command timeouts", () => {
         code: "git-failure",
         message: expect.stringContaining(`timed out after ${SHORT_TIMEOUT_MS}ms`),
       });
-      expect(Date.now() - started).toBeLessThan(1_500);
+      expect(Date.now() - started).toBeLessThan(RETURN_TIMEOUT_MS);
     },
   );
 
@@ -90,7 +92,7 @@ describe("open-pr command timeouts", () => {
         code: "github-failure",
         message: expect.stringContaining(`timed out after ${SHORT_TIMEOUT_MS}ms`),
       });
-      expect(Date.now() - started).toBeLessThan(1_500);
+      expect(Date.now() - started).toBeLessThan(RETURN_TIMEOUT_MS);
     },
   );
 });


### PR DESCRIPTION
Real subprocess timeout tests intermittently failed on busy hosts because the 1.5-second return assertion included process startup and scheduling delays. The prior sweep reproduced this on unchanged main (1.65–1.89 seconds).

Keep explicit 5-second return assertions, timeout exit codes, and timeout error checks. Give the test runner additional setup/cleanup headroom. Production timeouts are unchanged.

Validation: typecheck and lint passed; the full suite passed (924 tests, 2 platform skips), and the final focused run passed (23 tests, 2 platform skips). The built CLI completed init/map/status on a synthetic Node/Rust repository. Codex autoreview of the working change was clean at P2 after preserving explicit return-time assertions.

Local package smoke also exposed a separate pre-existing compatibility issue: a globally installed pnpm 12 rejects the prepack script's `-s` alias before honoring the pinned package manager. That repair belongs to the final tooling/notes PR. This PR contains tests only; the final notes PR will consolidate the maintenance entry.

## Targeted runtime proof

Actual timeout proof from an isolated checkout built at `dd75865cc35593816832814bf11aafbe6654d00a`, on macOS arm64 / Node 24.20.0:

| Scenario | Configured deadline | Result | Elapsed | Readiness confirmed |
|---|---:|---:|---:|---|
| inherited stdio descendant | 500 ms | exit 124 | 1006 ms | yes |
| git push | 80 ms | exit 1 | 987 ms | yes |
| gh pr create | 500 ms | exit 7 | 1192 ms | yes |

The inherited-stdio probe ran a real parent and descendant through the built `dist/exec.js`. The publishing probes ran the built CLI:

```sh
node dist/cli.js open-pr --root <fixture> --patch pat_timeout_proof --base main --branch clawpatch/pat_timeout_proof --json --quiet
```

A local bare Git remote and hanging executables exercised `git push` and `gh pr create`; no external push or PR creation occurred. Each process wrote a readiness marker before its timeout. All three errors contained `command timed out after <configured deadline>ms`. The 500 ms probes allow process startup before testing the hang; the regression tests retain their 50/80 ms deadlines and 5-second return bounds.

The exact-head Linux/Windows CI remains green: https://github.com/openclaw/clawpatch/actions/runs/34112758456. This supplies the requested inspectable timeout behavior in addition to the already-passing test suite and clean P2 branch autoreview.
