### PR TITLE
refactor: simplify registry verification for Node 22

### DIFF
--- a/src/registry-verifier.ts
+++ b/src/registry-verifier.ts
@@ -1,57 +1,10 @@
-/**
- * Registry verifier — drops review findings that claim a package version is
- * unpublished when the npm registry says otherwise.
- *
- * Background: providers backed by an LLM with a fixed knowledge cutoff
- * routinely surface "package X@Y does not exist on npm" findings for
- * versions released after the cutoff. The model has no way to know about
- * post-cutoff releases without a tool, so the assertion is a hallucination
- * dressed as ground truth. (See "We Have a Package for You!" Spracklen et
- * al., USENIX Security 2025, arXiv:2406.10279 — measured 5-22% rates of
- * the symmetric failure: hallucinating *nonexistent* packages.)
- *
- * The mitigation is the obvious one already practised in dependency tools
- * (Renovate's `lib/modules/datasource/npm/get.ts`, Dependabot, Socket): ask
- * the registry. This module is the partition-layer addition that lets
- * `validateReviewOutputPartitioned` reject findings whose central claim is
- * trivially refuted by a registry GET.
- *
- * Failure modes are biased toward "keep the finding":
- *   - registry says version is published → drop finding (positive signal)
- *   - registry returns 404                → keep finding (claim stands)
- *   - registry returns any non-200       → keep finding (no false drop)
- *   - request errors / offline           → keep finding (no false drop)
- *   - finding text has no extractable spec → keep finding (out of scope)
- *
- * Only a `verified-published` outcome causes a drop. Errors are
- * non-fatal and surfaced via `notes` for operators.
- */
-
+// Refute only direct public-npm publication claims; uncertain registry results keep findings.
 const NPM_REGISTRY_BASE = "https://registry.npmjs.org";
 const REQUEST_TIMEOUT_MS = 5_000;
 const RESPONSE_BODY_BYTE_CAP = 1_048_576; // 1 MiB; per-version manifests are ~1-3 KB
 const USER_AGENT = "clawpatch (+https://github.com/openclaw/clawpatch)";
 
-/**
- * Match an npm `pkg@version` spec inside arbitrary prose. Accepts:
- *   - bare names:     `mongodb@7.0.0`, `tsx@4.21.0`
- *   - scoped names:   `@types/node@24.10.4`, `@aws-sdk/client-s3@3.1000.0`
- *   - prereleases:    `vitest@4.0.16-beta.1`, `react@19.0.0-rc.1`
- *   - build metadata: `pkg@1.2.3+sha.abcd`
- *
- * The version segment matches semver-shaped strings; non-semver tags
- * ("latest", "next") are intentionally excluded — those aren't subject to
- * the hallucination failure mode this verifier addresses.
- *
- * The trailing `.` (sentence period) is never consumed: the
- * `[0-9A-Za-z-]+` core forbids `.` and is followed by an optional
- * `(?:\.[0-9A-Za-z-]+)*` for dotted parts, so the final character of the
- * match is always a digit/letter/dash, never a `.`.
- *
- * The `u` flag (no `i`) keeps package names lowercase per npm's naming
- * rule (RFC 7468 / npm-package-json). Uppercase tokens like
- * `WatchedActivities@1.0.0` (a class name in prose) won't extract.
- */
+// Match complete lowercase package@semver tokens, excluding tags and sentence punctuation.
 const SPEC_PATTERN =
   /(?<![A-Za-z0-9_/-])(@?[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)?)@(\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)(?!\.\d|[A-Za-z0-9-])/gu;
 
