### PR TITLE
refactor: share mapper metadata parsing and file references

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,3 +1,9 @@
+import {
+  pyprojectHasToolSection,
+  pythonTomlStringValues,
+  readTomlBracketValue,
+  pythonRequirementName,
+} from "./python-metadata.js";
 import { stripLineComments, stripSwiftComments, stripXmlComments } from "./source-comments.js";
 import { lstat, readFile, readdir } from "node:fs/promises";
 import { join, posix } from "node:path";
@@ -645,15 +651,6 @@ async function pythonRunner(root: string): Promise<string | null> {
   return null;
 }
 
-async function pyprojectHasToolSection(root: string, tool: string): Promise<boolean> {
-  if (!(await pathExists(join(root, "pyproject.toml")))) {
-    return false;
-  }
-  const source = await readFile(join(root, "pyproject.toml"), "utf8");
-  const escaped = tool.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  return new RegExp(`^\\s*\\[\\[?tool\\.${escaped}(?:\\.|\\])`, "mu").test(source);
-}
-
 function pythonRunCommand(runner: string | null, command: string): string {
   if (runner === "uv") {
     return `uv run ${command}`;
@@ -918,72 +915,6 @@ function pythonTomlArrayValues(source: string): string[] {
   return pythonTomlStringValues(source);
 }
 
-function pythonTomlStringValues(source: string): string[] {
-  const values: string[] = [];
-  let quote: string | null = null;
-  let value = "";
-  let escaped = false;
-  for (let index = 0; index < source.length; index += 1) {
-    const char = source[index];
-    if (quote !== null) {
-      if (escaped) {
-        value += char;
-        escaped = false;
-      } else if (char === "\\" && quote === '"') {
-        escaped = true;
-      } else if (char === quote) {
-        values.push(value);
-        quote = null;
-        value = "";
-      } else {
-        value += char;
-      }
-      continue;
-    }
-    if (char === "#") {
-      const nextNewline = source.indexOf("\n", index + 1);
-      if (nextNewline === -1) {
-        break;
-      }
-      index = nextNewline;
-    } else if (char === '"' || char === "'") {
-      quote = char;
-      value = "";
-    }
-  }
-  return values;
-}
-
-function readTomlBracketValue(source: string, bracketIndex: number): string {
-  let depth = 0;
-  let quote: string | null = null;
-  let escaped = false;
-  for (let index = bracketIndex; index < source.length; index += 1) {
-    const char = source[index];
-    if (quote !== null) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === quote) {
-        quote = null;
-      }
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = char;
-    } else if (char === "[") {
-      depth += 1;
-    } else if (char === "]") {
-      depth -= 1;
-      if (depth === 0) {
-        return source.slice(bracketIndex, index + 1);
-      }
-    }
-  }
-  return source.slice(bracketIndex);
-}
-
 function pythonRequirementNames(source: string): string[] {
   return source
     .split("\n")
@@ -1035,15 +966,6 @@ function addPythonRequirementNames(names: Set<string>, value: string): void {
       names.add(name);
     }
   }
