### PR TITLE
refactor: share comment scanners across detection and mapping

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,3 +1,4 @@
+import { stripLineComments, stripSwiftComments, stripXmlComments } from "./source-comments.js";
 import { lstat, readFile, readdir } from "node:fs/promises";
 import { join, posix } from "node:path";
 import { pathExists } from "./fs.js";
@@ -1878,25 +1879,6 @@ function hasDotnetTestFrameworkEvidence(source: string): boolean {
   );
 }
 
-function stripXmlComments(source: string): string {
-  let output = "";
-  let index = 0;
-  while (index < source.length) {
-    const start = source.indexOf("<!--", index);
-    if (start === -1) {
-      output += source.slice(index);
-      break;
-    }
-    output += source.slice(index, start);
-    const end = source.indexOf("-->", start + 4);
-    if (end === -1) {
-      break;
-    }
-    index = end + 3;
-  }
-  return output;
-}
-
 function isDotnetWebProject(source: string): boolean {
   return (
     /<Project\b[^>]*\bSdk\s*=\s*["']Microsoft\.NET\.Sdk\.Web(?:\/|["'])/iu.test(source) ||
@@ -1904,88 +1886,4 @@ function isDotnetWebProject(source: string): boolean {
     /<FrameworkReference\b[^>]*\bInclude\s*=\s*["']Microsoft\.AspNetCore\.App["']/iu.test(source) ||
     /<PackageReference\b[^>]*\bInclude\s*=\s*["']Microsoft\.AspNetCore\./iu.test(source)
   );
-}
-
-function stripLineComments(source: string, marker: "#" | "//"): string {
-  return source
-    .split("\n")
-    .map((line) => stripLineComment(line, marker))
-    .join("\n");
-}
-
-function stripSwiftComments(source: string): string {
-  return stripLineComments(stripBlockComments(source), "//");
-}
-
-function stripBlockComments(source: string): string {
-  let output = "";
-  let inString = false;
-  let escaped = false;
-  for (let index = 0; index < source.length; index += 1) {
-    const char = source[index];
-    const next = source[index + 1];
-    if (inString) {
-      output += char;
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-      output += char;
-    } else if (char === "/" && next === "*") {
-      let depth = 1;
-      output += "  ";
-      index += 2;
-      while (index < source.length && depth > 0) {
-        if (source[index] === "/" && source[index + 1] === "*") {
-          output += "  ";
-          depth += 1;
-          index += 2;
-          continue;
-        }
-        if (source[index] === "*" && source[index + 1] === "/") {
-          output += "  ";
-          depth -= 1;
-          index += 2;
-          continue;
-        }
-        output += source[index] === "\n" ? "\n" : " ";
-        index += 1;
-      }
-      index -= 1;
-    } else {
-      output += char;
-    }
-  }
-  return output;
-}
-
-function stripLineComment(line: string, marker: "#" | "//"): string {
-  let inString = false;
-  let escaped = false;
-  for (let index = 0; index < line.length; index += 1) {
-    const char = line[index];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-    } else if (line.startsWith(marker, index)) {
-      return line.slice(0, index);
-    }
-  }
-  return line;
 }

--- a/src/mappers/c-cpp.ts
+++ b/src/mappers/c-cpp.ts
@@ -1,3 +1,4 @@
+import { stripLineComments } from "../source-comments.js";
 import { readFile } from "node:fs/promises";
 import { isAbsolute, join, relative } from "node:path";
 import {
@@ -9,7 +10,6 @@ import {
   normalize,
   packageTrustBoundaries,
   shouldSkip,
-  stripLineComments,
   targetLanguageTag,
   withCudaConcurrency,
 } from "./shared.js";

--- a/src/mappers/dotnet.ts
+++ b/src/mappers/dotnet.ts
@@ -1,3 +1,4 @@
+import { stripXmlComments } from "../source-comments.js";
 import { readFile } from "node:fs/promises";
 import { basename, dirname, extname, join } from "node:path";
 import { shellQuotePath } from "../shell.js";
@@ -946,25 +947,6 @@ function xmlAttributeValues(source: string, element: string, attribute: string):
 
 function normalizeMsbuildPath(path: string): string {
   return normalize(path.replace(/\\/gu, "/"));
-}
-
-function stripXmlComments(source: string): string {
-  let output = "";
-  let index = 0;
-  while (index < source.length) {
-    const start = source.indexOf("<!--", index);
-    if (start === -1) {
-      output += source.slice(index);
-      break;
-    }
-    output += source.slice(index, start);
-    const end = source.indexOf("-->", start + 4);
-    if (end === -1) {
-      break;
-    }
-    index = end + 3;
-  }
-  return output;
 }
 
 function isStrongTestProject(source: string): boolean {

--- a/src/mappers/elixir.ts
+++ b/src/mappers/elixir.ts
@@ -1,8 +1,9 @@
+import { stripLineComments } from "../source-comments.js";
 import { readFile, readdir } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { pathExists } from "../fs.js";
 import { shellQuotePath } from "../shell.js";
-import { packageKind, pathMatchesPrefix, shouldSkip, stripLineComments, walk } from "./shared.js";
+import { packageKind, pathMatchesPrefix, shouldSkip, walk } from "./shared.js";
 import { FeatureSeed, SeedTestRef } from "./types.js";
 
 const elixirSourceGroupMaxOwnedFiles = 24;

--- a/src/mappers/maven.ts
+++ b/src/mappers/maven.ts
@@ -1,3 +1,4 @@
+import { stripXmlComments } from "../source-comments.js";
 import { lstat, readFile, readdir } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { pathExists } from "../fs.js";
@@ -371,25 +372,6 @@ function removeXmlBlocks(source: string, names: string[]): string {
       new RegExp(`<${escapedName}\\b[^>]*>[\\s\\S]*?</${escapedName}>`, "giu"),
       " ",
     );
-  }
-  return output;
-}
-
-function stripXmlComments(source: string): string {
-  let output = "";
-  let index = 0;
-  while (index < source.length) {
-    const start = source.indexOf("<!--", index);
-    if (start === -1) {
-      output += source.slice(index);
-      break;
-    }
-    output += source.slice(index, start);
-    const end = source.indexOf("-->", start + 4);
-    if (end === -1) {
-      break;
-    }
-    index = end + 3;
   }
   return output;
 }

--- a/src/mappers/rust.ts
+++ b/src/mappers/rust.ts
@@ -1,3 +1,4 @@
+import { stripLineComments } from "../source-comments.js";
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { pathExists } from "../fs.js";
@@ -9,7 +10,6 @@ import {
   packageKind,
   packageTrustBoundaries,
   normalize,
-  stripLineComments,
   walk,
 } from "./shared.js";
 import { FeatureSeed, SeedFileRef } from "./types.js";

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -380,17 +380,6 @@ export function normalize(path: string): string {
   return path.split(sep).join("/");
 }
 
-export function stripLineComments(source: string, marker: "#" | "//"): string {
-  return source
-    .split("\n")
-    .map((line) => stripLineComment(line, marker))
-    .join("\n");
-}
-
-export function stripSwiftComments(source: string): string {
-  return stripLineComments(stripBlockComments(source), "//");
-}
-
 export function pathMatchesPrefix(path: string, prefix: string): boolean {
   const normalized = normalize(prefix).replace(/\/$/u, "");
   return normalized === "" || path === normalized || path.startsWith(`${normalized}/`);
@@ -505,77 +494,4 @@ function rustTestPrefixesForEntry(entryPath: string): string[] {
     return [`${parts.slice(0, srcIndex).join("/")}/tests/`];
   }
   return ["tests/"];
-}
-
-function stripBlockComments(source: string): string {
-  let output = "";
-  let inString = false;
-  let escaped = false;
-  for (let index = 0; index < source.length; index += 1) {
-    const char = source[index];
-    const next = source[index + 1];
-    if (inString) {
-      output += char;
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-      output += char;
-    } else if (char === "/" && next === "*") {
-      let depth = 1;
-      output += "  ";
-      index += 2;
-      while (index < source.length && depth > 0) {
-        if (source[index] === "/" && source[index + 1] === "*") {
-          output += "  ";
-          depth += 1;
-          index += 2;
-          continue;
-        }
-        if (source[index] === "*" && source[index + 1] === "/") {
-          output += "  ";
-          depth -= 1;
-          index += 2;
-          continue;
-        }
-        output += source[index] === "\n" ? "\n" : " ";
-        index += 1;
-      }
-      index -= 1;
-    } else {
-      output += char;
-    }
-  }
-  return output;
-}
-
-function stripLineComment(line: string, marker: "#" | "//"): string {
-  let inString = false;
-  let escaped = false;
-  for (let index = 0; index < line.length; index += 1) {
-    const char = line[index];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-    } else if (line.startsWith(marker, index)) {
-      return line.slice(0, index);
-    }
-  }
-  return line;
 }

--- a/src/mappers/swift.ts
+++ b/src/mappers/swift.ts
@@ -1,3 +1,4 @@
+import { stripSwiftComments } from "../source-comments.js";
 import { lstat, readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { pathExists } from "../fs.js";
@@ -8,7 +9,6 @@ import {
   packageTrustBoundaries,
   pathMatchesPrefix,
   shouldSkip,
-  stripSwiftComments,
   walk,
 } from "./shared.js";
 import { FeatureSeed, SeedFileRef, SeedTestRef } from "./types.js";

--- a/src/source-comments.ts
+++ b/src/source-comments.ts
@@ -1,0 +1,102 @@
+export function stripLineComments(source: string, marker: "#" | "//"): string {
+  return source
+    .split("\n")
+    .map((line) => stripLineComment(line, marker))
+    .join("\n");
+}
+
+export function stripSwiftComments(source: string): string {
+  return stripLineComments(stripBlockComments(source), "//");
+}
+
+function stripBlockComments(source: string): string {
+  let output = "";
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (inString) {
+      output += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      output += char;
+    } else if (char === "/" && next === "*") {
+      let depth = 1;
+      output += "  ";
+      index += 2;
+      while (index < source.length && depth > 0) {
+        if (source[index] === "/" && source[index + 1] === "*") {
+          output += "  ";
+          depth += 1;
+          index += 2;
+          continue;
+        }
+        if (source[index] === "*" && source[index + 1] === "/") {
+          output += "  ";
+          depth -= 1;
+          index += 2;
+          continue;
+        }
+        output += source[index] === "\n" ? "\n" : " ";
+        index += 1;
+      }
+      index -= 1;
+    } else {
+      output += char;
+    }
+  }
+  return output;
+}
+
+function stripLineComment(line: string, marker: "#" | "//"): string {
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (line.startsWith(marker, index)) {
+      return line.slice(0, index);
+    }
+  }
+  return line;
+}
+
+export function stripXmlComments(source: string): string {
+  let output = "";
+  let index = 0;
+  while (index < source.length) {
+    const start = source.indexOf("<!--", index);
+    if (start === -1) {
+      output += source.slice(index);
+      break;
+    }
+    output += source.slice(index, start);
+    const end = source.indexOf("-->", start + 4);
+    if (end === -1) {
+      break;
+    }
+    index = end + 3;
+  }
+  return output;
+}


### PR DESCRIPTION
## What Problem This Solves

Project detection and language mappers maintained identical copies of the XML, line-comment, and Swift nested-comment scanners. Fixing either copy could leave detection and mapping inconsistent.

## Why This Change Was Made

Move the existing implementations unchanged into one source-comment module and import them at each call site. No CLI behavior or runtime floor changes.

## User Impact

Maintenance-only refactor; existing feature identities and discovery behavior are preserved.

## Evidence

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, and `pnpm build` passed; 941 tests passed, 2 existing platform skips.
- Isolated Codex autoreview: scoped-clean at P0–P2.
- Live proof: invoked the rebuilt `node dist/cli.js --root <synthetic-fixture> init --json --quiet` and `map --json --quiet`. The fixture combines nested Swift comments, a commented-out executable declaration, and XML-commented `.NET` test metadata. The CLI mapped 4 features, including `Swift executable Active`; it did not map the commented executable or a spurious .NET test suite. Detection returned Swift/C#, SwiftPM/.NET, `swift build`, and no test command.
