### PR TITLE
refactor: remove dead task helper and normalize internal test hooks

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { __testing as appTesting, AppContext } from "./app.js";
+import { appTesting, AppContext } from "./app.js";
 import { defaultConfig } from "./config.js";
 import { ClawpatchError } from "./errors.js";
 import type { PartitionedReviewOutput, Provider } from "./provider-types.js";

--- a/src/app.ts
+++ b/src/app.ts
@@ -410,8 +410,7 @@ function parseMapSource(flags: Record<string, string | boolean>): "heuristic" | 
   );
 }
 
-// eslint-disable-next-line no-underscore-dangle
-export const __testing = {
+export const appTesting = {
   ...reviewTesting,
   reviewFlagSubset,
 };

--- a/src/mappers/task-graph.ts
+++ b/src/mappers/task-graph.ts
@@ -40,17 +40,3 @@ export function taskGraphCommand(
     (command) => command.projectRoot === project.root && command.task === task,
   )?.command;
 }
-
-export function taskGraphProjectCommands(
-  graph: WorkspaceTaskGraph,
-  project: NodeProjectInfo,
-): Record<string, string> {
-  const commands: Record<string, string> = {};
-  for (const task of validationTaskNames) {
-    const command = taskGraphCommand(graph, project, task);
-    if (command !== undefined && command !== null) {
-      commands[task] = command;
-    }
-  }
-  return commands;
-}

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -1,11 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { ClawpatchError } from "./errors.js";
-import { __testing, extractJson, providerByName } from "./provider.js";
+import { providerTesting, extractJson, providerByName } from "./provider.js";
 import { safeProviderPreview } from "./provider-json.js";
 import { agentMapJsonSchema, reviewJsonSchema } from "./provider-schema.js";
 import { evidenceRefSchema, revalidateOutputSchema, reviewOutputSchema } from "./types.js";
 
-// eslint-disable-next-line no-underscore-dangle
 const {
   addClaudeModelArgs,
   acpxFailureMessage,
@@ -43,7 +42,7 @@ const {
   piThinkingLevel,
   providerExitCode,
   providerJsonSchema,
-} = __testing;
+} = providerTesting;
 
 function withEnv(name: string, value: string | undefined, fn: () => void): void {
   const previous = process.env[name];

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -33,8 +33,7 @@ export function providerByName(name: string): Provider {
   throw new ClawpatchError(`unsupported provider: ${name}`, 2, "unsupported-provider");
 }
 
-// eslint-disable-next-line no-underscore-dangle
-export const __testing = {
+export const providerTesting = {
   ...acpxTesting,
   ...claudeTesting,
   ...codexTesting,

--- a/src/providers/acpx.ts
+++ b/src/providers/acpx.ts
@@ -423,8 +423,6 @@ function acpxPromptRetries(): number {
   return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : 1;
 }
 
-// eslint-disable-next-line no-underscore-dangle
-
 export const acpxTesting = {
   acpxFailureMessage,
   acpxPromptRetries,


### PR DESCRIPTION
## What Problem This Solves

The final source sweep found an unused task-graph command collector and internal test hooks whose names required lint suppression.

## User Impact

No CLI behavior or public configuration changes.

## Why This Change Was Made

Delete the unreferenced collector and give the internal hooks the same descriptive naming used by the provider modules. Remove the now-unneeded suppression comments rather than changing lint rules.

## Evidence

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, focused mapper/provider/retry tests (189 passed), and `pnpm build` passed.
- Isolated Codex autoreview: scoped-clean at P0–P2 against the final formatted files.
- Live rebuilt CLI walkthrough with the deterministic mock provider: mapped 4 features, reviewed 3, reported 2 findings, inspected and previewed a fix, revalidated, and cleaned stale locks.
- Repository-wide symbol search confirmed the removed helper had no callers.
