### PR TITLE
chore: prepare 0.8.0 notes and refresh pnpm setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
       - uses: actions/setup-node@v7
         with:
           node-version: 26
@@ -31,7 +31,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7.0.1
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
       - uses: actions/setup-node@v7
         with:
           node-version: 26

--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           fi
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Set up Node
         uses: actions/setup-node@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.7.4 - Unreleased
+## 0.8.0 - Unreleased
+
+**Highlights:** Opt-in HTTP context connects Node callers and Rust handlers during review.
+
+- Added `map --link-http caller:backend` and `review --link-http caller:backend` for bounded, method-aware HTTP candidate context, with ambiguity checks and unchanged default feature records, thanks @Tanmay-008.
+- Fixed source packaging with pnpm 12 by using the portable `pnpm run build` prepack command.
+- Updated the pnpm GitHub Actions setup to 6.1.0.
+- Added shared-host scheduling headroom to timeout regression tests while retaining explicit bounded-return checks.
 
 ## 0.7.3 - 2026-09-05
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "type": "module",
   "scripts": {
     "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.build.json",
-    "prepack": "pnpm -s build",
+    "prepack": "pnpm run build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "oxlint . --config oxlint.json",
     "format": "oxfmt --write .",


### PR DESCRIPTION
Prepare the complete 0.8.0 Unreleased notes and repair source packaging when pnpm 12 is installed globally: use `pnpm run build` instead of the removed `-s` alias. Update pnpm/action-setup to its verified v6.1.0 commit.

**Merge after #199 and #200.** This is the only PR in this group that edits CHANGELOG.md. It credits @Tanmay-008 for the HTTP context proposal and includes all user-visible changes since v0.7.3. Package version and published release sections are unchanged; this PR does not publish a release.

Keep pnpm 11.25.0 and the original single-document lockfile. pnpm 12.3.4 passed a frozen install, the full suite, and package smoke, but generated an environment document before the project dependency graph. The dependency-graph parser fix in dependabot/dependabot-core#15968 merged on September 2; hosted rollout could not be verified, and dependabot/dependabot-core#15904 remains open. Do not introduce a scanning policy workaround as part of this refresh. All direct dependencies remain current, and the 48-hour release-age policy is unchanged.

Validation: typecheck, lint, formatting, full suite (924 passed, 2 platform skips), build, and packaged CLI smoke (13 features, including 3 CUDA). Codex local autoreview is clean at P2; exact-head CI and final branch review are recorded in the proof comment before handoff.