-}
-
-function pythonRequirementName(value: string): string | null {
-  const trimmed = value.trim().replace(/^["']|["']$/gu, "");
-  if (trimmed.length === 0 || trimmed.startsWith("#") || trimmed.startsWith("-")) {
-    return null;
-  }
-  const match = /^([A-Za-z0-9_.-]+)/u.exec(trimmed);
-  return match?.[1]?.toLowerCase().replace(/_/gu, "-") ?? null;
 }
 
 async function containsPythonTestFile(root: string, maxDepth: number): Promise<boolean> {

--- a/src/mappers/dotnet.ts
+++ b/src/mappers/dotnet.ts
@@ -4,7 +4,13 @@ import { basename, dirname, extname, join } from "node:path";
 import { shellQuotePath } from "../shell.js";
 import { TrustBoundary } from "../types.js";
 import { partitionFileGroups } from "./grouping.js";
-import { isSampleProjectPath, normalize, pathMatchesPrefix, shouldSkip } from "./shared.js";
+import {
+  uniqueFileRefs,
+  isSampleProjectPath,
+  normalize,
+  pathMatchesPrefix,
+  shouldSkip,
+} from "./shared.js";
 import { FeatureSeed, MapperContext, SeedFileRef, SeedTestRef } from "./types.js";
 
 const maxOwnedFiles = 12;
@@ -1090,19 +1096,6 @@ function isDotnetGeneratedOrCachePath(path: string): boolean {
 
 function normalizeName(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/gu, "");
-}
-
-function uniqueFileRefs(refs: SeedFileRef[]): SeedFileRef[] {
-  const seen = new Set<string>();
-  const output: SeedFileRef[] = [];
-  for (const ref of refs) {
-    if (seen.has(ref.path)) {
-      continue;
-    }
-    seen.add(ref.path);
-    output.push(ref);
-  }
-  return output;
 }
 
 function uniqueStrings<T extends string>(values: T[]): T[] {

--- a/src/mappers/laravel.ts
+++ b/src/mappers/laravel.ts
@@ -9,7 +9,14 @@ import {
 import { pathExists } from "../fs.js";
 import { TrustBoundary } from "../types.js";
 import { chunkFiles } from "./grouping.js";
-import { isSafeDirectory, isSafeFile, pathMatchesPrefix, shouldSkip, walk } from "./shared.js";
+import {
+  uniqueFileRefs,
+  isSafeDirectory,
+  isSafeFile,
+  pathMatchesPrefix,
+  shouldSkip,
+  walk,
+} from "./shared.js";
 import { FeatureSeed, SeedFileRef, SeedTestRef } from "./types.js";
 
 type RouteRef = {
@@ -184,7 +191,7 @@ async function controllerSeeds(
         route: controllerRoutes[0]?.uri ?? null,
         command: null,
         ownedFiles: [{ path, reason: "controller" }],
-        contextFiles: uniqueRefs([
+        contextFiles: uniqueFileRefs([
           ...controllerRoutes.map((route) => ({ path: route.file, reason: "route definition" })),
           ...(await phpUseContextFiles(root, path, controllerByClass)),
           ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
@@ -242,7 +249,7 @@ async function commandSeeds(
         route: null,
         command: signature,
         ownedFiles: [{ path, reason: "Artisan command" }],
-        contextFiles: uniqueRefs([
+        contextFiles: uniqueFileRefs([
           ...(await phpUseContextFiles(root, path)),
           ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
         ]),
@@ -295,7 +302,7 @@ async function serviceSeeds(
         route: null,
         command: null,
         ownedFiles: [{ path, reason: "service" }],
-        contextFiles: uniqueRefs([
+        contextFiles: uniqueFileRefs([
           ...(await phpUseContextFiles(root, path)),
           ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
         ]),
@@ -354,7 +361,7 @@ async function phpClassSeeds(
         route: null,
         command: null,
         ownedFiles: [{ path, reason: titlePrefix.toLowerCase() }],
-        contextFiles: uniqueRefs([
+        contextFiles: uniqueFileRefs([
           ...(await phpUseContextFiles(root, path)),
           ...tests.map((test) => ({ path: test.path, reason: "associated test" })),
         ]),
@@ -1145,19 +1152,6 @@ async function existingRefs(root: string, refs: Array<[string, string]>): Promis
     if (await pathExists(join(root, path))) {
       output.push({ path, reason });
     }
-  }
-  return output;
-}
-
-function uniqueRefs(refs: SeedFileRef[]): SeedFileRef[] {
-  const seen = new Set<string>();
-  const output: SeedFileRef[] = [];
-  for (const ref of refs) {
-    if (seen.has(ref.path)) {
-      continue;
-    }
-    seen.add(ref.path);
-    output.push(ref);
   }
   return output;
 }

--- a/src/mappers/node-routes.ts
+++ b/src/mappers/node-routes.ts
@@ -7,14 +7,8 @@ import {
   projectTags,
   projectTargetCommand,
 } from "./projects.js";
-import { pathMatchesPrefix, walk } from "./shared.js";
-import {
-  FeatureSeed,
-  MapperContext,
-  SeedFileRef,
-  SeedTestRef,
-  suppressedTestCommandTag,
-} from "./types.js";
+import { uniqueFileRefs, pathMatchesPrefix, walk } from "./shared.js";
+import { FeatureSeed, MapperContext, SeedTestRef, suppressedTestCommandTag } from "./types.js";
 import type { NodeProjectInfo } from "./projects.js";
 import type { WorkspaceTaskGraph } from "./task-graph.js";
 
@@ -1999,19 +1993,6 @@ function uniqueRoutes(routes: ServerRoute[]): ServerRoute[] {
     }
     seen.add(key);
     output.push(route);
-  }
-  return output;
-}
-
-function uniqueFileRefs(refs: SeedFileRef[]): SeedFileRef[] {
-  const seen = new Set<string>();
-  const output: SeedFileRef[] = [];
-  for (const ref of refs) {
-    if (seen.has(ref.path)) {
-      continue;
-    }
-    seen.add(ref.path);
-    output.push(ref);
   }
   return output;
 }

--- a/src/mappers/node.ts
+++ b/src/mappers/node.ts
@@ -5,6 +5,7 @@ import { pathExists } from "../fs.js";
 import { rubyDependencyNames, rubyGemspecPaths, stripRubyComments } from "../ruby.js";
 import { partitionFileGroups } from "./grouping.js";
 import {
+  uniqueFileRefs,
   normalize,
   packageKind,
   packageTrustBoundaries,
@@ -671,17 +672,4 @@ function isExtensionPackage(info: PackageInfo): boolean {
 
 function isNodeTestPath(path: string): boolean {
   return /\.(test|spec)\.(ts|tsx|js|jsx|mts|cts|mjs|cjs)$/u.test(path);
-}
-
-function uniqueFileRefs(refs: SeedFileRef[]): SeedFileRef[] {
-  const seen = new Set<string>();
-  const output: SeedFileRef[] = [];
-  for (const ref of refs) {
-    if (seen.has(ref.path)) {
-      continue;
-    }
-    seen.add(ref.path);
-    output.push(ref);
-  }
-  return output;
 }

--- a/src/mappers/projects.ts
+++ b/src/mappers/projects.ts
@@ -1,3 +1,9 @@
+import {
+  parsePnpmWorkspace,
+  isExcludedWorkspace,
+  hasWorkspaceGlob,
+  globSegmentRegExp,
+} from "./workspace-patterns.js";
 import { lstat, readFile, readdir, realpath } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { packageScripts, readPackageJson } from "../detect.js";
@@ -514,25 +520,6 @@ function packageWorkspacePatterns(pkg: NodePackageJson): string[] {
   return [];
 }
 
-function parsePnpmWorkspace(source: string): string[] {
-  const patterns: string[] = [];
-  let inPackages = false;
-  for (const rawLine of source.split("\n")) {
-    const line = rawLine.replace(/#.*/u, "");
-    if (/^\S/u.test(line)) {
-      inPackages = /^packages\s*:/u.test(line);
-    }
-    if (!inPackages) {
-      continue;
-    }
-    const match = /^\s*-\s*["']?([^"'\s]+)["']?\s*$/u.exec(line);
-    if (match?.[1] !== undefined) {
-      patterns.push(match[1]);
-    }
-  }
-  return patterns;
-}
-
 async function expandWorkspacePattern(root: string, pattern: string): Promise<string[]> {
   const normalized = normalizeWorkspacePattern(pattern);
   if (normalized === null) {
@@ -576,52 +563,6 @@ function normalizeWorkspacePattern(pattern: string): string | null {
   return normalized;
 }
 
-function isExcludedWorkspace(packageRoot: string, excludes: string[]): boolean {
-  return excludes.some((pattern) => workspacePatternMatches(pattern, packageRoot));
-}
-
-function workspacePatternMatches(pattern: string, packageRoot: string): boolean {
-  if (pattern === packageRoot) {
-    return true;
-  }
-  if (hasWorkspaceGlob(pattern)) {
-    return workspaceGlobMatches(pattern, packageRoot);
-  }
-  if (pattern.endsWith("/**")) {
-    return pathMatchesPrefix(packageRoot, pattern.slice(0, -3));
-  }
-  if (pattern.endsWith("/*")) {
-    const parent = pattern.slice(0, -2);
-    if (!pathMatchesPrefix(packageRoot, parent)) {
-      return false;
-    }
-    return packageRoot.slice(parent.length + 1).split("/").length === 1;
-  }
-  return false;
-}
-
-function workspaceGlobMatches(pattern: string, packageRoot: string): boolean {
-  return globSegmentsMatch(pattern.split("/"), packageRoot.split("/"));
-}
-
-function globSegmentsMatch(pattern: string[], candidate: string[]): boolean {
-  const [segment, ...remainingPattern] = pattern;
-  if (segment === undefined) {
-    return candidate.length === 0;
-  }
-  if (segment === "**") {
-    return (
-      globSegmentsMatch(remainingPattern, candidate) ||
-      (candidate.length > 0 && globSegmentsMatch(pattern, candidate.slice(1)))
-    );
-  }
-  const [candidateSegment, ...remainingCandidate] = candidate;
-  if (candidateSegment === undefined || !globSegmentRegExp(segment).test(candidateSegment)) {
-    return false;
-  }
-  return globSegmentsMatch(remainingPattern, remainingCandidate);
-}
-
 async function expandWorkspaceGlob(root: string, pattern: string): Promise<string[]> {
   const packages: string[] = [];
   const segments = pattern.split("/");
@@ -662,15 +603,6 @@ async function expandWorkspaceGlob(root: string, pattern: string): Promise<strin
 
   await visit("", segments);
   return packages.toSorted();
-}
-
-function hasWorkspaceGlob(pattern: string): boolean {
-  return /[*?]/u.test(pattern);
-}
-
-function globSegmentRegExp(segment: string): RegExp {
-  const escaped = segment.replace(/[.+^${}()|[\]\\]/gu, "\\$&");
-  return new RegExp(`^${escaped.replace(/\*/gu, "[^/]*").replace(/\?/gu, "[^/]")}$`, "u");
 }
 
 async function discoverPackageRootsUnder(

--- a/src/mappers/python.ts
+++ b/src/mappers/python.ts
@@ -1,9 +1,16 @@
+import {
+  pyprojectHasToolSection,
+  pythonTomlStringValues,
+  readTomlBracketValue,
+  pythonRequirementName,
+} from "../python-metadata.js";
 import { readFile, readdir } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { pathExists } from "../fs.js";
 import { shellQuotePath } from "../shell.js";
 import { partitionFileGroups } from "./grouping.js";
 import {
+  uniqueFileRefs,
   isSafeDirectory,
   isSafeFile,
   normalize,
@@ -384,25 +391,12 @@ async function workspaceMemberSeed(
     ...(seed.ownedFiles === undefined
       ? {}
       : { ownedFiles: seed.ownedFiles.map((file) => ({ ...file, path: prefixPath(file.path) })) }),
-    contextFiles: uniqueSeedFileRefs([...(contextFiles ?? []), ...workspaceRuntimeContext]),
+    contextFiles: uniqueFileRefs([...(contextFiles ?? []), ...workspaceRuntimeContext]),
     ...(seed.tests === undefined
       ? {}
       : { tests: seed.tests.map((test) => ({ ...test, path: prefixPath(test.path) })) }),
     ...(seed.testPrefixes === undefined ? {} : { testPrefixes: seed.testPrefixes.map(prefixPath) }),
   };
-}
-
-function uniqueSeedFileRefs(refs: SeedFileRef[]): SeedFileRef[] {
-  const seen = new Set<string>();
-  const output: SeedFileRef[] = [];
-  for (const ref of refs) {
-    if (seen.has(ref.path)) {
-      continue;
-    }
-    seen.add(ref.path);
-    output.push(ref);
-  }
-  return output;
 }
 
 function workspaceMemberSummary(seed: FeatureSeed, member: string): string {
@@ -741,15 +735,6 @@ async function pythonTestCommand(root: string, pyproject: PyprojectInfo): Promis
     return "hatch run pytest";
   }
   return "pytest";
-}
-
-async function pyprojectHasToolSection(root: string, tool: string): Promise<boolean> {
-  if (!(await pathExists(join(root, "pyproject.toml")))) {
-    return false;
-  }
-  const source = await readFile(join(root, "pyproject.toml"), "utf8");
-  const escaped = tool.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-  return new RegExp(`^\\s*\\[\\[?tool\\.${escaped}(?:\\.|\\])`, "mu").test(source);
 }
 
 async function dependencyFileHas(root: string, dependency: string): Promise<boolean> {
@@ -2411,7 +2396,7 @@ function dependencyNames(source: string): Set<string> {
   const names = new Set<string>();
   for (const array of tomlArrayAssignments(source, ["dependencies", "dev-dependencies"])) {
     for (const value of arrayValues(array)) {
-      const name = requirementName(value);
+      const name = pythonRequirementName(value);
       if (name !== null) {
         names.add(name);
       }
@@ -2426,7 +2411,7 @@ function dependencyNames(source: string): Set<string> {
     ...tablesMatching(source, /^tool\.poetry\.group\.[^.]+\.dependencies$/u),
   ]) {
     for (const value of assignedKeysAndValues(dependencyTable)) {
-      const name = requirementName(value);
+      const name = pythonRequirementName(value);
       if (name !== null) {
         names.add(name);
       }
@@ -2438,7 +2423,7 @@ function dependencyNames(source: string): Set<string> {
     table(source, "tool.pdm.dev-dependencies"),
   ]) {
     for (const value of assignedValues(dependencyTable)) {
-      const name = requirementName(value);
+      const name = pythonRequirementName(value);
       if (name !== null) {
         names.add(name);
       }
@@ -2452,7 +2437,7 @@ function tomlArrayAssignments(source: string, keys: string[]): string[] {
   for (const key of keys) {
     const escaped = key.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
     for (const match of source.matchAll(new RegExp(`^\\s*${escaped}\\s*=\\s*\\[`, "gmu"))) {
-      arrays.push(readBracketValue(source, match.index + match[0].lastIndexOf("[")));
+      arrays.push(readTomlBracketValue(source, match.index + match[0].lastIndexOf("[")));
     }
   }
   return arrays;
@@ -2468,7 +2453,7 @@ function assignedValues(source: string): string[] {
     const lineEnd = source.indexOf("\n", valueStart);
     const rawValue = source.slice(valueStart, lineEnd === -1 ? source.length : lineEnd).trim();
     if (rawValue.startsWith("[")) {
-      values.push(...arrayValues(readBracketValue(source, valueStart)));
+      values.push(...arrayValues(readTomlBracketValue(source, valueStart)));
       continue;
     }
     values.push(...arrayValues(rawValue));
@@ -2488,80 +2473,14 @@ function assignedKeysAndValues(source: string): string[] {
 }
 
 function arrayValues(source: string): string[] {
-  return stringValues(source);
-}
-
-function stringValues(source: string): string[] {
-  const values: string[] = [];
-  let quote: string | null = null;
-  let value = "";
-  let escaped = false;
-  for (let index = 0; index < source.length; index += 1) {
-    const char = source[index];
-    if (quote !== null) {
-      if (escaped) {
-        value += char;
-        escaped = false;
-      } else if (char === "\\" && quote === '"') {
-        escaped = true;
-      } else if (char === quote) {
-        values.push(value);
-        quote = null;
-        value = "";
-      } else {
-        value += char;
-      }
-      continue;
-    }
-    if (char === "#") {
-      const nextNewline = source.indexOf("\n", index + 1);
-      if (nextNewline === -1) {
-        break;
-      }
-      index = nextNewline;
-    } else if (char === '"' || char === "'") {
-      quote = char;
-      value = "";
-    }
-  }
-  return values;
-}
-
-function readBracketValue(source: string, bracketIndex: number): string {
-  let depth = 0;
-  let quote: string | null = null;
-  let escaped = false;
-  for (let index = bracketIndex; index < source.length; index += 1) {
-    const char = source[index];
-    if (quote !== null) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === quote) {
-        quote = null;
-      }
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = char;
-    } else if (char === "[") {
-      depth += 1;
-    } else if (char === "]") {
-      depth -= 1;
-      if (depth === 0) {
-        return source.slice(bracketIndex, index + 1);
-      }
-    }
-  }
-  return source.slice(bracketIndex);
+  return pythonTomlStringValues(source);
 }
 
 function requirementNames(source: string): Set<string> {
   return new Set(
     source
       .split("\n")
-      .map((line) => requirementName(line))
+      .map((line) => pythonRequirementName(line))
       .filter((name): name is string => name !== null),
   );
 }
@@ -2605,20 +2524,11 @@ function setupCfgRequirementNames(source: string): Set<string> {
 
 function addRequirementNames(names: Set<string>, value: string): void {
   for (const part of value.split(",")) {
-    const name = requirementName(part);
+    const name = pythonRequirementName(part);
     if (name !== null) {
       names.add(name);
     }
   }
-}
-
-function requirementName(value: string): string | null {
-  const trimmed = value.trim().replace(/^["']|["']$/gu, "");
-  if (trimmed.length === 0 || trimmed.startsWith("#") || trimmed.startsWith("-")) {
-    return null;
-  }
-  const match = /^([A-Za-z0-9_.-]+)/u.exec(trimmed);
-  return match?.[1]?.toLowerCase().replace(/_/gu, "-") ?? null;
 }
 
 function uniquePaths(paths: string[]): string[] {

--- a/src/mappers/react.ts
+++ b/src/mappers/react.ts
@@ -1,7 +1,14 @@
+import {
+  parsePnpmWorkspace,
+  isExcludedWorkspace,
+  hasWorkspaceGlob,
+  globSegmentRegExp,
+} from "./workspace-patterns.js";
 import { lstat, readFile, readdir, realpath } from "node:fs/promises";
 import { basename, dirname, extname, join } from "node:path";
 import { pathExists } from "../fs.js";
 import {
+  uniqueFileRefs,
   isSafeDirectory,
   isSampleProjectPath,
   normalize,
@@ -386,25 +393,6 @@ function packageWorkspacePatterns(pkg: PackageJson): string[] {
   return [];
 }
 
-function parsePnpmWorkspace(source: string): string[] {
-  const patterns: string[] = [];
-  let inPackages = false;
-  for (const rawLine of source.split("\n")) {
-    const line = rawLine.replace(/#.*/u, "");
-    if (/^\S/u.test(line)) {
-      inPackages = /^packages\s*:/u.test(line);
-    }
-    if (!inPackages) {
-      continue;
-    }
-    const match = /^\s*-\s*["']?([^"'\s]+)["']?\s*$/u.exec(line);
-    if (match?.[1] !== undefined) {
-      patterns.push(match[1]);
-    }
-  }
-  return patterns;
-}
-
 async function expandWorkspacePattern(root: string, pattern: string): Promise<string[]> {
   const normalized = normalizeWorkspacePattern(pattern);
   if (normalized === null) {
@@ -444,30 +432,6 @@ function normalizeWorkspacePattern(pattern: string): string | null {
     return null;
   }
   return normalized;
-}
-
-function isExcludedWorkspace(packageRoot: string, excludes: string[]): boolean {
-  return excludes.some((pattern) => workspacePatternMatches(pattern, packageRoot));
-}
-
-function workspacePatternMatches(pattern: string, packageRoot: string): boolean {
-  if (pattern === packageRoot) {
-    return true;
-  }
-  if (hasWorkspaceGlob(pattern)) {
-    return workspaceGlobMatches(pattern, packageRoot);
-  }
-  if (pattern.endsWith("/**")) {
-    return pathMatchesPrefix(packageRoot, pattern.slice(0, -3));
-  }
-  if (pattern.endsWith("/*")) {
-    const parent = pattern.slice(0, -2);
-    if (!pathMatchesPrefix(packageRoot, parent)) {
-      return false;
-    }
-    return packageRoot.slice(parent.length + 1).split("/").length === 1;
-  }
-  return false;
 }
 
 async function expandWorkspaceGlob(root: string, pattern: string): Promise<string[]> {
@@ -521,37 +485,6 @@ async function safeDirectoryEntries(root: string, prefix: string): Promise<strin
     .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
     .map((entry) => entry.name)
     .toSorted();
-}
-
-function hasWorkspaceGlob(pattern: string): boolean {
-  return /[*?]/u.test(pattern);
-}
-
-function workspaceGlobMatches(pattern: string, packageRoot: string): boolean {
-  return globSegmentsMatch(pattern.split("/"), packageRoot.split("/"));
-}
-
-function globSegmentsMatch(pattern: string[], candidate: string[]): boolean {
-  const [segment, ...remainingPattern] = pattern;
-  if (segment === undefined) {
-    return candidate.length === 0;
-  }
-  if (segment === "**") {
-    return (
-      globSegmentsMatch(remainingPattern, candidate) ||
-      (candidate.length > 0 && globSegmentsMatch(pattern, candidate.slice(1)))
-    );
-  }
-  const [candidateSegment, ...remainingCandidate] = candidate;
-  if (candidateSegment === undefined || !globSegmentRegExp(segment).test(candidateSegment)) {
-    return false;
-  }
-  return globSegmentsMatch(remainingPattern, remainingCandidate);
-}
-
-function globSegmentRegExp(segment: string): RegExp {
-  const escaped = segment.replace(/[.+^${}()|[\]\\]/gu, "\\$&");
-  return new RegExp(`^${escaped.replace(/\*/gu, "[^/]*").replace(/\?/gu, "[^/]")}$`, "u");
 }
 
 function hasReactDependency(pkg: PackageJson): boolean {
@@ -1383,17 +1316,4 @@ async function safeFile(root: string, path: string): Promise<boolean> {
   }
   const info = await lstat(fullPath);
   return info.isFile() && !info.isSymbolicLink();
-}
-
-function uniqueFileRefs(refs: SeedFileRef[]): SeedFileRef[] {
-  const seen = new Set<string>();
-  const output: SeedFileRef[] = [];
-  for (const ref of refs) {
-    if (seen.has(ref.path)) {
-      continue;
-    }
-    seen.add(ref.path);
-    output.push(ref);
-  }
-  return output;
 }

--- a/src/mappers/shared.ts
+++ b/src/mappers/shared.ts
@@ -2,7 +2,7 @@ import { lstat, readdir, realpath } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, sep } from "node:path";
 import { pathExists } from "../fs.js";
 import { TrustBoundary } from "../types.js";
-import { FeatureSeed } from "./types.js";
+import { FeatureSeed, SeedFileRef } from "./types.js";
 
 export type TestRef = {
   path: string;
@@ -494,4 +494,17 @@ function rustTestPrefixesForEntry(entryPath: string): string[] {
     return [`${parts.slice(0, srcIndex).join("/")}/tests/`];
   }
   return ["tests/"];
+}
+
+export function uniqueFileRefs(refs: SeedFileRef[]): SeedFileRef[] {
+  const seen = new Set<string>();
+  const output: SeedFileRef[] = [];
+  for (const ref of refs) {
+    if (seen.has(ref.path)) {
+      continue;
+    }
+    seen.add(ref.path);
+    output.push(ref);
+  }
+  return output;
 }

--- a/src/mappers/workspace-patterns.ts
+++ b/src/mappers/workspace-patterns.ts
@@ -1,0 +1,60 @@
+export function parsePnpmWorkspace(source: string): string[] {
+  const patterns: string[] = [];
+  let inPackages = false;
+  for (const rawLine of source.split("\n")) {
+    const line = rawLine.replace(/#.*/u, "");
+    if (/^\S/u.test(line)) {
+      inPackages = /^packages\s*:/u.test(line);
+    }
+    if (!inPackages) {
+      continue;
+    }
+    const match = /^\s*-\s*["']?([^"'\s]+)["']?\s*$/u.exec(line);
+    if (match?.[1] !== undefined) {
+      patterns.push(match[1]);
+    }
+  }
+  return patterns;
+}
+
+export function isExcludedWorkspace(packageRoot: string, excludes: string[]): boolean {
+  return excludes.some((pattern) => workspacePatternMatches(pattern, packageRoot));
+}
+
+function workspacePatternMatches(pattern: string, packageRoot: string): boolean {
+  return (
+    pattern === packageRoot ||
+    (hasWorkspaceGlob(pattern) && workspaceGlobMatches(pattern, packageRoot))
+  );
+}
+
+function workspaceGlobMatches(pattern: string, packageRoot: string): boolean {
+  return globSegmentsMatch(pattern.split("/"), packageRoot.split("/"));
+}
+
+function globSegmentsMatch(pattern: string[], candidate: string[]): boolean {
+  const [segment, ...remainingPattern] = pattern;
+  if (segment === undefined) {
+    return candidate.length === 0;
+  }
+  if (segment === "**") {
+    return (
+      globSegmentsMatch(remainingPattern, candidate) ||
+      (candidate.length > 0 && globSegmentsMatch(pattern, candidate.slice(1)))
+    );
+  }
+  const [candidateSegment, ...remainingCandidate] = candidate;
+  if (candidateSegment === undefined || !globSegmentRegExp(segment).test(candidateSegment)) {
+    return false;
+  }
+  return globSegmentsMatch(remainingPattern, remainingCandidate);
+}
+
+export function hasWorkspaceGlob(pattern: string): boolean {
+  return /[*?]/u.test(pattern);
+}
+
+export function globSegmentRegExp(segment: string): RegExp {
+  const escaped = segment.replace(/[.+^${}()|[\]\\]/gu, "\\$&");
+  return new RegExp(`^${escaped.replace(/\*/gu, "[^/]*").replace(/\?/gu, "[^/]")}$`, "u");
+}

--- a/src/python-metadata.ts
+++ b/src/python-metadata.ts
@@ -1,0 +1,87 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathExists } from "./fs.js";
+
+export async function pyprojectHasToolSection(root: string, tool: string): Promise<boolean> {
+  if (!(await pathExists(join(root, "pyproject.toml")))) {
+    return false;
+  }
+  const source = await readFile(join(root, "pyproject.toml"), "utf8");
+  const escaped = tool.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  return new RegExp(`^\\s*\\[\\[?tool\\.${escaped}(?:\\.|\\])`, "mu").test(source);
+}
+
+export function pythonTomlStringValues(source: string): string[] {
+  const values: string[] = [];
+  let quote: string | null = null;
+  let value = "";
+  let escaped = false;
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (quote !== null) {
+      if (escaped) {
+        value += char;
+        escaped = false;
+      } else if (char === "\\" && quote === '"') {
+        escaped = true;
+      } else if (char === quote) {
+        values.push(value);
+        quote = null;
+        value = "";
+      } else {
+        value += char;
+      }
+      continue;
+    }
+    if (char === "#") {
+      const nextNewline = source.indexOf("\n", index + 1);
+      if (nextNewline === -1) {
+        break;
+      }
+      index = nextNewline;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+      value = "";
+    }
+  }
+  return values;
+}
+
+export function readTomlBracketValue(source: string, bracketIndex: number): string {
+  let depth = 0;
+  let quote: string | null = null;
+  let escaped = false;
+  for (let index = bracketIndex; index < source.length; index += 1) {
+    const char = source[index];
+    if (quote !== null) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === "[") {
+      depth += 1;
+    } else if (char === "]") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(bracketIndex, index + 1);
+      }
+    }
+  }
+  return source.slice(bracketIndex);
+}
+
+export function pythonRequirementName(value: string): string | null {
+  const trimmed = value.trim().replace(/^["']|["']$/gu, "");
+  if (trimmed.length === 0 || trimmed.startsWith("#") || trimmed.startsWith("-")) {
+    return null;
+  }
+  const match = /^([A-Za-z0-9_.-]+)/u.exec(trimmed);
+  return match?.[1]?.toLowerCase().replace(/_/gu, "-") ?? null;
+}


### PR DESCRIPTION
## What Problem This Solves

Initialization and mapper modules copied the same Python metadata scanners, Node workspace pattern matching, and file-reference deduplication. Their shared behavior could drift when a fix was applied to only one copy.

## User Impact

No behavior or runtime-floor changes. Feature identity, ordering, and path filtering remain unchanged.

## Why This Change Was Made

Share exact common implementations while retaining language-specific traversal and interpretation. Keep the first file reference for each path, as before. Remove unreachable workspace suffix branches that were already handled by the earlier wildcard branch.

## Evidence

- Isolated Codex autoreview: scoped-clean at P0–P2.
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm test`, and `pnpm build` passed: 941 passed, 2 existing platform skips.
- Live installed-package proof: `pnpm pack:smoke` built/installed the package offline and ran its CLI against a mixed Python/Next/CUDA fixture: `packaged CLI smoke mapped 13 features (3 CUDA)`.