@@ -197,20 +150,16 @@ async function resolveVerdict(
 ): Promise<RegistryVerdict> {
   const fetchImpl = options.fetchImpl ?? globalThis.fetch;
   const base = options.registryBase ?? NPM_REGISTRY_BASE;
-  const url = `${base}/${encodeRegistryName(spec.name)}/${encodeURIComponent(spec.version)}`;
+  const url = `${base}/${encodeURIComponent(spec.name)}/${encodeURIComponent(spec.version)}`;
   const timeoutController = new AbortController();
   const timeoutMs = options.timeoutMs ?? REQUEST_TIMEOUT_MS;
   const timer = setTimeout(
     () => timeoutController.abort(new DOMException(`timeout ${timeoutMs}ms`, "TimeoutError")),
     timeoutMs,
   );
-  // Don't let the timeout pin the event loop on caller paths that exit
-  // before the timer fires.
-  if (typeof timer === "object" && "unref" in timer && typeof timer.unref === "function") {
-    timer.unref();
-  }
+  timer.unref();
   const signal = options.signal
-    ? anyAbortSignal([timeoutController.signal, options.signal])
+    ? AbortSignal.any([timeoutController.signal, options.signal])
     : timeoutController.signal;
   try {
     const response = await fetchImpl(url, {
@@ -347,65 +296,7 @@ async function readCappedText(response: Response, cap: number): Promise<string |
   return new TextDecoder("utf-8").decode(merged);
 }
 
-/**
- * Combine multiple AbortSignals so the resulting signal aborts when any
- * input does. Prefers `AbortSignal.any` (Node 22+, Bun ≥1.1, modern
- * browsers) with a manual fallback for older runtimes.
- *
- * The fallback is careful to remove sibling listeners as soon as one
- * input fires, so a long-lived caller signal (e.g. a process-wide
- * Ctrl-C controller passed to many verifications) doesn't accrete dead
- * listeners. On runtimes with native `AbortSignal.any` this concern is
- * handled internally by the platform.
- */
-function anyAbortSignal(signals: readonly AbortSignal[]): AbortSignal {
-  const ctor = AbortSignal as unknown as { any?: (s: readonly AbortSignal[]) => AbortSignal };
-  if (typeof ctor.any === "function") {
-    return ctor.any(signals);
-  }
-  const controller = new AbortController();
-  for (const signal of signals) {
-    if (signal.aborted) {
-      controller.abort(signal.reason);
-      return controller.signal;
-    }
-  }
-  const handlers: Array<{ signal: AbortSignal; handler: () => void }> = [];
-  const cleanup = () => {
-    for (const { signal, handler } of handlers) {
-      signal.removeEventListener("abort", handler);
-    }
-  };
-  for (const signal of signals) {
-    const handler = () => {
-      controller.abort(signal.reason);
-      cleanup();
-    };
-    signal.addEventListener("abort", handler, { once: true });
-    handlers.push({ signal, handler });
-  }
-  return controller.signal;
-}
-
-/**
- * Encode a package name for the registry URL. Scoped names like
- * `@types/node` must encode the `/` so the URL parser keeps the scope as
- * a single path segment; bare names pass through unchanged.
- */
-function encodeRegistryName(name: string): string {
-  return encodeURIComponent(name);
-}
-
-/**
- * Decide whether a finding should be dropped as a registry-verified
- * false positive. Returns the spec that was verified-published, or null
- * if the finding should be kept. A finding is dropped only when every
- * claimed spec resolves to `verified-published` — every other outcome
- * (missing, unknown, no specs) leaves the finding in place.
- *
- * Returns the first published spec encountered so callers can include it
- * in the drop's `message` for operator clarity.
- */
+// Title and reasoning must make the same single-package claim before any registry request.
 export async function evaluateFindingForDrop(
   finding: { title: string; reasoning: string; recommendation: string },
   options: RegistryVerifierOptions = {},
@@ -413,33 +304,17 @@ export async function evaluateFindingForDrop(
   if (!findingClaimsNonexistence(finding.title) || !findingClaimsNonexistence(finding.reasoning)) {
     return null;
   }
-  const claimedSpecs = extractPackageSpecs(finding.title);
-  const reasoningSpec = extractPackageSpecs(finding.reasoning)[0];
-  if (
-    reasoningSpec === undefined ||
-    reasoningSpec.name !== claimedSpecs[0]?.name ||
-    reasoningSpec.version !== claimedSpecs[0]?.version
-  ) {
+  const spec = extractPackageSpecs(finding.title)[0]!;
+  const reasoningSpec = extractPackageSpecs(finding.reasoning)[0]!;
+  if (reasoningSpec.name !== spec.name || reasoningSpec.version !== spec.version) {
     return null;
   }
-  const specs = Array.from(
-    new Map(claimedSpecs.map((spec) => [`${spec.name}@${spec.version}`, spec])).values(),
-  );
-  if (specs.length === 0) {
+  const verdict = await verifyPackageSpec(spec, options);
+  if (verdict.kind !== "verified-published") {
     return null;
   }
-  let firstPublished: PackageSpec | null = null;
-  for (const spec of specs) {
-    const verdict = await verifyPackageSpec(spec, options);
-    if (verdict.kind !== "verified-published") {
-      return null;
-    }
-    firstPublished ??= spec;
-  }
-  return firstPublished === null
-    ? null
-    : {
-        spec: firstPublished,
-        dropReason: `npm registry confirms every claimed package version is published (${specs.map((spec) => `${spec.name}@${spec.version}`).join(", ")}); finding's nonexistence claim is refuted by ground truth`,
-      };
+  return {
+    spec,
+    dropReason: `npm registry confirms every claimed package version is published (${spec.name}@${spec.version}); finding's nonexistence claim is refuted by ground truth`,
+  };
 }


### PR DESCRIPTION
## What Problem This Solves

The registry verifier retained a manual cancellation fallback for runtimes older than the declared Node 22 floor, plus multi-package processing after an earlier parser already restricted both fields to one package claim.

## Why This Change Was Made

Use native `AbortSignal.any` and Node timer handles, remove the encoding wrapper, and verify the single matching claim directly. Keep the conservative publication policy and existing diagnostic strings unchanged. Trim comments that duplicated the implementation or documentation.

## User Impact

No behavior, CLI contract, or runtime-floor change.

## Evidence

- `pnpm typecheck`, `pnpm lint`, `pnpm test src/registry-verifier.test.ts src/review-validation.test.ts`, and `pnpm build` passed (61 tests).
- Isolated Codex autoreview is scoped-clean at P0–P2. An initial diff-only pass lacked the unchanged claim-parser definition; a full-source/context pass verified its single-package invariant.
- Live compiled-runtime proof: ran `dist/registry-verifier.js` against a real local HTTP server. A matching published manifest dropped the finding; caller abort and a 25 ms deadline both returned `unknown` and kept findings. No mocked fetch implementation was used.
